### PR TITLE
Replaced legacy Dockerfile ENV syntax for key/value.

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 ARG NEXT_PUBLIC_BACKEND_URL
 ARG NEXT_PUBLIC_CLOUD
 ENV NEXT_PUBLIC_BACKEND_URL=${NEXT_PUBLIC_BACKEND_URL}
@@ -29,8 +29,8 @@ RUN npm run build
 FROM base AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
@@ -50,7 +50,7 @@ USER nextjs
 
 EXPOSE 3002
 
-ENV PORT 3002
-ENV HOSTNAME "0.0.0.0"
+ENV PORT=3002
+ENV HOSTNAME="0.0.0.0"
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
See https://docs.docker.com/reference/dockerfile/#env explaining that the legacy syntax "ENV key value" is now deprecated. The new syntax "ENV key=value foo=bar" allows for clearer Dockerfiles.