### PR TITLE
Allow self-hosted instances to use Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,4 @@ POSTGRES_USER=frog
 POSTGRES_PASSWORD=frog
 
 RESEND_API_KEY=rs_XXXXXXX
+RESEND_FROM_EMAIL="Rybbit <onboarding@app.rybbit.io>"

--- a/server/src/lib/const.ts
+++ b/server/src/lib/const.ts
@@ -3,6 +3,8 @@ import dotenv from "dotenv";
 dotenv.config();
 
 export const IS_CLOUD = process.env.CLOUD === "true";
+export const RESEND_API_KEY = process.env.RESEND_API_KEY ?? false;
+export const RESEND_FROM_EMAIL = process.env.RESEND_FROM_EMAIL ?? "Rybbit <onboarding@app.rybbit.io>";
 export const DISABLE_SIGNUP = process.env.DISABLE_SIGNUP === "true";
 
 // Trial constants

--- a/server/src/lib/resend.ts
+++ b/server/src/lib/resend.ts
@@ -1,10 +1,10 @@
 import { Resend } from "resend";
-import { IS_CLOUD } from "./const.js";
+import { RESEND_API_KEY, RESEND_FROM_EMAIL } from "./const.js";
 
 let resend: Resend | undefined;
 
-if (IS_CLOUD) {
-  resend = new Resend(process.env.RESEND_API_KEY);
+if (RESEND_API_KEY !== false) {
+  resend = new Resend(RESEND_API_KEY);
 }
 
 export const sendEmail = async (
@@ -19,7 +19,7 @@ export const sendEmail = async (
   }
   try {
     const response = await resend.emails.send({
-      from: "Rybbit <onboarding@app.rybbit.io>",
+      from: RESEND_FROM_EMAIL,
       to: email,
       subject,
       html,


### PR DESCRIPTION
Enables Resend if API key is set and allows the user to change the from-email address.

Also adds RESEND_FROM_EMAIL to the .env.exampel file.


Addresses #240 and #247 