### PR TITLE
fix(healthcheck): v1.0.0 now requires /api prefix in base path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       postgres:
         condition: service_started
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3001/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3001/api/health"]
       interval: 3s
       timeout: 5s
       retries: 5

--- a/docs/src/content/self-hosting-advanced.mdx
+++ b/docs/src/content/self-hosting-advanced.mdx
@@ -152,7 +152,7 @@ services:
       rybbit_postgres:
         condition: service_started
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3001/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3001/api/health"]
       interval: 3s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Change `/health` to `/api/health` in docker compose and self host advanced guide to match v1.0.0.

Release notes:
- https://github.com/rybbit-io/rybbit/releases/tag/v1.0.0

Migration guide:
- https://www.rybbit.io/docs/v1-migration