### PR TITLE
fix(cron): invalid cron syntax

### DIFF
--- a/server/src/cron/index.ts
+++ b/server/src/cron/index.ts
@@ -11,7 +11,7 @@ export async function initializeCronJobs() {
     cron.schedule("*/5 * * * *", updateUsersMonthlyUsage);
     updateUsersMonthlyUsage();
   }
-  cron.schedule("*/60 * * * * *", cleanupOldSessions);
+  cron.schedule("*/60 * * * *", cleanupOldSessions);
 
   console.log("Cron jobs initialized successfully");
 }


### PR DESCRIPTION
tested using the website crontab.guru ([Old Value](https://crontab.guru/#*/60_*_*_*_*_*) vs [New Value](https://crontab.guru/#*/60_*_*_*_*))

I tried to run the docker compose example and It failed:

```sh
rybbit_backend     | GeoIP database loaded successfully
rybbit_backend     | Starting server...
rybbit_backend     | Loaded 0 sites into site config cache
rybbit_backend     | Initializing cron jobs...
rybbit_backend     | 2025-05-17 00:58:33.707+0000 - info - Server listening at http://127.0.0.1:3001 
rybbit_backend     | 2025-05-17 00:58:33.707+0000 - info - Server listening at http://192.168.0.4:3001
rybbit_backend     | 2025-05-17 00:58:33.707+0000 - info - Server listening at http://172.19.0.14:3001
rybbit_backend     | /app/node_modules/node-cron/dist/esm/time/localized-time.js:52
rybbit_backend     |     const parts = dateFormat.formatToParts(date).filter(part => {
rybbit_backend     |                              ^
rybbit_backend     | 
rybbit_backend     | RangeError: Invalid time value
rybbit_backend     |     at DateTimeFormat.formatToParts (<anonymous>)
rybbit_backend     |     at buidDateParts (/app/node_modules/node-cron/dist/esm/time/localized-time.js:52:30)
rybbit_backend     |     at LocalizedTime.set (/app/node_modules/node-cron/dist/esm/time/localized-time.js:32:22)
rybbit_backend     |     at findNextDateIgnoringWeekday (/app/node_modules/node-cron/dist/esm/time/matcher-walker.js:41:18)
rybbit_backend     |     at MatcherWalker.matchNext (/app/node_modules/node-cron/dist/esm/time/matcher-walker.js:73:22)
rybbit_backend     |     at TimeMatcher.getNextMatch (/app/node_modules/node-cron/dist/esm/time/time-matcher.js:36:29)
rybbit_backend     |     at getDelay (/app/node_modules/node-cron/dist/esm/scheduler/runner.js:163:33)
rybbit_backend     |     at Runner.start (/app/node_modules/node-cron/dist/esm/scheduler/runner.js:110:12)
rybbit_backend     |     at InlineScheduledTask.start (/app/node_modules/node-cron/dist/esm/tasks/inline-scheduled-task.js:84:25)
rybbit_backend     |     at Module.schedule (/app/node_modules/node-cron/dist/esm/node-cron.js:24:10)
rybbit_backend     | 
rybbit_backend     | Node.js v20.19.1
```