### PR TITLE
Add helm chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: rybbit
+description: A Helm chart for Rybbit self-hosted analytics
+type: application
+version: 0.2.1
+appVersion: "1.0.0" 

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,218 @@
+# Rybbit Helm Chart
+
+This Helm chart deploys the Rybbit self-hosted analytics platform on Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+- PV provisioner support in the underlying infrastructure
+
+## Installation
+
+### Using OCI Registry
+
+The chart is available in our OCI registry. To install:
+
+```bash
+# Install the chart
+helm install rybbit oci://harbor.lag0.com.br/library/rybbit
+```
+
+Or install with custom values:
+
+```bash
+helm install rybbit oci://harbor.lag0.com.br/library/rybbit -f values.yaml
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Rybbit chart and their default values.
+
+### Backend Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `backend.image.repository` | Backend image repository | `ghcr.io/rybbit-io/rybbit-backend` |
+| `backend.image.tag` | Backend image tag | `latest` |
+| `backend.image.pullPolicy` | Backend image pull policy | `IfNotPresent` |
+| `backend.replicaCount` | Number of backend replicas | `1` |
+| `backend.resources` | Backend pod resource requests and limits | See values.yaml |
+| `backend.env` | Backend environment variables | See values.yaml |
+
+### Client Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `client.image.repository` | Client image repository | `ghcr.io/rybbit-io/rybbit-client` |
+| `client.image.tag` | Client image tag | `latest` |
+| `client.image.pullPolicy` | Client image pull policy | `IfNotPresent` |
+| `client.replicaCount` | Number of client replicas | `1` |
+| `client.resources` | Client pod resource requests and limits | See values.yaml |
+| `client.env` | Client environment variables | See values.yaml |
+
+### PostgreSQL Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `postgres.image.repository` | PostgreSQL image repository | `postgres` |
+| `postgres.image.tag` | PostgreSQL image tag | `17.4` |
+| `postgres.image.pullPolicy` | PostgreSQL image pull policy | `IfNotPresent` |
+| `postgres.replicaCount` | Number of PostgreSQL replicas | `1` |
+| `postgres.resources` | PostgreSQL pod resource requests and limits | See values.yaml |
+| `postgres.user` | PostgreSQL username | `frog` |
+| `postgres.password` | PostgreSQL password | Randomly generated |
+| `postgres.db` | PostgreSQL database name | `analytics` |
+| `postgres.persistence.enabled` | Enable PostgreSQL persistence | `true` |
+| `postgres.persistence.storageClass` | Storage class for PostgreSQL PVC | `""` |
+| `postgres.persistence.accessMode` | Access mode for PostgreSQL PVC | `ReadWriteOnce` |
+| `postgres.persistence.size` | Size of PostgreSQL PVC | `10Gi` |
+| `postgres.persistence.annotations` | Annotations for PostgreSQL PVC | `{}` |
+
+### ClickHouse Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `clickhouse.image.repository` | ClickHouse image repository | `clickhouse/clickhouse-server` |
+| `clickhouse.image.tag` | ClickHouse image tag | `25.4.2` |
+| `clickhouse.image.pullPolicy` | ClickHouse image pull policy | `IfNotPresent` |
+| `clickhouse.replicaCount` | Number of ClickHouse replicas | `1` |
+| `clickhouse.resources` | ClickHouse pod resource requests and limits | See values.yaml |
+| `clickhouse.user` | ClickHouse username | `default` |
+| `clickhouse.password` | ClickHouse password | Randomly generated |
+| `clickhouse.db` | ClickHouse database name | `analytics` |
+| `clickhouse.persistence.enabled` | Enable ClickHouse persistence | `true` |
+| `clickhouse.persistence.storageClass` | Storage class for ClickHouse PVC | `""` |
+| `clickhouse.persistence.accessMode` | Access mode for ClickHouse PVC | `ReadWriteOnce` |
+| `clickhouse.persistence.size` | Size of ClickHouse PVC | `20Gi` |
+| `clickhouse.persistence.annotations` | Annotations for ClickHouse PVC | `{}` |
+
+### Ingress Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `ingress.enabled` | Enable ingress | `false` |
+| `ingress.className` | Ingress class name | `""` |
+| `ingress.annotations` | Ingress annotations | `{}` |
+| `ingress.hosts` | Ingress hosts configuration | See values.yaml |
+| `ingress.tls` | Ingress TLS configuration | `[]` |
+
+## Security
+
+### Password Management
+
+The chart automatically generates random passwords for PostgreSQL and ClickHouse on first installation. These passwords are stored in a Kubernetes Secret and will be preserved across upgrades unless explicitly changed in values.yaml.
+
+To set custom passwords, add them to your values.yaml:
+
+```yaml
+postgres:
+  password: "your-custom-password"
+
+clickhouse:
+  password: "your-custom-password"
+```
+
+### Authentication Secret
+
+The backend uses a secret for authentication. This is automatically generated on first installation and preserved across upgrades. To set a custom secret:
+
+```yaml
+backend:
+  env:
+    BETTER_AUTH_SECRET: "your-custom-secret"
+```
+
+## Upgrading
+
+To upgrade the release:
+
+```bash
+helm upgrade rybbit oci://harbor.lag0.com.br/library/rybbit
+```
+
+Or upgrade with custom values:
+
+```bash
+helm upgrade rybbit oci://harbor.lag0.com.br/library/rybbit -f values.yaml
+```
+
+## Uninstalling
+
+To uninstall/delete the deployment:
+
+```bash
+helm uninstall rybbit
+```
+
+## Persistence
+
+The chart creates PersistentVolumeClaims for both PostgreSQL and ClickHouse data. You can configure the persistence settings for each database:
+
+```yaml
+postgres:
+  persistence:
+    enabled: true
+    storageClass: "standard"  # Use your preferred storage class
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    annotations:
+      custom-annotation: value
+
+clickhouse:
+  persistence:
+    enabled: true
+    storageClass: "standard"  # Use your preferred storage class
+    accessMode: ReadWriteOnce
+    size: 20Gi
+    annotations:
+      custom-annotation: value
+```
+
+Key persistence options:
+- `enabled`: Enable/disable persistence
+- `storageClass`: Specify the storage class to use (empty string means use default)
+- `accessMode`: Access mode for the PVC (ReadWriteOnce, ReadWriteMany, ReadOnlyMany)
+- `size`: Size of the persistent volume
+- `annotations`: Custom annotations for the PVC
+
+## Ingress
+
+The chart supports ingress configuration for exposing the application. To enable ingress:
+
+```yaml
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  hosts:
+    - host: your-domain.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: your-domain-tls
+      hosts:
+        - your-domain.com
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Database Connection Issues**
+   - Verify that the database passwords in the secret match your configuration
+   - Check that the database services are running and accessible
+
+2. **Ingress Issues**
+   - Ensure your ingress controller is properly configured
+   - Verify that the ingress annotations match your ingress controller requirements
+
+3. **Resource Issues**
+   - Check if pods are being scheduled (kubectl get pods)
+   - Verify resource requests and limits are appropriate for your cluster
+
+## Support
+
+For support, please open an issue in the [GitHub repository](https://github.com/rybbit-io/rybbit). 

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rybbit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rybbit.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rybbit.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "rybbit.labels" -}}
+helm.sh/chart: {{ include "rybbit.chart" . }}
+{{ include "rybbit.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "rybbit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rybbit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Generate random password
+*/}}
+{{- define "rybbit.randomPassword" -}}
+{{- $password := randAlphaNum 32 -}}
+{{- $password -}}
+{{- end -}}
+
+{{/*
+Generate random string
+*/}}
+{{- define "rybbit.randomString" -}}
+{{- $string := randAlphaNum 16 -}}
+{{- $string -}}
+{{- end -}} 

