### PR TITLE
fix: resolve black screen issue when switching to current site

### DIFF
--- a/client/src/app/[site]/components/Sidebar/SiteSelector.tsx
+++ b/client/src/app/[site]/components/Sidebar/SiteSelector.tsx
@@ -19,6 +19,15 @@ function SiteSelectorContent() {
   const router = useRouter();
   const currentSiteId = Number(pathname.split("/")[1]);
 
+  function handleChange(siteId: number) {
+    if (currentSiteId === siteId) {
+      window.location.reload();
+      return;
+    }
+    resetStore();
+    router.push(`/${siteId}`);
+  }
+
   return (
     <DropdownMenuContent align="start">
       {sites?.map((site) => {
@@ -26,10 +35,7 @@ function SiteSelectorContent() {
         return (
           <DropdownMenuItem
             key={site.siteId}
-            onClick={() => {
-              resetStore();
-              router.push(`/${site.siteId}`);
-            }}
+            onClick={() => handleChange(site.siteId)}
             className={cn("flex items-center justify-between", isSelected && "bg-neutral-800")}
           >
             <div className="flex items-center gap-2">


### PR DESCRIPTION
In the current version, it was discovered that when switching sites, if the current site is selected, it causes the page to go black and fail to display content. This PR fixes this error.

Note: I'm not certain if the current approach is optimal. I also tried using `⁠router.refresh()` when the current site is selected, but this causes the dropdown to display twice, which might be related to SSR hydration, but I'm not familiar with SSR. Therefore, I used `⁠window.location.reload()` instead. If maintainers have a better method, please suggest it.