### PR TITLE
docs: fix incorrect nginx configuration

### DIFF
--- a/docs/src/content/self-hosting-advanced.mdx
+++ b/docs/src/content/self-hosting-advanced.mdx
@@ -63,7 +63,7 @@ server {
 
     # API requests - adjust port if you customized it
     location /api/ {
-        proxy_pass http://localhost:3001;  # or your custom port
+        proxy_pass http://localhost:3001/;  # or your custom port
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
The example nginx configuration in self-hosting-advanced.mdx is missing the trailing slash in the proxy_pass