--- a/helm/templates/backend-deployment.yaml
+++ b/helm/templates/backend-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-backend
+  labels:
+    app: {{ .Release.Name }}-backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-backend
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-backend
+    spec:
+      containers:
+        - name: backend
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+          env:
+            - name: NODE_ENV
+              value: {{ .Values.backend.env.NODE_ENV | quote }}
+            - name: CLICKHOUSE_HOST
+              value: http://{{ .Release.Name }}-clickhouse:8123
+            - name: CLICKHOUSE_DB
+              value: {{ .Values.clickhouse.db | quote }}
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: clickhouse-password
+            - name: POSTGRES_HOST
+              value: {{ .Release.Name }}-postgres
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.db | quote }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: postgres-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: postgres-password
+            - name: BETTER_AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: better-auth-secret
+            - name: BASE_URL
+              value: {{ .Values.backend.env.BASE_URL | quote }}
+            - name: DISABLE_SIGNUP
+              value: {{ .Values.backend.env.DISABLE_SIGNUP | quote }} 

--- a/helm/templates/clickhouse-configmap.yaml
+++ b/helm/templates/clickhouse-configmap.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-clickhouse-config
+  labels:
+    app: {{ .Release.Name }}-clickhouse
+data:
+  user_logging.xml: |
+    <clickhouse>
+      <profiles>
+        <default>
+          <log_queries>0</log_queries>
+          <log_query_threads>0</log_query_threads>
+        </default>
+      </profiles>
+    </clickhouse>
+  enable_json.xml: |
+    <clickhouse>
+        <settings>
+            <enable_json_type>1</enable_json_type>
+        </settings>
+    </clickhouse>
+  logging_rules.xml: |
+    <clickhouse>
+      <logger>
+          <level>warning</level>
+          <console>true</console>
+      </logger>
+      <query_thread_log remove="remove"/>
+      <query_log remove="remove"/>
+      <text_log remove="remove"/>
+      <trace_log remove="remove"/>
+      <metric_log remove="remove"/>
+      <asynchronous_metric_log remove="remove"/>
+      <session_log remove="remove"/>
+      <part_log remove="remove"/>
+    </clickhouse>
+  network.xml: |
+    <clickhouse>
+        <listen_host>0.0.0.0</listen_host>
+    </clickhouse> 

