### PR TITLE
feat: Implement past-24-hours mode for analytics

### DIFF
--- a/client/src/api/analytics/useGetGoals.ts
+++ b/client/src/api/analytics/useGetGoals.ts
@@ -67,7 +67,7 @@ export function useGetGoals({
     timeParams = { minutes: minutes.toString(), timezone };
   } else if (!startDate || !endDate) {
     // Otherwise get time parameters from the store's time
-    // This will handle past-24-hours mode automatically
+    // This will handle last-24-hours mode automatically
     const queryParams = getQueryTimeParams(time);
     timeParams = Object.fromEntries(new URLSearchParams(queryParams));
   } else {

--- a/client/src/api/analytics/useGetGoals.ts
+++ b/client/src/api/analytics/useGetGoals.ts
@@ -5,7 +5,8 @@ import {
   GOALS_PAGE_FILTERS,
   useStore,
 } from "../../lib/store";
-import { authedFetch } from "../utils";
+import { authedFetch, getStartAndEndDate } from "../utils";
+import { getQueryTimeParams } from "./utils";
 
 export interface Goal {
   goalId: number;
@@ -43,27 +44,42 @@ export function useGetGoals({
   sort = "createdAt",
   order = "desc",
   enabled = true,
+  minutes,
 }: {
-  startDate: string;
-  endDate: string;
+  startDate?: string;
+  endDate?: string;
   page?: number;
   pageSize?: number;
   sort?: "goalId" | "name" | "goalType" | "createdAt";
   order?: "asc" | "desc";
   enabled?: boolean;
+  minutes?: number;
 }) {
-  const { site } = useStore();
+  const { site, time } = useStore();
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
   const filteredFilters = getFilteredFilters(GOALS_PAGE_FILTERS);
+
+  // If startDate and endDate are not provided, use time from store
+  let timeParams: Record<string, string> = {};
+
+  if (minutes) {
+    // If minutes is explicitly provided, use it
+    timeParams = { minutes: minutes.toString(), timezone };
+  } else if (!startDate || !endDate) {
+    // Otherwise get time parameters from the store's time
+    // This will handle past-24-hours mode automatically
+    const queryParams = getQueryTimeParams(time);
+    timeParams = Object.fromEntries(new URLSearchParams(queryParams));
+  } else {
+    // Use explicitly provided dates if available
+    timeParams = { startDate, endDate, timezone };
+  }
 
   return useQuery({
     queryKey: [
       "goals",
       site,
-      startDate,
-      endDate,
-      timezone,
+      timeParams,
       filteredFilters,
       page,
       pageSize,
@@ -72,9 +88,7 @@ export function useGetGoals({
     ],
     queryFn: async () => {
       return authedFetch(`${BACKEND_URL}/goals/${site}`, {
-        startDate,
-        endDate,
-        timezone,
+        ...timeParams,
         filteredFilters,
         page,
         pageSize,
@@ -83,5 +97,33 @@ export function useGetGoals({
       }).then((res) => res.json());
     },
     enabled: !!site && enabled,
+  });
+}
+
+/**
+ * Hook to get goals data for the past X minutes
+ */
+export function useGetGoalsPastMinutes({
+  minutes = 24 * 60,
+  page = 1,
+  pageSize = 10,
+  sort = "createdAt",
+  order = "desc",
+  enabled = true,
+}: {
+  minutes?: number;
+  page?: number;
+  pageSize?: number;
+  sort?: "goalId" | "name" | "goalType" | "createdAt";
+  order?: "asc" | "desc";
+  enabled?: boolean;
+}) {
+  return useGetGoals({
+    minutes,
+    page,
+    pageSize,
+    sort,
+    order,
+    enabled,
   });
 }

--- a/client/src/api/analytics/useGetOverviewBucketed.ts
+++ b/client/src/api/analytics/useGetOverviewBucketed.ts
@@ -1,8 +1,12 @@
-import { UseQueryResult, useQuery } from "@tanstack/react-query";
+import {
+  UseQueryOptions,
+  UseQueryResult,
+  useQuery,
+} from "@tanstack/react-query";
 import { BACKEND_URL } from "../../lib/const";
-import { APIResponse } from "../types";
-import { getStartAndEndDate, authedFetch } from "../utils";
 import { TimeBucket, useStore } from "../../lib/store";
+import { APIResponse } from "../types";
+import { authedFetch, getStartAndEndDate } from "../utils";
 
 type PeriodTime = "current" | "previous";
 
@@ -20,10 +24,12 @@ export function useGetOverviewBucketed({
   periodTime,
   site,
   bucket = "hour",
+  props,
 }: {
   periodTime?: PeriodTime;
   site?: number | string;
   bucket?: TimeBucket;
+  props?: Partial<UseQueryOptions<APIResponse<GetOverviewBucketedResponse>>>;
 }): UseQueryResult<APIResponse<GetOverviewBucketedResponse>> {
   const { time, previousTime, filters } = useStore();
 
@@ -54,6 +60,7 @@ export function useGetOverviewBucketed({
       return undefined;
     },
     staleTime: Infinity,
+    ...props,
   });
 }
 
@@ -62,11 +69,13 @@ export function useGetOverviewBucketedPastMinutes({
   site,
   bucket = "hour",
   refetchInterval,
+  props,
 }: {
   pastMinutes: number;
   site?: number | string;
   bucket?: TimeBucket;
   refetchInterval?: number;
+  props?: Partial<UseQueryOptions<APIResponse<GetOverviewBucketedResponse>>>;
 }): UseQueryResult<APIResponse<GetOverviewBucketedResponse>> {
   return useQuery({
     queryKey: ["overview-bucketed-past-minutes", pastMinutes, site, bucket],
@@ -90,5 +99,6 @@ export function useGetOverviewBucketedPastMinutes({
       return undefined;
     },
     staleTime: Infinity,
+    ...props,
   });
 }

--- a/client/src/api/analytics/useGetOverviewBucketed.ts
+++ b/client/src/api/analytics/useGetOverviewBucketed.ts
@@ -81,6 +81,8 @@ export function useGetOverviewBucketedPastMinutes({
   refetchInterval?: number;
   props?: Partial<UseQueryOptions<APIResponse<GetOverviewBucketedResponse>>>;
 }): UseQueryResult<APIResponse<GetOverviewBucketedResponse>> {
+  const { filters } = useStore();
+
   // Determine if we're using a specific range or just pastMinutes
   const useRange =
     pastMinutesStart !== undefined && pastMinutesEnd !== undefined;
@@ -93,8 +95,9 @@ export function useGetOverviewBucketedPastMinutes({
           pastMinutesEnd,
           site,
           bucket,
+          filters,
         ]
-      : ["overview-bucketed-past-minutes", pastMinutes, site, bucket],
+      : ["overview-bucketed-past-minutes", pastMinutes, site, bucket, filters],
     queryFn: () => {
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
       return authedFetch(
@@ -105,11 +108,13 @@ export function useGetOverviewBucketedPastMinutes({
               bucket,
               pastMinutesStart,
               pastMinutesEnd,
+              filters,
             }
           : {
               timezone,
               bucket,
               pastMinutes,
+              filters,
             }
       ).then((res) => res.json());
     },
@@ -145,6 +150,8 @@ export function useGetOverviewBucketedPreviousPastMinutes({
   refetchInterval?: number;
   props?: Partial<UseQueryOptions<APIResponse<GetOverviewBucketedResponse>>>;
 }): UseQueryResult<APIResponse<GetOverviewBucketedResponse>> {
+  const { filters } = useStore();
+
   // For the previous period, we use the pastMinutesStart/End approach
   // If pastMinutes is 24 * 60 (24 hours), then we fetch 24-48 hour data
   const pastMinutesStart = pastMinutes * 2; // e.g., 48 hours ago
@@ -157,6 +164,7 @@ export function useGetOverviewBucketedPreviousPastMinutes({
       pastMinutesEnd,
       site,
       bucket,
+      filters,
     ],
     queryFn: () => {
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -165,6 +173,7 @@ export function useGetOverviewBucketedPreviousPastMinutes({
         bucket,
         pastMinutesStart,
         pastMinutesEnd,
+        filters,
       }).then((res) => res.json());
     },
     refetchInterval,

--- a/client/src/api/analytics/useGetOverviewBucketed.ts
+++ b/client/src/api/analytics/useGetOverviewBucketed.ts
@@ -135,7 +135,7 @@ export function useGetOverviewBucketedPastMinutes({
 }
 
 /**
- * Hook to get previous time period data for comparison with past-24-hours mode
+ * Hook to get previous time period data for comparison with last-24-hours mode
  */
 export function useGetOverviewBucketedPreviousPastMinutes({
   pastMinutes = 24 * 60,

--- a/client/src/api/analytics/useSingleCol.ts
+++ b/client/src/api/analytics/useSingleCol.ts
@@ -29,8 +29,8 @@ export function useSingleCol({
   const { time, previousTime, site, filters } = useStore();
   const timeToUse = periodTime === "previous" ? previousTime : time;
 
-  // Check if we're using past-24-hours mode
-  const isPast24HoursMode = timeToUse.mode === "past-24-hours";
+  // Check if we're using last-24-hours mode
+  const isPast24HoursMode = timeToUse.mode === "last-24-hours";
 
   // Determine the query parameters based on mode
   const queryParams = isPast24HoursMode

--- a/client/src/api/analytics/useSingleCol.ts
+++ b/client/src/api/analytics/useSingleCol.ts
@@ -28,20 +28,46 @@ export function useSingleCol({
 }): UseQueryResult<APIResponse<SingleColResponse[]>> {
   const { time, previousTime, site, filters } = useStore();
   const timeToUse = periodTime === "previous" ? previousTime : time;
-  const { startDate, endDate } = getStartAndEndDate(timeToUse);
 
-  return useQuery({
-    queryKey: [parameter, timeToUse, site, filters, limit, useFilters],
-    queryFn: () => {
-      const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-      return authedFetch(`${BACKEND_URL}/single-col/${site}`, {
-        startDate,
-        endDate,
-        timezone,
+  // Check if we're using past-24-hours mode
+  const isPast24HoursMode = timeToUse.mode === "past-24-hours";
+
+  // Determine the query parameters based on mode
+  const queryParams = isPast24HoursMode
+    ? {
+        // Past minutes approach
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        parameter,
+        limit,
+        minutes: periodTime === "previous" ? 48 * 60 : 24 * 60,
+        filters: useFilters ? filters : undefined,
+      }
+    : {
+        // Regular date-based approach
+        ...getStartAndEndDate(timeToUse),
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         parameter,
         limit,
         filters: useFilters ? filters : undefined,
-      }).then((res) => res.json());
+      };
+
+  // Use a consistent query key format that includes the mode
+  const queryKey = [
+    parameter,
+    timeToUse,
+    site,
+    filters,
+    limit,
+    useFilters,
+    isPast24HoursMode ? "past-minutes" : "date-range",
+  ];
+
+  return useQuery({
+    queryKey,
+    queryFn: () => {
+      return authedFetch(`${BACKEND_URL}/single-col/${site}`, queryParams).then(
+        (res) => res.json()
+      );
     },
     staleTime: Infinity,
     placeholderData: (_, query: any) => {
@@ -66,10 +92,10 @@ export function useSingleColRealtime({
   limit?: number;
   minutes?: number;
 }): UseQueryResult<APIResponse<SingleColResponse[]>> {
-  const { time, previousTime, site, filters } = useStore();
+  const { site } = useStore();
 
   return useQuery({
-    queryKey: [parameter, site, limit, minutes],
+    queryKey: [parameter, site, limit, minutes, "realtime"],
     queryFn: () => {
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
       return authedFetch(`${BACKEND_URL}/single-col/${site}`, {

--- a/client/src/api/analytics/userInfo.ts
+++ b/client/src/api/analytics/userInfo.ts
@@ -26,8 +26,6 @@ export function useUserInfo(siteId: number, userId: string) {
   return useQuery<UserInfo>({
     queryKey: ["user-info", userId, siteId],
     queryFn: () => {
-      console.info("Fetching user info");
-
       return authedFetch(`${BACKEND_URL}/user/info/${userId}/${siteId}`)
         .then((res) => res.json())
         .then((res) => res.data);

--- a/client/src/api/analytics/userSessions.ts
+++ b/client/src/api/analytics/userSessions.ts
@@ -7,6 +7,7 @@ import {
 } from "../../lib/store";
 import { APIResponse } from "../types";
 import { authedFetch, getStartAndEndDate } from "../utils";
+import { getQueryTimeParams } from "./utils";
 
 export type UserSessionsResponse = {
   session_id: string;
@@ -73,7 +74,12 @@ export type GetSessionsResponse = {
 
 export function useGetSessionsInfinite(userId?: string) {
   const { time, site, filters } = useStore();
-  const { startDate, endDate } = getStartAndEndDate(time);
+  const isPast24HoursMode = time.mode === "past-24-hours";
+
+  // Get the appropriate time parameters
+  const timeParams = isPast24HoursMode
+    ? Object.fromEntries(new URLSearchParams(getQueryTimeParams(time)))
+    : getStartAndEndDate(time);
 
   const filteredFilters = getFilteredFilters(SESSION_PAGE_FILTERS);
 
@@ -81,14 +87,32 @@ export function useGetSessionsInfinite(userId?: string) {
     queryKey: ["sessions-infinite", time, site, filteredFilters, userId],
     queryFn: ({ pageParam = 1 }) => {
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-      return authedFetch(`${BACKEND_URL}/sessions/${site}`, {
-        startDate: userId ? undefined : startDate,
-        endDate: userId ? undefined : endDate,
+
+      // Use an object for request parameters so we can conditionally add fields
+      const requestParams: Record<string, any> = {
         timezone,
         filters: filteredFilters,
         page: pageParam,
-        userId,
-      }).then((res) => res.json());
+      };
+
+      // Add userId if provided
+      if (userId) {
+        requestParams.userId = userId;
+      }
+
+      // Add time parameters
+      if (isPast24HoursMode) {
+        // Add minutes parameter for past-24-hours mode
+        Object.assign(requestParams, timeParams);
+      } else if (!userId) {
+        // Only add date parameters if not filtering by userId
+        requestParams.startDate = timeParams.startDate;
+        requestParams.endDate = timeParams.endDate;
+      }
+
+      return authedFetch(`${BACKEND_URL}/sessions/${site}`, requestParams).then(
+        (res) => res.json()
+      );
     },
     initialPageParam: 1,
     getNextPageParam: (
@@ -150,17 +174,27 @@ export interface SessionPageviewsAndEvents {
 }
 
 export function useGetSessionDetailsInfinite(sessionId: string | null) {
-  const { site } = useStore();
+  const { site, time } = useStore();
+  const isPast24HoursMode = time.mode === "past-24-hours";
+
+  // Get minutes for past-24-hours mode
+  const minutes = isPast24HoursMode ? 24 * 60 : undefined;
 
   return useInfiniteQuery<APIResponse<SessionPageviewsAndEvents>>({
-    queryKey: ["session-details-infinite", sessionId, site],
+    queryKey: ["session-details-infinite", sessionId, site, minutes],
     queryFn: ({ pageParam = 0 }) => {
       if (!sessionId) throw new Error("Session ID is required");
       const limit = 100;
 
-      return authedFetch(
-        `${BACKEND_URL}/session/${sessionId}/${site}?limit=${limit}&offset=${pageParam}`
-      ).then((res) => res.json());
+      // Build URL with query parameters
+      let url = `${BACKEND_URL}/session/${sessionId}/${site}?limit=${limit}&offset=${pageParam}`;
+
+      // Add minutes parameter for past-24-hours mode
+      if (isPast24HoursMode && minutes) {
+        url += `&minutes=${minutes}`;
+      }
+
+      return authedFetch(url).then((res) => res.json());
     },
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {

--- a/client/src/api/analytics/userSessions.ts
+++ b/client/src/api/analytics/userSessions.ts
@@ -74,7 +74,7 @@ export type GetSessionsResponse = {
 
 export function useGetSessionsInfinite(userId?: string) {
   const { time, site, filters } = useStore();
-  const isPast24HoursMode = time.mode === "past-24-hours";
+  const isPast24HoursMode = time.mode === "last-24-hours";
 
   // Get the appropriate time parameters
   const timeParams = isPast24HoursMode
@@ -102,7 +102,7 @@ export function useGetSessionsInfinite(userId?: string) {
 
       // Add time parameters
       if (isPast24HoursMode) {
-        // Add minutes parameter for past-24-hours mode
+        // Add minutes parameter for last-24-hours mode
         Object.assign(requestParams, timeParams);
       } else if (!userId) {
         // Only add date parameters if not filtering by userId
@@ -175,9 +175,9 @@ export interface SessionPageviewsAndEvents {
 
 export function useGetSessionDetailsInfinite(sessionId: string | null) {
   const { site, time } = useStore();
-  const isPast24HoursMode = time.mode === "past-24-hours";
+  const isPast24HoursMode = time.mode === "last-24-hours";
 
-  // Get minutes for past-24-hours mode
+  // Get minutes for last-24-hours mode
   const minutes = isPast24HoursMode ? 24 * 60 : undefined;
 
   return useInfiniteQuery<APIResponse<SessionPageviewsAndEvents>>({
@@ -189,7 +189,7 @@ export function useGetSessionDetailsInfinite(sessionId: string | null) {
       // Build URL with query parameters
       let url = `${BACKEND_URL}/session/${sessionId}/${site}?limit=${limit}&offset=${pageParam}`;
 
-      // Add minutes parameter for past-24-hours mode
+      // Add minutes parameter for last-24-hours mode
       if (isPast24HoursMode && minutes) {
         url += `&minutes=${minutes}`;
       }

--- a/client/src/api/analytics/users.ts
+++ b/client/src/api/analytics/users.ts
@@ -8,6 +8,7 @@ import {
 } from "../../lib/store";
 import { getStartAndEndDate, authedFetch } from "../utils";
 import { APIResponse } from "../types";
+import { getQueryTimeParams } from "./utils";
 
 export type UsersResponse = {
   user_id: string;
@@ -35,7 +36,12 @@ export interface GetUsersOptions {
 
 export function useGetUsers(options: GetUsersOptions) {
   const { time, site } = useStore();
-  const { startDate, endDate } = getStartAndEndDate(time);
+  const isPast24HoursMode = time.mode === "past-24-hours";
+
+  // Get the appropriate time parameters
+  const timeParams = isPast24HoursMode
+    ? Object.fromEntries(new URLSearchParams(getQueryTimeParams(time)))
+    : getStartAndEndDate(time);
 
   const { page, pageSize, sortBy, sortOrder } = options;
   const filteredFilters = getFilteredFilters(USER_PAGE_FILTERS);
@@ -60,16 +66,28 @@ export function useGetUsers(options: GetUsersOptions) {
     queryFn: async () => {
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-      return authedFetch(`${BACKEND_URL}/users/${site}`, {
-        startDate,
-        endDate,
+      // Build request parameters
+      const requestParams: Record<string, any> = {
         timezone,
         filters: filteredFilters,
         page,
         pageSize,
         sortBy,
         sortOrder,
-      }).then((res) => res.json());
+      };
+
+      // Add time parameters
+      if (isPast24HoursMode) {
+        // Add minutes parameter for past-24-hours mode
+        Object.assign(requestParams, timeParams);
+      } else {
+        requestParams.startDate = timeParams.startDate;
+        requestParams.endDate = timeParams.endDate;
+      }
+
+      return authedFetch(`${BACKEND_URL}/users/${site}`, requestParams).then(
+        (res) => res.json()
+      );
     },
     // Use default staleTime (0) for real-time data
     staleTime: 0,

--- a/client/src/api/analytics/users.ts
+++ b/client/src/api/analytics/users.ts
@@ -36,7 +36,7 @@ export interface GetUsersOptions {
 
 export function useGetUsers(options: GetUsersOptions) {
   const { time, site } = useStore();
-  const isPast24HoursMode = time.mode === "past-24-hours";
+  const isPast24HoursMode = time.mode === "last-24-hours";
 
   // Get the appropriate time parameters
   const timeParams = isPast24HoursMode
@@ -78,7 +78,7 @@ export function useGetUsers(options: GetUsersOptions) {
 
       // Add time parameters
       if (isPast24HoursMode) {
-        // Add minutes parameter for past-24-hours mode
+        // Add minutes parameter for last-24-hours mode
         Object.assign(requestParams, timeParams);
       } else {
         requestParams.startDate = timeParams.startDate;

--- a/client/src/api/analytics/utils.ts
+++ b/client/src/api/analytics/utils.ts
@@ -10,8 +10,8 @@ export function getQueryTimeParams(time: Time): string {
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const params = new URLSearchParams();
 
-  // Handle past-24-hours mode differently
-  if (time.mode === "past-24-hours") {
+  // Handle last-24-hours mode differently
+  if (time.mode === "last-24-hours") {
     // Use minutes parameter instead of date range
     params.append("minutes", "1440"); // 24 hours * 60 minutes
     params.append("timezone", timezone);

--- a/client/src/api/analytics/utils.ts
+++ b/client/src/api/analytics/utils.ts
@@ -7,10 +7,19 @@ import { getStartAndEndDate } from "../utils";
  * @returns URL query string with time parameters
  */
 export function getQueryTimeParams(time: Time): string {
-  const { startDate, endDate } = getStartAndEndDate(time);
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
   const params = new URLSearchParams();
+
+  // Handle past-24-hours mode differently
+  if (time.mode === "past-24-hours") {
+    // Use minutes parameter instead of date range
+    params.append("minutes", "1440"); // 24 hours * 60 minutes
+    params.append("timezone", timezone);
+    return params.toString();
+  }
+
+  // Regular date-based approach for other modes
+  const { startDate, endDate } = getStartAndEndDate(time);
 
   if (startDate) params.append("startDate", startDate);
   if (endDate) params.append("endDate", endDate);

--- a/client/src/api/utils.ts
+++ b/client/src/api/utils.ts
@@ -26,7 +26,7 @@ export function getStartAndEndDate(time: Time) {
   if (time.mode === "all-time") {
     return { startDate: null, endDate: null };
   }
-  if (time.mode === "past-24-hours") {
+  if (time.mode === "last-24-hours") {
     return { startDate: null, endDate: null };
   }
   return { startDate: time.day, endDate: time.day };

--- a/client/src/api/utils.ts
+++ b/client/src/api/utils.ts
@@ -1,7 +1,4 @@
 import { DateTime } from "luxon";
-import { APIResponse } from "./types";
-import { useQuery, UseQueryResult } from "@tanstack/react-query";
-import { BACKEND_URL } from "../lib/const";
 import { Time } from "../components/DateSelector/types";
 
 export function getStartAndEndDate(time: Time) {
@@ -27,6 +24,9 @@ export function getStartAndEndDate(time: Time) {
     };
   }
   if (time.mode === "all-time") {
+    return { startDate: null, endDate: null };
+  }
+  if (time.mode === "past-24-hours") {
     return { startDate: null, endDate: null };
   }
   return { startDate: time.day, endDate: time.day };

--- a/client/src/app/[site]/components/SubHeader/SubHeader.tsx
+++ b/client/src/app/[site]/components/SubHeader/SubHeader.tsx
@@ -94,6 +94,7 @@ export function SubHeader({
               variant="outline"
               size="icon"
               onClick={goBack}
+              disabled={time.mode === "past-24-hours"}
               className="rounded-r-none h-8 w-8 sm:h-9 sm:w-9"
             >
               <ChevronLeft />

--- a/client/src/app/[site]/components/SubHeader/SubHeader.tsx
+++ b/client/src/app/[site]/components/SubHeader/SubHeader.tsx
@@ -94,7 +94,7 @@ export function SubHeader({
               variant="outline"
               size="icon"
               onClick={goBack}
-              disabled={time.mode === "past-24-hours"}
+              disabled={time.mode === "last-24-hours"}
               className="rounded-r-none h-8 w-8 sm:h-9 sm:w-9"
             >
               <ChevronLeft />

--- a/client/src/app/[site]/components/shared/StandardSection/StandardSection.tsx
+++ b/client/src/app/[site]/components/shared/StandardSection/StandardSection.tsx
@@ -36,29 +36,30 @@ export function StandardSection({
     parameter: filterParameter,
   });
 
-  const {
-    data: previousData,
-    isLoading: previousIsLoading,
-    isFetching: previousIsFetching,
-  } = useSingleCol({
-    parameter: filterParameter,
-    periodTime: "previous",
-  });
+  // const {
+  //   data: previousData,
+  //   isLoading: previousIsLoading,
+  //   isFetching: previousIsFetching,
+  // } = useSingleCol({
+  //   parameter: filterParameter,
+  //   periodTime: "previous",
+  // });
 
   // Create combined loading state
-  const loading = isLoading || previousIsLoading;
+  const loading = isLoading;
+  // const loading = isLoading || previousIsLoading;
 
   // For potential additional features that use previous data
-  const previousDataMap = useMemo(() => {
-    return previousData?.data?.reduce((acc, curr) => {
-      acc[getKey(curr)] = curr;
-      return acc;
-    }, {} as Record<string, SingleColResponse>);
-  }, [previousData, getKey]);
+  // const previousDataMap = useMemo(() => {
+  //   return previousData?.data?.reduce((acc, curr) => {
+  //     acc[getKey(curr)] = curr;
+  //     return acc;
+  //   }, {} as Record<string, SingleColResponse>);
+  // }, [previousData, getKey]);
 
   return (
     <>
-      {(isFetching || previousIsFetching) && (
+      {isFetching && (
         <div className="absolute top-[-8px] left-0 w-full h-full">
           <CardLoader />
         </div>

--- a/client/src/app/[site]/funnels/components/Funnel.tsx
+++ b/client/src/app/[site]/funnels/components/Funnel.tsx
@@ -72,7 +72,11 @@ export function Funnel({
             <span>Conversion from previous step</span>
           </div>
         </div>
-        <DateSelector time={time} setTime={setTime} />
+        <DateSelector
+          time={time}
+          setTime={setTime}
+          past24HoursEnabled={false}
+        />
       </div>
 
       {isError ? (

--- a/client/src/app/[site]/funnels/components/FunnelForm.tsx
+++ b/client/src/app/[site]/funnels/components/FunnelForm.tsx
@@ -61,7 +61,6 @@ export function FunnelForm({
   saveError,
   funnelData,
 }: FunnelFormProps) {
-  console.info(funnelData);
   const [showFilters, setShowFilters] = useState(filters.length > 0);
   // State to track which event steps have property filtering enabled
   const [useProperties, setUseProperties] = useState<boolean[]>(() =>

--- a/client/src/app/[site]/goals/page.tsx
+++ b/client/src/app/[site]/goals/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { useGetGoals } from "../../../api/analytics/useGetGoals";
+import {
+  useGetGoals,
+  useGetGoalsPastMinutes,
+} from "../../../api/analytics/useGetGoals";
 import { getStartAndEndDate } from "../../../api/utils";
 import { NothingFound } from "../../../components/NothingFound";
 import { GOALS_PAGE_FILTERS, useStore } from "../../../lib/store";
@@ -14,21 +17,20 @@ export default function GoalsPage() {
   useSetPageTitle("Rybbit · Goals");
 
   const { time, site } = useStore();
-  const { startDate, endDate } = getStartAndEndDate(time);
+  const isPast24HoursMode = time.mode === "past-24-hours";
   const [currentPage, setCurrentPage] = useState(1);
   const pageSize = 9; // Show 9 cards (3x3 grid)
 
-  // Handle the case where startDate or endDate might be null (for 'all-time' mode)
-  const queryStartDate = startDate || "2020-01-01"; // Default fallback date
-  const queryEndDate = endDate || new Date().toISOString().split("T")[0]; // Today
-
-  // Fetch goals data with pagination
-  const { data: goalsData, isLoading } = useGetGoals({
-    startDate: queryStartDate,
-    endDate: queryEndDate,
-    page: currentPage,
-    pageSize,
-  });
+  // Use the appropriate hook based on the mode
+  const { data: goalsData, isLoading } = isPast24HoursMode
+    ? useGetGoalsPastMinutes({
+        page: currentPage,
+        pageSize,
+      })
+    : useGetGoals({
+        page: currentPage,
+        pageSize,
+      });
 
   // Handle page change
   const handlePageChange = (newPage: number) => {

--- a/client/src/app/[site]/goals/page.tsx
+++ b/client/src/app/[site]/goals/page.tsx
@@ -17,7 +17,7 @@ export default function GoalsPage() {
   useSetPageTitle("Rybbit · Goals");
 
   const { time, site } = useStore();
-  const isPast24HoursMode = time.mode === "past-24-hours";
+  const isPast24HoursMode = time.mode === "last-24-hours";
   const [currentPage, setCurrentPage] = useState(1);
   const pageSize = 9; // Show 9 cards (3x3 grid)
 

--- a/client/src/app/[site]/journeys/page.tsx
+++ b/client/src/app/[site]/journeys/page.tsx
@@ -435,7 +435,11 @@ export default function JourneysPage() {
         <MobileSidebar />
       </div>
       <div className="flex justify-end items-center gap-2 mb-2">
-        <DateSelector time={time} setTime={setTime} />
+        <DateSelector
+          time={time}
+          setTime={setTime}
+          past24HoursEnabled={false}
+        />
         <Select
           value={steps.toString()}
           onValueChange={(value) => setSteps(Number(value))}

--- a/client/src/app/[site]/main/components/MainSection/BucketSelection.tsx
+++ b/client/src/app/[site]/main/components/MainSection/BucketSelection.tsx
@@ -12,6 +12,24 @@ import { DateTime } from "luxon";
 import { Time } from "../../../../../components/DateSelector/types";
 
 const getOptions = (time: Time) => {
+  if (time.mode === "past-24-hours") {
+    return (
+      <SelectContent>
+        <SelectItem size="sm" value="minute">
+          Minute
+        </SelectItem>
+        <SelectItem size="sm" value="five_minutes">
+          5 Minutes
+        </SelectItem>
+        <SelectItem size="sm" value="fifteen_minutes">
+          15 Minutes
+        </SelectItem>
+        <SelectItem size="sm" value="hour">
+          Hour
+        </SelectItem>
+      </SelectContent>
+    );
+  }
   if (time.mode === "day") {
     return (
       <SelectContent>

--- a/client/src/app/[site]/main/components/MainSection/BucketSelection.tsx
+++ b/client/src/app/[site]/main/components/MainSection/BucketSelection.tsx
@@ -12,7 +12,7 @@ import { DateTime } from "luxon";
 import { Time } from "../../../../../components/DateSelector/types";
 
 const getOptions = (time: Time) => {
-  if (time.mode === "past-24-hours") {
+  if (time.mode === "last-24-hours") {
     return (
       <SelectContent>
         <SelectItem size="sm" value="minute">

--- a/client/src/app/[site]/main/components/MainSection/Chart.tsx
+++ b/client/src/app/[site]/main/components/MainSection/Chart.tsx
@@ -65,7 +65,7 @@ const getMax = (time: Time, bucket: TimeBucket) => {
 
 const getMin = (time: Time, bucket: TimeBucket) => {
   if (time.mode === "past-24-hours") {
-    return DateTime.now().setZone("UTC").minus({ hours: 24 }).toJSDate();
+    return DateTime.now().setZone("UTC").minus({ hours: 25 }).toJSDate();
   } else if (time.mode === "day") {
     const dayDate = DateTime.fromISO(time.day).startOf("day");
     return dayDate.toJSDate();

--- a/client/src/app/[site]/main/components/MainSection/Chart.tsx
+++ b/client/src/app/[site]/main/components/MainSection/Chart.tsx
@@ -19,7 +19,7 @@ export const formatter = Intl.NumberFormat("en", { notation: "compact" });
 
 const getMax = (time: Time, bucket: TimeBucket) => {
   const now = DateTime.now();
-  if (time.mode === "past-24-hours") {
+  if (time.mode === "last-24-hours") {
     return DateTime.now().setZone("UTC").startOf("hour").toJSDate();
   } else if (time.mode === "day") {
     const dayDate = DateTime.fromISO(time.day)
@@ -64,7 +64,7 @@ const getMax = (time: Time, bucket: TimeBucket) => {
 };
 
 const getMin = (time: Time, bucket: TimeBucket) => {
-  if (time.mode === "past-24-hours") {
+  if (time.mode === "last-24-hours") {
     return DateTime.now()
       .setZone("UTC")
       .minus({ hours: 24 })
@@ -278,7 +278,7 @@ export function Chart({
         truncateTickAt: 0,
         tickValues: Math.min(
           maxTicks,
-          time.mode === "day" || time.mode === "past-24-hours"
+          time.mode === "day" || time.mode === "last-24-hours"
             ? 24
             : Math.min(12, data?.data?.length ?? 0)
         ),
@@ -286,7 +286,7 @@ export function Chart({
           // Convert UTC date to local timezone for display
           const localTime = DateTime.fromJSDate(value).toLocal();
 
-          if (time.mode === "past-24-hours" || time.mode === "day") {
+          if (time.mode === "last-24-hours" || time.mode === "day") {
             return localTime.toFormat("ha");
           } else if (time.mode === "range") {
             return localTime.toFormat("MMM d");

--- a/client/src/app/[site]/main/components/MainSection/Chart.tsx
+++ b/client/src/app/[site]/main/components/MainSection/Chart.tsx
@@ -20,7 +20,7 @@ export const formatter = Intl.NumberFormat("en", { notation: "compact" });
 const getMax = (time: Time, bucket: TimeBucket) => {
   const now = DateTime.now();
   if (time.mode === "past-24-hours") {
-    return DateTime.now().setZone("UTC").toJSDate();
+    return DateTime.now().setZone("UTC").startOf("hour").toJSDate();
   } else if (time.mode === "day") {
     const dayDate = DateTime.fromISO(time.day)
       .endOf("day")
@@ -65,7 +65,11 @@ const getMax = (time: Time, bucket: TimeBucket) => {
 
 const getMin = (time: Time, bucket: TimeBucket) => {
   if (time.mode === "past-24-hours") {
-    return DateTime.now().setZone("UTC").minus({ hours: 25 }).toJSDate();
+    return DateTime.now()
+      .setZone("UTC")
+      .minus({ hours: 24 })
+      .startOf("hour")
+      .toJSDate();
   } else if (time.mode === "day") {
     const dayDate = DateTime.fromISO(time.day).startOf("day");
     return dayDate.toJSDate();

--- a/client/src/app/[site]/main/components/MainSection/MainSection.tsx
+++ b/client/src/app/[site]/main/components/MainSection/MainSection.tsx
@@ -46,6 +46,9 @@ export function MainSection() {
   } = useGetOverviewBucketed({
     site,
     bucket,
+    props: {
+      enabled: !isPast24HoursMode,
+    },
   });
 
   const {
@@ -56,6 +59,9 @@ export function MainSection() {
     periodTime: "previous",
     site,
     bucket,
+    props: {
+      enabled: isPast24HoursMode,
+    },
   });
 
   // Past minutes-based queries (for 24 hour mode)
@@ -67,6 +73,9 @@ export function MainSection() {
     pastMinutes: 24 * 60,
     site,
     bucket,
+    props: {
+      enabled: isPast24HoursMode,
+    },
   });
 
   const {
@@ -77,6 +86,9 @@ export function MainSection() {
     pastMinutes: 48 * 60, // Previous 24 hours
     site,
     bucket,
+    props: {
+      enabled: isPast24HoursMode,
+    },
   });
 
   // Combine the data based on the mode

--- a/client/src/app/[site]/main/components/MainSection/MainSection.tsx
+++ b/client/src/app/[site]/main/components/MainSection/MainSection.tsx
@@ -7,6 +7,7 @@ import { useGetOverview } from "../../../../../api/analytics/useGetOverview";
 import {
   useGetOverviewBucketed,
   useGetOverviewBucketedPastMinutes,
+  useGetOverviewBucketedPreviousPastMinutes,
 } from "../../../../../api/analytics/useGetOverviewBucketed";
 import { authClient } from "../../../../../lib/auth";
 import { useStore } from "../../../../../lib/store";
@@ -60,7 +61,7 @@ export function MainSection() {
     site,
     bucket,
     props: {
-      enabled: isPast24HoursMode,
+      enabled: !isPast24HoursMode,
     },
   });
 
@@ -82,8 +83,8 @@ export function MainSection() {
     data: pastMinutesPreviousData,
     isFetching: isPastMinutesPreviousFetching,
     error: pastMinutesPreviousError,
-  } = useGetOverviewBucketedPastMinutes({
-    pastMinutes: 48 * 60, // Previous 24 hours
+  } = useGetOverviewBucketedPreviousPastMinutes({
+    pastMinutes: 24 * 60,
     site,
     bucket,
     props: {
@@ -110,8 +111,8 @@ export function MainSection() {
   });
 
   const maxOfDataAndPreviousData = Math.max(
-    Math.max(...(data?.data?.map((d) => d[selectedStat]) ?? [])),
-    Math.max(...(previousData?.data?.map((d) => d[selectedStat]) ?? []))
+    Math.max(...(data?.data?.map((d: any) => d[selectedStat]) ?? [])),
+    Math.max(...(previousData?.data?.map((d: any) => d[selectedStat]) ?? []))
   );
 
   return (

--- a/client/src/app/[site]/main/components/MainSection/MainSection.tsx
+++ b/client/src/app/[site]/main/components/MainSection/MainSection.tsx
@@ -36,8 +36,8 @@ export function MainSection() {
 
   const { selectedStat, time, site, bucket } = useStore();
 
-  // Use the past minutes API when in past-24-hours mode
-  const isPast24HoursMode = time.mode === "past-24-hours";
+  // Use the past minutes API when in last-24-hours mode
+  const isPast24HoursMode = time.mode === "last-24-hours";
 
   // Regular date-based queries
   const {

--- a/client/src/app/[site]/main/components/MainSection/MainSection.tsx
+++ b/client/src/app/[site]/main/components/MainSection/MainSection.tsx
@@ -4,7 +4,10 @@ import { Tilt_Warp } from "next/font/google";
 import Image from "next/image";
 import Link from "next/link";
 import { useGetOverview } from "../../../../../api/analytics/useGetOverview";
-import { useGetOverviewBucketed } from "../../../../../api/analytics/useGetOverviewBucketed";
+import {
+  useGetOverviewBucketed,
+  useGetOverviewBucketedPastMinutes,
+} from "../../../../../api/analytics/useGetOverviewBucketed";
 import { authClient } from "../../../../../lib/auth";
 import { useStore } from "../../../../../lib/store";
 import { cn } from "../../../../../lib/utils";
@@ -32,12 +35,62 @@ export function MainSection() {
 
   const { selectedStat, time, site, bucket } = useStore();
 
-  const { data, isFetching, error } = useGetOverviewBucketed({ site, bucket });
+  // Use the past minutes API when in past-24-hours mode
+  const isPast24HoursMode = time.mode === "past-24-hours";
+
+  // Regular date-based queries
   const {
-    data: previousData,
-    isFetching: isPreviousFetching,
-    error: previousError,
-  } = useGetOverviewBucketed({ periodTime: "previous", site, bucket });
+    data: regularData,
+    isFetching: isRegularFetching,
+    error: regularError,
+  } = useGetOverviewBucketed({
+    site,
+    bucket,
+  });
+
+  const {
+    data: regularPreviousData,
+    isFetching: isRegularPreviousFetching,
+    error: regularPreviousError,
+  } = useGetOverviewBucketed({
+    periodTime: "previous",
+    site,
+    bucket,
+  });
+
+  // Past minutes-based queries (for 24 hour mode)
+  const {
+    data: pastMinutesData,
+    isFetching: isPastMinutesFetching,
+    error: pastMinutesError,
+  } = useGetOverviewBucketedPastMinutes({
+    pastMinutes: 24 * 60,
+    site,
+    bucket,
+  });
+
+  const {
+    data: pastMinutesPreviousData,
+    isFetching: isPastMinutesPreviousFetching,
+    error: pastMinutesPreviousError,
+  } = useGetOverviewBucketedPastMinutes({
+    pastMinutes: 48 * 60, // Previous 24 hours
+    site,
+    bucket,
+  });
+
+  // Combine the data based on the mode
+  const data = isPast24HoursMode ? pastMinutesData : regularData;
+  const previousData = isPast24HoursMode
+    ? pastMinutesPreviousData
+    : regularPreviousData;
+  const isFetching = isPast24HoursMode
+    ? isPastMinutesFetching
+    : isRegularFetching;
+  const isPreviousFetching = isPast24HoursMode
+    ? isPastMinutesPreviousFetching
+    : isRegularPreviousFetching;
+
   const { isFetching: isOverviewFetching } = useGetOverview({ site });
   const { isFetching: isOverviewFetchingPrevious } = useGetOverview({
     site,
@@ -64,7 +117,10 @@ export function MainSection() {
             <div className="flex items-center space-x-4">
               <Link
                 href={session.data ? "/" : "https://rybbit.io"}
-                className={cn("text-lg font-semibold flex items-center gap-1.5 opacity-75", tilt_wrap.className)}
+                className={cn(
+                  "text-lg font-semibold flex items-center gap-1.5 opacity-75",
+                  tilt_wrap.className
+                )}
               >
                 <Image src="/rybbit.png" alt="Rybbit" width={20} height={20} />
                 rybbit.io

--- a/client/src/app/[site]/main/components/MainSection/Overview.tsx
+++ b/client/src/app/[site]/main/components/MainSection/Overview.tsx
@@ -80,7 +80,7 @@ const Stat = ({
 }) => {
   const { selectedStat, setSelectedStat, site, bucket, time } = useStore();
   const [isHovering, setIsHovering] = useState(false);
-  const isPast24HoursMode = time.mode === "past-24-hours";
+  const isPast24HoursMode = time.mode === "last-24-hours";
 
   // Regular bucketed data for sparklines
   const { data: regularData } = useGetOverviewBucketed({
@@ -108,7 +108,7 @@ const Stat = ({
   const sparklinesData =
     data?.data
       ?.filter((d) => {
-        // For past-24-hours mode, ensure we only show data within the last 24 hours
+        // For last-24-hours mode, ensure we only show data within the last 24 hours
         if (isPast24HoursMode) {
           const timestamp = new Date(d.time);
           const now = new Date();
@@ -176,7 +176,7 @@ const Stat = ({
 
 export function Overview() {
   const { site, time } = useStore();
-  const isPast24HoursMode = time.mode === "past-24-hours";
+  const isPast24HoursMode = time.mode === "last-24-hours";
 
   // Regular time-based queries
   const {

--- a/client/src/app/[site]/main/components/MainSection/Overview.tsx
+++ b/client/src/app/[site]/main/components/MainSection/Overview.tsx
@@ -5,8 +5,14 @@ import { cn, formatSecondsAsMinutesAndSeconds } from "@/lib/utils";
 import NumberFlow from "@number-flow/react";
 import { TrendingDown, TrendingUp } from "lucide-react";
 import { useState } from "react";
-import { useGetOverview } from "../../../../../api/analytics/useGetOverview";
-import { useGetOverviewBucketed } from "../../../../../api/analytics/useGetOverviewBucketed";
+import {
+  useGetOverview,
+  useGetOverviewPastMinutes,
+} from "../../../../../api/analytics/useGetOverview";
+import {
+  useGetOverviewBucketed,
+  useGetOverviewBucketedPastMinutes,
+} from "../../../../../api/analytics/useGetOverviewBucketed";
 import { StatType, useStore } from "../../../../../lib/store";
 import { SparklinesChart } from "./SparklinesChart";
 
@@ -34,7 +40,12 @@ const ChangePercentage = ({
 
   return (
     <div
-      className={cn("text-xs flex items-center gap-1", (reverseColor ? -change : change) > 0 ? "text-green-400" : "text-red-400")}
+      className={cn(
+        "text-xs flex items-center gap-1",
+        (reverseColor ? -change : change) > 0
+          ? "text-green-400"
+          : "text-red-400"
+      )}
     >
       {change > 0 ? (
         <TrendingUp className="w-4 h-4" />
@@ -67,20 +78,49 @@ const Stat = ({
   postfix?: string;
   reverseColor?: boolean;
 }) => {
-  const { selectedStat, setSelectedStat, site, bucket } = useStore();
+  const { selectedStat, setSelectedStat, site, bucket, time } = useStore();
   const [isHovering, setIsHovering] = useState(false);
+  const isPast24HoursMode = time.mode === "past-24-hours";
 
-  const { data, isFetching, error } = useGetOverviewBucketed({ site, bucket });
+  // Regular bucketed data for sparklines
+  const { data: regularData } = useGetOverviewBucketed({ site, bucket });
 
+  // Past minutes data for sparklines
+  const { data: pastMinutesData } = useGetOverviewBucketedPastMinutes({
+    pastMinutes: 24 * 60,
+    site,
+    bucket,
+  });
+
+  // Use the appropriate data source based on mode
+  const data = isPast24HoursMode ? pastMinutesData : regularData;
+
+  // Filter and format sparklines data
   const sparklinesData =
-    data?.data?.map((d) => ({
-      value: d[id],
-      time: d.time,
-    })) ?? [];
+    data?.data
+      ?.filter((d) => {
+        // For past-24-hours mode, ensure we only show data within the last 24 hours
+        if (isPast24HoursMode) {
+          const timestamp = new Date(d.time);
+          const now = new Date();
+          const twentyFourHoursAgo = new Date(
+            now.getTime() - 24 * 60 * 60 * 1000
+          );
+          return timestamp >= twentyFourHoursAgo && timestamp <= now;
+        }
+        return true;
+      })
+      .map((d: any) => ({
+        value: d[id],
+        time: d.time,
+      })) ?? [];
 
   return (
     <div
-      className={cn("flex flex-col cursor-pointer border-r border-neutral-800 last:border-r-0 text-nowrap", selectedStat === id && "bg-neutral-850")}
+      className={cn(
+        "flex flex-col cursor-pointer border-r border-neutral-800 last:border-r-0 text-nowrap",
+        selectedStat === id && "bg-neutral-850"
+      )}
       onClick={() => setSelectedStat(id)}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
@@ -126,15 +166,62 @@ const Stat = ({
 };
 
 export function Overview() {
-  const { site } = useStore();
+  const { site, time } = useStore();
+  const isPast24HoursMode = time.mode === "past-24-hours";
+
+  // Regular time-based queries
   const {
-    data: overviewData,
-    isFetching: isOverviewFetching,
-    isLoading: isOverviewLoading,
-    error: overviewError,
+    data: regularOverviewData,
+    isFetching: isRegularOverviewFetching,
+    isLoading: isRegularOverviewLoading,
+    error: regularOverviewError,
   } = useGetOverview({ site });
-  const { data: overviewDataPrevious, isLoading: isOverviewLoadingPrevious } =
-    useGetOverview({ site, periodTime: "previous" });
+
+  const {
+    data: regularOverviewDataPrevious,
+    isLoading: isRegularOverviewLoadingPrevious,
+  } = useGetOverview({ site, periodTime: "previous" });
+
+  // Past minutes-based queries
+  const {
+    data: pastMinutesOverviewData,
+    isFetching: isPastMinutesOverviewFetching,
+    isLoading: isPastMinutesOverviewLoading,
+    error: pastMinutesOverviewError,
+  } = useGetOverviewPastMinutes({
+    site,
+    pastMinutes: 24 * 60,
+  });
+
+  // Past minutes-based queries for previous period
+  const {
+    data: pastMinutesOverviewDataPrevious,
+    isLoading: isPastMinutesOverviewLoadingPrevious,
+  } = useGetOverviewPastMinutes({
+    site,
+    pastMinutes: 48 * 60, // Use 48 hours instead of a isPrevious flag
+  });
+
+  // Combine the data based on the mode
+  const overviewData = isPast24HoursMode
+    ? pastMinutesOverviewData
+    : regularOverviewData;
+  const overviewDataPrevious = isPast24HoursMode
+    ? pastMinutesOverviewDataPrevious
+    : regularOverviewDataPrevious;
+
+  const isOverviewFetching = isPast24HoursMode
+    ? isPastMinutesOverviewFetching
+    : isRegularOverviewFetching;
+  const isOverviewLoading = isPast24HoursMode
+    ? isPastMinutesOverviewLoading
+    : isRegularOverviewLoading;
+  const isOverviewLoadingPrevious = isPast24HoursMode
+    ? isPastMinutesOverviewLoadingPrevious
+    : isRegularOverviewLoadingPrevious;
+  const overviewError = isPast24HoursMode
+    ? pastMinutesOverviewError
+    : regularOverviewError;
 
   const isLoading = isOverviewLoading || isOverviewLoadingPrevious;
 

--- a/client/src/app/[site]/main/components/MainSection/Overview.tsx
+++ b/client/src/app/[site]/main/components/MainSection/Overview.tsx
@@ -83,13 +83,22 @@ const Stat = ({
   const isPast24HoursMode = time.mode === "past-24-hours";
 
   // Regular bucketed data for sparklines
-  const { data: regularData } = useGetOverviewBucketed({ site, bucket });
+  const { data: regularData } = useGetOverviewBucketed({
+    site,
+    bucket,
+    props: {
+      enabled: !isPast24HoursMode,
+    },
+  });
 
   // Past minutes data for sparklines
   const { data: pastMinutesData } = useGetOverviewBucketedPastMinutes({
     pastMinutes: 24 * 60,
     site,
     bucket,
+    props: {
+      enabled: isPast24HoursMode,
+    },
   });
 
   // Use the appropriate data source based on mode

--- a/client/src/app/[site]/main/components/MainSection/PreviousChart.tsx
+++ b/client/src/app/[site]/main/components/MainSection/PreviousChart.tsx
@@ -10,7 +10,7 @@ import { Time } from "../../../../../components/DateSelector/types";
 
 const getMin = (time: Time) => {
   if (time.mode === "past-24-hours") {
-    return DateTime.now().minus({ hours: 48 }).toJSDate();
+    return DateTime.now().setZone("UTC").minus({ hours: 48 }).toJSDate();
   } else if (time.mode === "day") {
     const dayDate = DateTime.fromISO(time.day).startOf("day");
     return dayDate.toJSDate();
@@ -40,15 +40,21 @@ export function PreviousChart({
 }) {
   const { previousTime: time, selectedStat } = useStore();
 
-  const formattedData = data?.data?.map((e) => ({
-    x: DateTime.fromSQL(e.time).toUTC().toFormat("yyyy-MM-dd HH:mm:ss"),
-    y: e[selectedStat],
-  }));
+  const size = (data?.data.length ?? 0 / 2) + 1;
+  const formattedData = data?.data
+    ?.map((e) => {
+      const timestamp = DateTime.fromSQL(e.time).toUTC();
+      return {
+        x: timestamp.toFormat("yyyy-MM-dd HH:mm:ss"),
+        y: e[selectedStat],
+      };
+    })
+    .slice(0, size);
 
   const min = useMemo(() => getMin(time), [time]);
   const max24Hours =
     time.mode === "past-24-hours"
-      ? DateTime.now().minus({ hours: 24 }).toJSDate()
+      ? DateTime.now().setZone("UTC").minus({ hours: 24 }).toJSDate()
       : undefined;
 
   return (
@@ -88,15 +94,18 @@ export function PreviousChart({
         truncateTickAt: 0,
         tickValues: 0,
         format: (value) => {
-          if (time.mode === "day") {
-            return DateTime.fromJSDate(value).toFormat("ha");
+          const localTime = DateTime.fromJSDate(value).toLocal();
+
+          if (time.mode === "past-24-hours" || time.mode === "day") {
+            return localTime.toFormat("ha");
           } else if (time.mode === "range") {
-            return DateTime.fromJSDate(value).toFormat("MMM d");
+            return localTime.toFormat("MMM d");
           } else if (time.mode === "week") {
-            return DateTime.fromJSDate(value).toFormat("MMM d");
+            return localTime.toFormat("MMM d");
           } else if (time.mode === "month") {
-            return DateTime.fromJSDate(value).toFormat("MMM d");
+            return localTime.toFormat("MMM d");
           }
+          return "";
         },
       }}
       axisLeft={{

--- a/client/src/app/[site]/main/components/MainSection/PreviousChart.tsx
+++ b/client/src/app/[site]/main/components/MainSection/PreviousChart.tsx
@@ -10,7 +10,7 @@ import { Time } from "../../../../../components/DateSelector/types";
 
 const getMin = (time: Time) => {
   if (time.mode === "past-24-hours") {
-    return DateTime.now().setZone("UTC").minus({ hours: 48 }).toJSDate();
+    return DateTime.now().setZone("UTC").minus({ hours: 49 }).toJSDate();
   } else if (time.mode === "day") {
     const dayDate = DateTime.fromISO(time.day).startOf("day");
     return dayDate.toJSDate();

--- a/client/src/app/[site]/main/components/MainSection/PreviousChart.tsx
+++ b/client/src/app/[site]/main/components/MainSection/PreviousChart.tsx
@@ -9,7 +9,9 @@ import { GetOverviewBucketedResponse } from "../../../../../api/analytics/useGet
 import { Time } from "../../../../../components/DateSelector/types";
 
 const getMin = (time: Time) => {
-  if (time.mode === "day") {
+  if (time.mode === "past-24-hours") {
+    return DateTime.now().minus({ hours: 48 }).toJSDate();
+  } else if (time.mode === "day") {
     const dayDate = DateTime.fromISO(time.day).startOf("day");
     return dayDate.toJSDate();
   } else if (time.mode === "week") {
@@ -43,7 +45,11 @@ export function PreviousChart({
     y: e[selectedStat],
   }));
 
-  const min = useMemo(() => getMin(time), [data]);
+  const min = useMemo(() => getMin(time), [time]);
+  const max24Hours =
+    time.mode === "past-24-hours"
+      ? DateTime.now().minus({ hours: 24 }).toJSDate()
+      : undefined;
 
   return (
     <ResponsiveLine
@@ -61,6 +67,7 @@ export function PreviousChart({
         precision: "second",
         useUTC: true,
         min,
+        max: max24Hours,
       }}
       yScale={{
         type: "linear",

--- a/client/src/app/[site]/main/components/MainSection/PreviousChart.tsx
+++ b/client/src/app/[site]/main/components/MainSection/PreviousChart.tsx
@@ -10,7 +10,11 @@ import { Time } from "../../../../../components/DateSelector/types";
 
 const getMin = (time: Time) => {
   if (time.mode === "past-24-hours") {
-    return DateTime.now().setZone("UTC").minus({ hours: 49 }).toJSDate();
+    return DateTime.now()
+      .setZone("UTC")
+      .minus({ hours: 48 })
+      .startOf("hour")
+      .toJSDate();
   } else if (time.mode === "day") {
     const dayDate = DateTime.fromISO(time.day).startOf("day");
     return dayDate.toJSDate();

--- a/client/src/app/[site]/main/components/MainSection/PreviousChart.tsx
+++ b/client/src/app/[site]/main/components/MainSection/PreviousChart.tsx
@@ -9,7 +9,7 @@ import { GetOverviewBucketedResponse } from "../../../../../api/analytics/useGet
 import { Time } from "../../../../../components/DateSelector/types";
 
 const getMin = (time: Time) => {
-  if (time.mode === "past-24-hours") {
+  if (time.mode === "last-24-hours") {
     return DateTime.now()
       .setZone("UTC")
       .minus({ hours: 48 })
@@ -57,7 +57,7 @@ export function PreviousChart({
 
   const min = useMemo(() => getMin(time), [time]);
   const max24Hours =
-    time.mode === "past-24-hours"
+    time.mode === "last-24-hours"
       ? DateTime.now().setZone("UTC").minus({ hours: 24 }).toJSDate()
       : undefined;
 
@@ -100,7 +100,7 @@ export function PreviousChart({
         format: (value) => {
           const localTime = DateTime.fromJSDate(value).toLocal();
 
-          if (time.mode === "past-24-hours" || time.mode === "day") {
+          if (time.mode === "last-24-hours" || time.mode === "day") {
             return localTime.toFormat("ha");
           } else if (time.mode === "range") {
             return localTime.toFormat("MMM d");

--- a/client/src/app/[site]/main/components/sections/Weekdays.tsx
+++ b/client/src/app/[site]/main/components/sections/Weekdays.tsx
@@ -1,6 +1,9 @@
 import { DateTime } from "luxon";
 import { useMemo, useState } from "react";
-import { useGetOverviewBucketed } from "../../../../../api/analytics/useGetOverviewBucketed";
+import {
+  useGetOverviewBucketed,
+  useGetOverviewBucketedPastMinutes,
+} from "../../../../../api/analytics/useGetOverviewBucketed";
 import {
   Tabs,
   TabsList,
@@ -28,17 +31,39 @@ import { StatType, useStore } from "../../../../../lib/store";
 import { cn } from "../../../../../lib/utils";
 
 export function Weekdays() {
-  const { site } = useStore();
+  const { site, time } = useStore();
   const [metric, setMetric] = useState<StatType>("users");
+
+  // Use the past minutes API when in past-24-hours mode
+  const isPast24HoursMode = time.mode === "past-24-hours";
 
   const { data, isFetching, error } = useGetOverviewBucketed({
     site,
     bucket: "hour",
+    props: {
+      enabled: !isPast24HoursMode,
+    },
   });
+
+  // Past minutes-based queries (for 24 hour mode)
+  const {
+    data: past24HoursData,
+    isFetching: isPast24HoursFetching,
+    error: past24HoursError,
+  } = useGetOverviewBucketedPastMinutes({
+    pastMinutes: 24 * 60,
+    site,
+    bucket: "hour",
+    props: {
+      enabled: isPast24HoursMode,
+    },
+  });
+
+  const dataToUse = isPast24HoursMode ? past24HoursData : data;
 
   // Generate aggregated data for the heatmap
   const heatmapData = useMemo(() => {
-    if (!data?.data) return [];
+    if (!dataToUse?.data) return [];
 
     // Initialize a 2D array for days (0-6) and hours (0-23)
     const aggregated: number[][] = Array(7)
@@ -51,7 +76,7 @@ export function Weekdays() {
       .map(() => Array(24).fill(0));
 
     // Process each data point
-    data.data.forEach((item) => {
+    dataToUse.data.forEach((item) => {
       if (!item || !item.time) return;
 
       // Parse the timestamp
@@ -79,7 +104,7 @@ export function Weekdays() {
     }
 
     return aggregated;
-  }, [data, metric]);
+  }, [dataToUse, metric]);
 
   // Find max value for color intensity scaling
   const maxValue = useMemo(() => {
@@ -264,7 +289,10 @@ export function Weekdays() {
                           <Tooltip key={day}>
                             <TooltipTrigger asChild>
                               <div
-                                className={cn("flex-1 mx-0.5 hover:ring-1 hover:ring-emerald-300 transition-all rounded-sm my-0.5", colorClass)}
+                                className={cn(
+                                  "flex-1 mx-0.5 hover:ring-1 hover:ring-emerald-300 transition-all rounded-sm my-0.5",
+                                  colorClass
+                                )}
                               />
                             </TooltipTrigger>
                             <TooltipContent className="flex flex-col gap-1 p-2">

--- a/client/src/app/[site]/main/components/sections/Weekdays.tsx
+++ b/client/src/app/[site]/main/components/sections/Weekdays.tsx
@@ -34,8 +34,8 @@ export function Weekdays() {
   const { site, time } = useStore();
   const [metric, setMetric] = useState<StatType>("users");
 
-  // Use the past minutes API when in past-24-hours mode
-  const isPast24HoursMode = time.mode === "past-24-hours";
+  // Use the past minutes API when in last-24-hours mode
+  const isPast24HoursMode = time.mode === "last-24-hours";
 
   const { data, isFetching, error } = useGetOverviewBucketed({
     site,

--- a/client/src/components/DateSelector/DateSelector.tsx
+++ b/client/src/components/DateSelector/DateSelector.tsx
@@ -24,7 +24,7 @@ const getLabel = (time: Time) => {
     return `${startFormatted} - ${endFormatted}`;
   }
 
-  if (time.mode === "past-24-hours") {
+  if (time.mode === "last-24-hours") {
     return "Past 24 Hours";
   }
 
@@ -109,11 +109,11 @@ export function DateSelector({
           <DropdownMenuItem
             onClick={() =>
               setTime({
-                mode: "past-24-hours",
+                mode: "last-24-hours",
               })
             }
           >
-            Past 24 Hours
+            Last 24 Hours
           </DropdownMenuItem>
         )}
         <DropdownMenuItem

--- a/client/src/components/DateSelector/DateSelector.tsx
+++ b/client/src/components/DateSelector/DateSelector.tsx
@@ -79,9 +79,11 @@ const getLabel = (time: Time) => {
 export function DateSelector({
   time,
   setTime,
+  past24HoursEnabled = true,
 }: {
   time: Time;
   setTime: (time: Time) => void;
+  past24HoursEnabled?: boolean;
 }) {
   return (
     <DropdownMenu>
@@ -103,15 +105,17 @@ export function DateSelector({
         >
           Today
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() =>
-            setTime({
-              mode: "past-24-hours",
-            })
-          }
-        >
-          Past 24 Hours
-        </DropdownMenuItem>
+        {past24HoursEnabled && (
+          <DropdownMenuItem
+            onClick={() =>
+              setTime({
+                mode: "past-24-hours",
+              })
+            }
+          >
+            Past 24 Hours
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem
           onClick={() =>
             setTime({

--- a/client/src/components/DateSelector/DateSelector.tsx
+++ b/client/src/components/DateSelector/DateSelector.tsx
@@ -24,6 +24,10 @@ const getLabel = (time: Time) => {
     return `${startFormatted} - ${endFormatted}`;
   }
 
+  if (time.mode === "past-24-hours") {
+    return "Past 24 Hours";
+  }
+
   if (time.mode === "day") {
     if (time.day === DateTime.now().toISODate()) {
       return "Today";
@@ -98,6 +102,15 @@ export function DateSelector({
           }
         >
           Today
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() =>
+            setTime({
+              mode: "past-24-hours",
+            })
+          }
+        >
+          Past 24 Hours
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() =>

--- a/client/src/components/DateSelector/types.ts
+++ b/client/src/components/DateSelector/types.ts
@@ -35,7 +35,7 @@ export type AllTimeMode = {
 };
 
 export type Past24HoursMode = {
-  mode: "past-24-hours";
+  mode: "last-24-hours";
 };
 
 export type Time =

--- a/client/src/components/DateSelector/types.ts
+++ b/client/src/components/DateSelector/types.ts
@@ -34,10 +34,15 @@ export type AllTimeMode = {
   mode: "all-time";
 };
 
+export type Past24HoursMode = {
+  mode: "past-24-hours";
+};
+
 export type Time =
   | DateMode
   | DateRangeMode
   | WeekMode
   | MonthMode
   | YearMode
-  | AllTimeMode;
+  | AllTimeMode
+  | Past24HoursMode;

--- a/client/src/lib/store.ts
+++ b/client/src/lib/store.ts
@@ -195,10 +195,10 @@ export const useStore = create<Store>((set) => ({
         mode: "day",
         day: DateTime.fromISO(time.day).minus({ days: 1 }).toISODate() ?? "",
       };
-    } else if (time.mode === "past-24-hours") {
+    } else if (time.mode === "last-24-hours") {
       bucketToUse = "hour";
       previousTime = {
-        mode: "past-24-hours",
+        mode: "last-24-hours",
       };
     } else if (time.mode === "range") {
       const timeRangeLength =

--- a/client/src/lib/store.ts
+++ b/client/src/lib/store.ts
@@ -195,6 +195,11 @@ export const useStore = create<Store>((set) => ({
         mode: "day",
         day: DateTime.fromISO(time.day).minus({ days: 1 }).toISODate() ?? "",
       };
+    } else if (time.mode === "past-24-hours") {
+      bucketToUse = "hour";
+      previousTime = {
+        mode: "past-24-hours",
+      };
     } else if (time.mode === "range") {
       const timeRangeLength =
         DateTime.fromISO(time.endDate).diff(

--- a/client/src/lib/urlParams.ts
+++ b/client/src/lib/urlParams.ts
@@ -64,10 +64,7 @@ export const deserializeUrlToState = (
   const timeMode = searchParams.get("timeMode") as Time["mode"] | null;
   if (timeMode) {
     if (timeMode === "past-24-hours") {
-      const pastMinutes = searchParams.get("pastMinutes");
-      if (pastMinutes) {
-        result.time = { mode: "past-24-hours" };
-      }
+      result.time = { mode: "past-24-hours" };
     } else if (timeMode === "day") {
       const day = searchParams.get("day");
       if (day) {

--- a/client/src/lib/urlParams.ts
+++ b/client/src/lib/urlParams.ts
@@ -63,7 +63,12 @@ export const deserializeUrlToState = (
   // Deserialize time
   const timeMode = searchParams.get("timeMode") as Time["mode"] | null;
   if (timeMode) {
-    if (timeMode === "day") {
+    if (timeMode === "past-24-hours") {
+      const pastMinutes = searchParams.get("pastMinutes");
+      if (pastMinutes) {
+        result.time = { mode: "past-24-hours" };
+      }
+    } else if (timeMode === "day") {
       const day = searchParams.get("day");
       if (day) {
         result.time = { mode: "day", day };

--- a/client/src/lib/urlParams.ts
+++ b/client/src/lib/urlParams.ts
@@ -63,8 +63,8 @@ export const deserializeUrlToState = (
   // Deserialize time
   const timeMode = searchParams.get("timeMode") as Time["mode"] | null;
   if (timeMode) {
-    if (timeMode === "past-24-hours") {
-      result.time = { mode: "past-24-hours" };
+    if (timeMode === "last-24-hours") {
+      result.time = { mode: "last-24-hours" };
     } else if (timeMode === "day") {
       const day = searchParams.get("day");
       if (day) {

--- a/server/src/api/analytics/getEventNames.ts
+++ b/server/src/api/analytics/getEventNames.ts
@@ -17,10 +17,11 @@ export interface GetEventNamesRequest {
     site: string;
   };
   Querystring: {
-    startDate: string;
-    endDate: string;
+    startDate?: string;
+    endDate?: string;
     timezone: string;
     filters?: string;
+    minutes?: string;
   };
 }
 
@@ -28,16 +29,18 @@ export async function getEventNames(
   req: FastifyRequest<GetEventNamesRequest>,
   res: FastifyReply
 ) {
-  const { startDate, endDate, timezone, filters } = req.query;
+  const { startDate, endDate, timezone, filters, minutes } = req.query;
   const site = req.params.site;
   const userHasAccessToSite = await getUserHasAccessToSitePublic(req, site);
   if (!userHasAccessToSite) {
     return res.status(403).send({ error: "Forbidden" });
   }
 
-  const timeStatement = getTimeStatement({
-    date: { startDate, endDate, timezone },
-  });
+  const timeStatement = getTimeStatement(
+    minutes
+      ? { pastMinutes: Number(minutes) }
+      : { date: { startDate, endDate, timezone } }
+  );
 
   const filterStatement = filters ? getFilterStatement(filters) : "";
 

--- a/server/src/api/analytics/getEventNames.ts
+++ b/server/src/api/analytics/getEventNames.ts
@@ -36,11 +36,12 @@ export async function getEventNames(
     return res.status(403).send({ error: "Forbidden" });
   }
 
-  const timeStatement = getTimeStatement(
-    minutes
-      ? { pastMinutes: Number(minutes) }
-      : { date: { startDate, endDate, timezone } }
-  );
+  const timeStatement = getTimeStatement({
+    startDate,
+    endDate,
+    timezone,
+    minutes,
+  });
 
   const filterStatement = filters ? getFilterStatement(filters) : "";
 

--- a/server/src/api/analytics/getEventProperties.ts
+++ b/server/src/api/analytics/getEventProperties.ts
@@ -18,11 +18,12 @@ export interface GetEventPropertiesRequest {
     site: string;
   };
   Querystring: {
-    startDate: string;
-    endDate: string;
+    startDate?: string;
+    endDate?: string;
     timezone: string;
     eventName: string;
     filters?: string;
+    minutes?: string;
   };
 }
 
@@ -30,7 +31,8 @@ export async function getEventProperties(
   req: FastifyRequest<GetEventPropertiesRequest>,
   res: FastifyReply
 ) {
-  const { startDate, endDate, timezone, eventName, filters } = req.query;
+  const { startDate, endDate, timezone, eventName, filters, minutes } =
+    req.query;
   const site = req.params.site;
   const userHasAccessToSite = await getUserHasAccessToSitePublic(req, site);
   if (!userHasAccessToSite) {
@@ -41,9 +43,11 @@ export async function getEventProperties(
     return res.status(400).send({ error: "Event name is required" });
   }
 
-  const timeStatement = getTimeStatement({
-    date: { startDate, endDate, timezone },
-  });
+  const timeStatement = getTimeStatement(
+    minutes
+      ? { pastMinutes: Number(minutes) }
+      : { date: { startDate, endDate, timezone } }
+  );
 
   const filterStatement = filters ? getFilterStatement(filters) : "";
 

--- a/server/src/api/analytics/getEventProperties.ts
+++ b/server/src/api/analytics/getEventProperties.ts
@@ -43,11 +43,12 @@ export async function getEventProperties(
     return res.status(400).send({ error: "Event name is required" });
   }
 
-  const timeStatement = getTimeStatement(
-    minutes
-      ? { pastMinutes: Number(minutes) }
-      : { date: { startDate, endDate, timezone } }
-  );
+  const timeStatement = getTimeStatement({
+    startDate,
+    endDate,
+    timezone,
+    minutes,
+  });
 
   const filterStatement = filters ? getFilterStatement(filters) : "";
 

--- a/server/src/api/analytics/getEvents.ts
+++ b/server/src/api/analytics/getEvents.ts
@@ -66,7 +66,7 @@ export async function getEvents(
   // Get time and filter statements if parameters are provided
   const timeStatement =
     startDate || endDate
-      ? getTimeStatement({ date: { startDate, endDate, timezone } })
+      ? getTimeStatement({ startDate, endDate, timezone })
       : "AND timestamp > now() - INTERVAL 30 MINUTE"; // Default to last 30 minutes if no time range specified
 
   const filterStatement = filters ? getFilterStatement(filters) : "";

--- a/server/src/api/analytics/getGoals.ts
+++ b/server/src/api/analytics/getGoals.ts
@@ -155,23 +155,14 @@ export async function getGoals(
 
     // Build filter and time clauses for ClickHouse queries
     const filterStatement = filters ? getFilterStatement(filters) : "";
-
-    // Handle specific past minutes range if provided
-    const pastMinutesRange =
-      pastMinutesStart && pastMinutesEnd
-        ? { start: Number(pastMinutesStart), end: Number(pastMinutesEnd) }
-        : undefined;
-
-    // Set up time parameters
-    const timeParams = pastMinutesRange
-      ? { pastMinutesRange }
-      : minutes
-      ? { pastMinutes: Number(minutes) }
-      : startDate || endDate
-      ? { date: { startDate, endDate, timezone } }
-      : {};
-
-    const timeStatement = getTimeStatement(timeParams);
+    const timeStatement = getTimeStatement({
+      startDate,
+      endDate,
+      timezone,
+      minutes,
+      pastMinutesStart,
+      pastMinutesEnd,
+    });
 
     // First, get the total number of unique sessions (denominator for conversion rate)
     const totalSessionsQuery = `

--- a/server/src/api/analytics/getOverview.ts
+++ b/server/src/api/analytics/getOverview.ts
@@ -34,7 +34,8 @@ const getQuery = ({
 }) => {
   const filterStatement = getFilterStatement(filters);
 
-  return `SELECT   
+  return `
+    SELECT
       session_stats.sessions,
       session_stats.pages_per_session,
       session_stats.bounce_rate * 100 AS bounce_rate,
@@ -61,13 +62,12 @@ const getQuery = ({
                 WHERE
                     site_id = {siteId:Int32}
                     ${filterStatement}
-                    ${getTimeStatement(
-                      pastMinutes
-                        ? { pastMinutes }
-                        : {
-                            date: { startDate, endDate, timezone },
-                          }
-                    )}
+                    ${getTimeStatement({
+                      startDate,
+                      endDate,
+                      timezone,
+                      minutes: pastMinutes,
+                    })}
                 GROUP BY session_id
             )
         ) AS session_stats
@@ -81,13 +81,12 @@ const getQuery = ({
             WHERE 
                 site_id = {siteId:Int32}
                 ${filterStatement}
-                ${getTimeStatement(
-                  pastMinutes
-                    ? { pastMinutes }
-                    : {
-                        date: { startDate, endDate, timezone },
-                      }
-                )}
+                ${getTimeStatement({
+                  startDate,
+                  endDate,
+                  timezone,
+                  minutes: pastMinutes,
+                })}
                 AND type = 'pageview'
         ) AS page_stats`;
 };

--- a/server/src/api/analytics/getOverviewBucketed.ts
+++ b/server/src/api/analytics/getOverviewBucketed.ts
@@ -101,7 +101,8 @@ const getQuery = ({
   site,
   filters,
   pastMinutes,
-  pastMinutesRange,
+  pastMinutesStart,
+  pastMinutesEnd,
 }: {
   startDate: string;
   endDate: string;
@@ -110,14 +111,20 @@ const getQuery = ({
   site: string;
   filters: string;
   pastMinutes?: number;
-  pastMinutesRange?: { start: number; end: number };
+  pastMinutesStart?: number;
+  pastMinutesEnd?: number;
 }) => {
   const filterStatement = getFilterStatement(filters);
 
   const isAllTime = !startDate && !endDate;
 
-  const timeParams = pastMinutesRange
-    ? { pastMinutesRange }
+  const timeParams = pastMinutesEnd
+    ? {
+        pastMinutesRange: {
+          start: Number(pastMinutesStart),
+          end: Number(pastMinutesEnd),
+        },
+      }
     : pastMinutes
     ? { pastMinutes }
     : { date: { startDate, endDate, timezone } };
@@ -224,12 +231,6 @@ export async function getOverviewBucketed(
     return res.status(403).send({ error: "Forbidden" });
   }
 
-  // Handle specific past minutes range if provided
-  const pastMinutesRange =
-    pastMinutesStart && pastMinutesEnd
-      ? { start: Number(pastMinutesStart), end: Number(pastMinutesEnd) }
-      : undefined;
-
   const query = getQuery({
     startDate,
     endDate,
@@ -237,8 +238,9 @@ export async function getOverviewBucketed(
     bucket,
     site,
     filters,
-    pastMinutes: pastMinutes ? Number(pastMinutes) : undefined,
-    pastMinutesRange,
+    pastMinutes,
+    pastMinutesStart,
+    pastMinutesEnd,
   });
 
   try {

--- a/server/src/api/analytics/getSession.ts
+++ b/server/src/api/analytics/getSession.ts
@@ -77,8 +77,11 @@ export async function getSession(
 
   // Add time filter if minutes is provided
   const timeFilter = minutes
-    ? `AND timestamp > now() - interval ${minutes} minute`
+    ? `timestamp > now() - interval ${minutes} minute`
     : "";
+
+  // Add the WHERE clause connector if timeFilter exists
+  const timeFilterWithConnector = timeFilter ? `AND ${timeFilter}` : "";
 
   try {
     // 1. First query: Get session data derived from events
@@ -108,7 +111,7 @@ FROM events
 WHERE 
     site_id = {siteId:Int32}
     AND session_id = {sessionId:String}
-    AND ${timeFilter}
+    ${timeFilterWithConnector}
 GROUP BY session_id
 LIMIT 1
     `;
@@ -121,7 +124,7 @@ FROM events
 WHERE
     site_id = {siteId:Int32}
     AND session_id = {sessionId:String}
-    AND ${timeFilter}
+    ${timeFilterWithConnector}
     `;
 
     // 3. Query to get paginated pageviews
@@ -140,7 +143,7 @@ FROM events
 WHERE
     site_id = {siteId:Int32}
     AND session_id = {sessionId:String}
-    AND ${timeFilter}
+    ${timeFilterWithConnector}
 ORDER BY timestamp ASC
 LIMIT {limit:Int32}
 OFFSET {offset:Int32}

--- a/server/src/api/analytics/getSession.ts
+++ b/server/src/api/analytics/getSession.ts
@@ -57,6 +57,7 @@ export interface GetSessionRequest {
   Querystring: {
     limit?: string;
     offset?: string;
+    minutes?: string;
   };
 }
 
@@ -67,11 +68,17 @@ export async function getSession(
   const { sessionId, site } = req.params;
   const limit = req.query.limit ? parseInt(req.query.limit) : 100;
   const offset = req.query.offset ? parseInt(req.query.offset) : 0;
+  const minutes = req.query.minutes ? parseInt(req.query.minutes) : undefined;
 
   const userHasAccessToSite = await getUserHasAccessToSitePublic(req, site);
   if (!userHasAccessToSite) {
     return res.status(403).send({ error: "Forbidden" });
   }
+
+  // Add time filter if minutes is provided
+  const timeFilter = minutes
+    ? `AND timestamp > now() - interval ${minutes} minute`
+    : "";
 
   try {
     // 1. First query: Get session data derived from events
@@ -101,6 +108,7 @@ FROM events
 WHERE 
     site_id = {siteId:Int32}
     AND session_id = {sessionId:String}
+    AND ${timeFilter}
 GROUP BY session_id
 LIMIT 1
     `;
@@ -113,6 +121,7 @@ FROM events
 WHERE
     site_id = {siteId:Int32}
     AND session_id = {sessionId:String}
+    AND ${timeFilter}
     `;
 
     // 3. Query to get paginated pageviews
@@ -131,6 +140,7 @@ FROM events
 WHERE
     site_id = {siteId:Int32}
     AND session_id = {sessionId:String}
+    AND ${timeFilter}
 ORDER BY timestamp ASC
 LIMIT {limit:Int32}
 OFFSET {offset:Int32}

--- a/server/src/api/analytics/getSessions.ts
+++ b/server/src/api/analytics/getSessions.ts
@@ -72,23 +72,14 @@ export async function getSessions(
   }
 
   const filterStatement = getFilterStatement(filters);
-
-  // Handle specific past minutes range if provided
-  const pastMinutesRange =
-    pastMinutesStart && pastMinutesEnd
-      ? { start: Number(pastMinutesStart), end: Number(pastMinutesEnd) }
-      : undefined;
-
-  // Set up time parameters
-  const timeParams = pastMinutesRange
-    ? { pastMinutesRange }
-    : minutes
-    ? { pastMinutes: Number(minutes) }
-    : startDate && endDate
-    ? { date: { startDate, endDate, timezone } }
-    : {};
-
-  const timeStatement = getTimeStatement(timeParams);
+  const timeStatement = getTimeStatement({
+    startDate,
+    endDate,
+    timezone,
+    minutes,
+    pastMinutesStart,
+    pastMinutesEnd,
+  });
 
   const query = `
   WITH AggregatedSessions AS (

--- a/server/src/api/analytics/getSingleCol.ts
+++ b/server/src/api/analytics/getSingleCol.ts
@@ -40,13 +40,12 @@ const getQuery = (request: FastifyRequest<GenericRequest>) => {
     request.query;
 
   const filterStatement = getFilterStatement(filters);
-  const timeStatement = getTimeStatement(
-    minutes
-      ? { pastMinutes: Number(minutes) }
-      : {
-          date: { startDate, endDate, timezone },
-        }
-  );
+  const timeStatement = getTimeStatement({
+    startDate,
+    endDate,
+    timezone,
+    minutes,
+  });
 
   // Validate and sanitize the limit parameter
   let validatedLimit: number | null = null;

--- a/server/src/api/analytics/getSingleCol.ts
+++ b/server/src/api/analytics/getSingleCol.ts
@@ -42,7 +42,7 @@ const getQuery = (request: FastifyRequest<GenericRequest>) => {
   const filterStatement = getFilterStatement(filters);
   const timeStatement = getTimeStatement(
     minutes
-      ? { pastMinutes: minutes }
+      ? { pastMinutes: Number(minutes) }
       : {
           date: { startDate, endDate, timezone },
         }

--- a/server/src/api/analytics/getUsers.ts
+++ b/server/src/api/analytics/getUsers.ts
@@ -81,24 +81,16 @@ export async function getUsers(
   const actualSortBy = validSortFields.includes(sortBy) ? sortBy : "last_seen";
   const actualSortOrder = sortOrder === "asc" ? "ASC" : "DESC";
 
-  // Handle specific past minutes range if provided
-  const pastMinutesRange =
-    pastMinutesStart && pastMinutesEnd
-      ? { start: Number(pastMinutesStart), end: Number(pastMinutesEnd) }
-      : undefined;
-
-  // Set up time parameters
-  const timeParams = pastMinutesRange
-    ? { pastMinutesRange }
-    : minutes
-    ? { pastMinutes: Number(minutes) }
-    : startDate && endDate
-    ? { date: { startDate, endDate, timezone } }
-    : {};
-
   // Generate filter statement and time statement
   const filterStatement = getFilterStatement(filters);
-  const timeStatement = getTimeStatement(timeParams);
+  const timeStatement = getTimeStatement({
+    startDate,
+    endDate,
+    timezone,
+    minutes,
+    pastMinutesStart,
+    pastMinutesEnd,
+  });
 
   const query = `
 WITH AggregatedUsers AS (

--- a/server/src/api/analytics/query-validation.ts
+++ b/server/src/api/analytics/query-validation.ts
@@ -92,7 +92,7 @@ const fillDateParamsSchema = z.object({
  */
 const timeStatementParamsSchema = z
   .object({
-    date: dateParamsSchema.optional(),
+    date: fillDateParamsSchema.optional(),
     pastMinutes: z.number().nonnegative().optional(),
     pastMinutesRange: z
       .object({
@@ -112,7 +112,13 @@ const timeStatementParamsSchema = z
     {
       message: "Either date, pastMinutes, or pastMinutesRange must be provided",
     }
-  );
+  )
+  // Set default empty objects if schema validation fails
+  .catch({
+    date: undefined,
+    pastMinutes: undefined,
+    pastMinutesRange: undefined,
+  });
 
 /**
  * Schema for parameters to getTimeStatementFill() function

--- a/server/src/api/analytics/query-validation.ts
+++ b/server/src/api/analytics/query-validation.ts
@@ -88,29 +88,59 @@ const fillDateParamsSchema = z.object({
 
 /**
  * Schema for parameters to getTimeStatement() function
- * Either date or pastMinutes must be provided
+ * Either date, pastMinutes, or pastMinutesRange must be provided
  */
 const timeStatementParamsSchema = z
   .object({
     date: dateParamsSchema.optional(),
     pastMinutes: z.number().nonnegative().optional(),
+    pastMinutesRange: z
+      .object({
+        start: z.number().nonnegative(),
+        end: z.number().nonnegative(),
+      })
+      .optional()
+      .refine((data) => !data || data.start > data.end, {
+        message: "start must be greater than end (start = older, end = newer)",
+      }),
   })
-  .refine((data) => data.date !== undefined || data.pastMinutes !== undefined, {
-    message: "Either date or pastMinutes must be provided",
-  });
+  .refine(
+    (data) =>
+      data.date !== undefined ||
+      data.pastMinutes !== undefined ||
+      data.pastMinutesRange !== undefined,
+    {
+      message: "Either date, pastMinutes, or pastMinutesRange must be provided",
+    }
+  );
 
 /**
  * Schema for parameters to getTimeStatementFill() function
- * Either date or pastMinutes must be provided
+ * Either date, pastMinutes, or pastMinutesRange must be provided
  */
 const timeStatementFillParamsSchema = z
   .object({
     date: fillDateParamsSchema.optional(),
     pastMinutes: z.number().nonnegative().optional(),
+    pastMinutesRange: z
+      .object({
+        start: z.number().nonnegative(),
+        end: z.number().nonnegative(),
+      })
+      .optional()
+      .refine((data) => !data || data.start > data.end, {
+        message: "start must be greater than end (start = older, end = newer)",
+      }),
   })
-  .refine((data) => data.date !== undefined || data.pastMinutes !== undefined, {
-    message: "Either date or pastMinutes must be provided",
-  });
+  .refine(
+    (data) =>
+      data.date !== undefined ||
+      data.pastMinutes !== undefined ||
+      data.pastMinutesRange !== undefined,
+    {
+      message: "Either date, pastMinutes, or pastMinutesRange must be provided",
+    }
+  );
 
 // =============================================================================
 // BUCKET RELATED SCHEMAS

--- a/server/src/api/analytics/utils.ts
+++ b/server/src/api/analytics/utils.ts
@@ -7,31 +7,62 @@ import {
 } from "./query-validation.js";
 import SqlString from "sqlstring";
 
-export function getTimeStatement({
-  date,
-  pastMinutes,
-  minutes,
-  pastMinutesRange,
-}: {
-  date?: {
-    startDate?: string;
-    endDate?: string;
-    timezone?: string;
-    table?: "events" | "sessions";
-  };
-  pastMinutes?: number;
-  minutes?: number; // Alternative name for pastMinutes for compatibility
-  pastMinutesRange?: { start: number; end: number };
-}) {
-  // For backward compatibility, support both minutes and pastMinutes
-  const actualPastMinutes = pastMinutes || minutes;
+export function getTimeStatement(
+  params:
+    | {
+        date?: {
+          startDate?: string;
+          endDate?: string;
+          timezone?: string;
+          table?: "events" | "sessions";
+        };
+        pastMinutes?: number;
+        pastMinutesRange?: { start: number; end: number };
+      }
+    | {
+        startDate?: string;
+        endDate?: string;
+        timezone?: string;
+        minutes?: string | number;
+        pastMinutesStart?: string | number;
+        pastMinutesEnd?: string | number;
+      }
+) {
+  // Handle if raw query parameters are passed
+  if ("pastMinutesStart" in params || "minutes" in params) {
+    // Extract and normalize raw parameters
+    const {
+      startDate,
+      endDate,
+      timezone,
+      minutes,
+      pastMinutesStart,
+      pastMinutesEnd,
+    } = params;
 
-  // Sanitize inputs with Zod
-  const sanitized = validateTimeStatementParams({
-    date,
-    pastMinutes: actualPastMinutes,
-    pastMinutesRange,
-  });
+    // Convert to the internal format
+    const pastMinutesRange =
+      pastMinutesStart && pastMinutesEnd
+        ? {
+            start: Number(pastMinutesStart),
+            end: Number(pastMinutesEnd),
+          }
+        : undefined;
+
+    const normalizedParams = pastMinutesRange
+      ? { pastMinutesRange }
+      : minutes
+      ? { pastMinutes: Number(minutes) }
+      : startDate && endDate
+      ? { date: { startDate, endDate, timezone } }
+      : {};
+
+    // Call self with normalized parameters
+    return getTimeStatement(normalizedParams);
+  }
+
+  // Original function implementation with sanitized parameters
+  const sanitized = validateTimeStatementParams(params);
 
   if (sanitized.date) {
     const { startDate, endDate, timezone } = sanitized.date;

--- a/server/src/api/analytics/utils.ts
+++ b/server/src/api/analytics/utils.ts
@@ -10,6 +10,7 @@ import SqlString from "sqlstring";
 export function getTimeStatement({
   date,
   pastMinutes,
+  minutes,
   pastMinutesRange,
 }: {
   date?: {
@@ -19,31 +20,33 @@ export function getTimeStatement({
     table?: "events" | "sessions";
   };
   pastMinutes?: number;
+  minutes?: number; // Alternative name for pastMinutes for compatibility
   pastMinutesRange?: { start: number; end: number };
 }) {
+  // For backward compatibility, support both minutes and pastMinutes
+  const actualPastMinutes = pastMinutes || minutes;
+
   // Sanitize inputs with Zod
   const sanitized = validateTimeStatementParams({
     date,
-    pastMinutes,
+    pastMinutes: actualPastMinutes,
     pastMinutesRange,
   });
 
   if (sanitized.date) {
-    const { startDate, endDate, timezone, table } = sanitized.date;
+    const { startDate, endDate, timezone } = sanitized.date;
     if (!startDate && !endDate) {
       return "";
     }
 
-    const col = (table ?? "events") === "events" ? "timestamp" : "session_end";
-
     // Use SqlString.escape for date and timezone values
-    return `AND ${col} >= toTimeZone(
+    return `AND timestamp >= toTimeZone(
       toStartOfDay(toDateTime(${SqlString.escape(
         startDate
       )}, ${SqlString.escape(timezone)})),
       'UTC'
       )
-      AND ${col} < if(
+      AND timestamp < if(
         toDate(${SqlString.escape(endDate)}) = toDate(now(), ${SqlString.escape(
       timezone
     )}),
@@ -74,6 +77,9 @@ export function getTimeStatement({
       sanitized.pastMinutes
     )} minute`;
   }
+
+  // If no valid time parameters were provided, return empty string
+  return "";
 }
 
 export async function processResults<T>(


### PR DESCRIPTION
- Added support for a new time mode "past-24-hours" across various components and APIs.
- Updated date selection, query parameters, and data fetching logic to accommodate this mode.
- Enhanced user interface elements to reflect the new time option and ensure consistent behavior in charts and data displays.
- Refactored relevant functions to handle minute-based data retrieval for the past 24 hours.