### PR TITLE
fix: resolve styling issues on settings page for mobile devices

### DIFF
--- a/client/src/app/settings/layout.tsx
+++ b/client/src/app/settings/layout.tsx
@@ -27,7 +27,7 @@ export default function SettingsLayout({
 
   return (
     <StandardPage>
-      <div className=" grid grid-cols-[200px_1fr] gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-[200px_1fr] gap-6">
         <div className="flex flex-col gap-2">
           <Button
             variant={selectedTab === "account" ? "default" : "ghost"}

--- a/client/src/app/settings/organizations/components/AddMemberDialog.tsx
+++ b/client/src/app/settings/organizations/components/AddMemberDialog.tsx
@@ -77,7 +77,7 @@ export function AddMemberDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button size="sm" variant="outline" className="ml-2">
+        <Button size="sm" variant="outline">
           <UserPlus className="h-4 w-4 mr-1" />
           Add Member
         </Button>

--- a/client/src/app/settings/organizations/components/DeleteOrganizationDialog.tsx
+++ b/client/src/app/settings/organizations/components/DeleteOrganizationDialog.tsx
@@ -53,7 +53,7 @@ export function DeleteOrganizationDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button size="sm" variant="destructive" className="ml-2">
+        <Button size="sm" variant="destructive">
           <Trash className="h-4 w-4 mr-1" />
           Delete
         </Button>

--- a/client/src/app/settings/organizations/components/EditOrganizationDialog.tsx
+++ b/client/src/app/settings/organizations/components/EditOrganizationDialog.tsx
@@ -56,7 +56,7 @@ export function EditOrganizationDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button size="sm" variant="outline" className="ml-2">
+        <Button size="sm" variant="outline">
           <Edit className="h-4 w-4 mr-1" />
           Edit
         </Button>

--- a/client/src/app/settings/organizations/page.tsx
+++ b/client/src/app/settings/organizations/page.tsx
@@ -87,7 +87,7 @@ function Organization({ org }: { org: UserOrganization }) {
     <>
       <Card className="w-full">
         <CardHeader className="pb-2">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between flex-wrap gap-2">
             <CardTitle className="text-xl">
               {org.name}
               <span className="text-sm font-normal text-muted-foreground ml-2">
@@ -95,7 +95,7 @@ function Organization({ org }: { org: UserOrganization }) {
               </span>
             </CardTitle>
 
-            <div className="flex items-center">
+            <div className="flex items-center gap-2">
               {isOwner && (
                 <>
                   <AddMemberDialog


### PR DESCRIPTION
This PR fixes some style issues on the settings page for mobile devices. The specific effects are as follows:

| before                                                                                                                | after                                                                                                                 |
|-----------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| <img width="404" alt="image" src="https://github.com/user-attachments/assets/e109fd6e-8b37-47e5-8df4-dd7e06804312" /> | <img width="403" alt="image" src="https://github.com/user-attachments/assets/2c1724a4-d903-425c-b82b-961f7c12f517" /> |



