### PR TITLE
feat(client): Use version from `package.json` file

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   env: {
     NEXT_PUBLIC_BACKEND_URL: process.env.NEXT_PUBLIC_BACKEND_URL,
     NEXT_PUBLIC_DISABLE_SIGNUP: process.env.NEXT_PUBLIC_DISABLE_SIGNUP,
+    NEXT_PUBLIC_APP_VERSION: process.env.npm_package_version
   },
 };
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002 --turbopack",

--- a/client/src/app/components/Footer.tsx
+++ b/client/src/app/components/Footer.tsx
@@ -1,17 +1,16 @@
 import Link from "next/link";
 
-const VERSION = "v0.1.4";
-
 export function Footer() {
-  const gitSha = process.env.NEXT_PUBLIC_GIT_SHA;
+  const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION;
+
   return (
     <div className="flex justify-center items-center h-12 text-neutral-400 gap-4 text-xs">
       <p>© 2025 Rybbit</p>
       <Link
-        href={`https://github.com/rybbit-io/rybbit/releases/tag/${VERSION}`}
+        href={`https://github.com/rybbit-io/rybbit/releases/tag/v${APP_VERSION}`}
         className="hover:text-neutral-300"
       >
-        {VERSION}
+        v{APP_VERSION}
       </Link>
       <Link href="https://rybbit.io/docs" className="hover:text-neutral-300">
         Docs


### PR DESCRIPTION
I think having a sharded version is a bad thing, so we can start by just grabbing the latest version from the package.json file. I have some ideas how we can get rid of manual versioning completely, but so far this option looks much better.