--- a/helm/templates/clickhouse-deployment.yaml
+++ b/helm/templates/clickhouse-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-clickhouse
+  labels:
+    app: {{ .Release.Name }}-clickhouse
+spec:
+  replicas: {{ .Values.clickhouse.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-clickhouse
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-clickhouse
+    spec:
+      containers:
+        - name: clickhouse
+          image: "{{ .Values.clickhouse.image.repository }}:{{ .Values.clickhouse.image.tag }}"
+          imagePullPolicy: {{ .Values.clickhouse.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.clickhouse.resources | nindent 12 }}
+          env:
+            - name: CLICKHOUSE_DB
+              value: {{ .Values.clickhouse.db | quote }}
+            - name: CLICKHOUSE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: clickhouse-user
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: clickhouse-password
+          ports:
+            - containerPort: 8123
+            - containerPort: 9000
+          volumeMounts:
+            - name: clickhouse-data
+              mountPath: /var/lib/clickhouse
+            - name: clickhouse-config
+              mountPath: /etc/clickhouse-server/config.d
+      volumes:
+        - name: clickhouse-data
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-clickhouse-pvc
+        - name: clickhouse-config
+          configMap:
+            name: {{ .Release.Name }}-clickhouse-config 

--- a/helm/templates/clickhouse-pvc.yaml
+++ b/helm/templates/clickhouse-pvc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.clickhouse.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-clickhouse-pvc
+  {{- with .Values.clickhouse.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.clickhouse.persistence.accessMode | quote }}
+  {{- if .Values.clickhouse.persistence.storageClass }}
+  storageClassName: {{ .Values.clickhouse.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.clickhouse.persistence.size | quote }}
+{{- end }} 

--- a/helm/templates/clickhouse-service.yaml
+++ b/helm/templates/clickhouse-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-clickhouse
+  labels:
+    app: {{ .Release.Name }}-clickhouse
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8123
+      targetPort: 8123
+      protocol: TCP
+      name: http
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      name: native
+  selector:
+    app: {{ .Release.Name }}-clickhouse 

--- a/helm/templates/client-deployment.yaml
+++ b/helm/templates/client-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-client
+  labels:
+    app: {{ .Release.Name }}-client
+spec:
+  replicas: {{ .Values.client.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-client
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-client
+    spec:
+      containers:
+        - name: client
+          image: "{{ .Values.client.image.repository }}:{{ .Values.client.image.tag }}"
+          imagePullPolicy: {{ .Values.client.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.client.resources | nindent 12 }}
+          env:
+            {{- range $key, $value := .Values.client.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }} 

--- a/helm/templates/client-service.yaml
+++ b/helm/templates/client-service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-backend
+  labels:
+    app: {{ .Release.Name }}-backend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 3001
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ .Release.Name }}-backend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-client
+  labels:
+    app: {{ .Release.Name }}-client
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 3002
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ .Release.Name }}-client 

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "rybbit.fullname" . -}}
+{{- $backendSvcPort := "3001" -}}
+{{- $clientSvcPort := "3002" -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "rybbit.labels" . | nindent 4 }}
+  {{- if .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}-backend
+                port:
+                  number: {{ $backendSvcPort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}-client
+                port:
+                  number: {{ $clientSvcPort }}
+    {{- end }}
+{{- end }} 

--- a/helm/templates/postgres-deployment.yaml
+++ b/helm/templates/postgres-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-postgres
+  labels:
+    app: {{ .Release.Name }}-postgres
+spec:
+  replicas: {{ .Values.postgres.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-postgres
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: postgres-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: postgres-password
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.db | quote }}
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-postgres-pvc 

--- a/helm/templates/postgres-pvc.yaml
+++ b/helm/templates/postgres-pvc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgres.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-postgres-pvc
+  {{- with .Values.postgres.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.postgres.persistence.accessMode | quote }}
+  {{- if .Values.postgres.persistence.storageClass }}
+  storageClassName: {{ .Values.postgres.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.postgres.persistence.size | quote }}
+{{- end }} 

--- a/helm/templates/postgres-service.yaml
+++ b/helm/templates/postgres-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-postgres
+  labels:
+    app: {{ .Release.Name }}-postgres
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+      name: postgres
+  selector:
+    app: {{ .Release.Name }}-postgres 

--- a/helm/templates/secrets.yaml
+++ b/helm/templates/secrets.yaml
@@ -1,0 +1,14 @@
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-secrets" .Release.Name)) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets
+  labels:
+    app: {{ .Release.Name }}
+type: Opaque
+data:
+  postgres-password: {{ if and (not $existingSecret) (not .Values.postgres.password) }}{{ include "rybbit.randomPassword" . | b64enc | quote }}{{ else }}{{ .Values.postgres.password | default (index $existingSecret.data "postgres-password") | b64enc | quote }}{{ end }}
+  postgres-user: {{ .Values.postgres.user | default "frog" | b64enc | quote }}
+  clickhouse-password: {{ if and (not $existingSecret) (not .Values.clickhouse.password) }}{{ include "rybbit.randomPassword" . | b64enc | quote }}{{ else }}{{ .Values.clickhouse.password | default (index $existingSecret.data "clickhouse-password") | b64enc | quote }}{{ end }}
+  clickhouse-user: {{ .Values.clickhouse.user | default "default" | b64enc | quote }}
+  better-auth-secret: {{ if and (not $existingSecret) (not .Values.backend.env.BETTER_AUTH_SECRET) }}{{ include "rybbit.randomString" . | b64enc | quote }}{{ else }}{{ .Values.backend.env.BETTER_AUTH_SECRET | default (index $existingSecret.data "better-auth-secret") | b64enc | quote }}{{ end }} 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,107 @@
+# Default values for rybbit chart
+
+backend:
+  image:
+    repository: ghcr.io/rybbit-io/rybbit-backend
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 10m
+      memory: 128Mi
+  env:
+    NODE_ENV: production
+    CLICKHOUSE_HOST: http://clickhouse:8123
+    CLICKHOUSE_DB: analytics
+    CLICKHOUSE_PASSWORD: frog
+    POSTGRES_HOST: postgres
+    POSTGRES_PORT: 5432
+    POSTGRES_DB: analytics
+    POSTGRES_USER: frog
+    # POSTGRES_PASSWORD: frog
+    BETTER_AUTH_SECRET: ""
+    BASE_URL: ""
+    DISABLE_SIGNUP: ""
+
+client:
+  image:
+    repository: ghcr.io/rybbit-io/rybbit-client
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  env:
+    NODE_ENV: production
+    NEXT_PUBLIC_BACKEND_URL: ""
+
+postgres:
+  image:
+    repository: postgres
+    tag: 17.4
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  user: frog
+  # password: frog
+  db: analytics
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    annotations: {}
+
+clickhouse:
+  image:
+    repository: clickhouse/clickhouse-server
+    tag: 25.4.2
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: 500m
+      memory: 2Gi
+    requests:
+      cpu: 10m
+      memory: 128Mi
+  db: analytics
+  user: default
+  # password: frog
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 20Gi
+    annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: chart-example-tls
+      hosts:
+        - chart-example.local 


### PR DESCRIPTION
as described in #242, helm charts are the best way of deploying in Kubernetes, so this is a tested helm chart implementation users can use to deploy Rybbit easily in Kubernetes.

*I took the liberty of uploading this same chart to my personal harbor implementation oci://harbor.lag0.com.br/library/rybbit and inserted in the readme instructions, this can be easily replaced if needed.