### PR TITLE
feat(server): allow dynamic origins using regexp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Domain and URL Configuration
 DOMAIN_NAME=demo.rybbit.io
 BASE_URL="https://${DOMAIN_NAME}"
+# Additional origin patterns (RegExp) to allow e.g. extensions: ^(chrome|moz)-extension:\/\/[a-z]{32}$
+ALLOWED_ORIGIN_PATTERNS=
 
 # Authentication and Security
 BETTER_AUTH_SECRET=insecure-secret

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -79,6 +79,7 @@ services:
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
       - BASE_URL=${BASE_URL}
       - DISABLE_SIGNUP=${DISABLE_SIGNUP}
+      - ALLOWED_ORIGIN_PATTERNS=${ALLOWED_ORIGIN_PATTERNS:-}
       # below is only for rybbit cloud
       - CLOUD=${CLOUD}
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -79,6 +79,7 @@ services:
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
       - BASE_URL=${BASE_URL}
       - DISABLE_SIGNUP=${DISABLE_SIGNUP}
+      - ALLOWED_ORIGIN_PATTERNS=${ALLOWED_ORIGIN_PATTERNS:-}
       # below is only for rybbit cloud
       - CLOUD=${CLOUD}
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,7 @@ services:
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
       - BASE_URL=${BASE_URL}
       - DISABLE_SIGNUP=${DISABLE_SIGNUP}
+      - ALLOWED_ORIGIN_PATTERNS=${ALLOWED_ORIGIN_PATTERNS:-}
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -56,7 +56,7 @@ import { getUserOrganizations } from "./api/user/getUserOrganizations.js";
 import { listOrganizationMembers } from "./api/user/listOrganizationMembers.js";
 import { initializeCronJobs } from "./cron/index.js";
 import { initializeClickhouse } from "./db/clickhouse/clickhouse.js";
-import { allowList, loadAllowedDomains } from "./lib/allowedDomains.js";
+import { loadAllowedDomains, isOriginAllowed } from "./lib/allowedDomains.js";
 import { getSessionFromReq, mapHeaders } from "./lib/auth-utils.js";
 import { auth } from "./lib/auth.js";
 import { IS_CLOUD } from "./lib/const.js";
@@ -79,7 +79,7 @@ const server = Fastify({
 
 server.register(cors, {
   origin: (origin, callback) => {
-    if (!origin || allowList.includes(normalizeOrigin(origin))) {
+    if (!origin || isOriginAllowed(origin)) {
       callback(null, true);
     } else {
       callback(new Error("Not allowed by CORS"), false);

--- a/server/src/lib/allowedDomains.ts
+++ b/server/src/lib/allowedDomains.ts
@@ -34,17 +34,20 @@ export const loadAllowedDomains = async () => {
       ...domains.map(({ domain }) => normalizeOrigin(domain)),
     ];
 
-    // Load regex patterns from ALLOWED_ORIGINS environment variable
-    if (process.env.ALLOWED_ORIGINS) {
+    // Load regex patterns from ALLOWED_ORIGIN_PATTERNS environment variable
+    if (process.env.ALLOWED_ORIGIN_PATTERNS) {
       try {
-        const regexPatterns = process.env.ALLOWED_ORIGINS.split(",").map(
-          pattern => pattern.trim()
-        );
+        const regexPatterns = process.env.ALLOWED_ORIGIN_PATTERNS.split(
+          ","
+        ).map((pattern) => pattern.trim());
         allowedOriginRegexes = regexPatterns.map(
-          pattern => new RegExp(pattern)
+          (pattern) => new RegExp(pattern)
         );
       } catch (error) {
-        console.error("Error parsing ALLOWED_ORIGINS regex patterns:", error);
+        console.error(
+          "Error parsing ALLOWED_ORIGIN_PATTERNS regex patterns:",
+          error
+        );
         allowedOriginRegexes = [];
       }
     }

--- a/server/src/lib/allowedDomains.ts
+++ b/server/src/lib/allowedDomains.ts
@@ -7,6 +7,7 @@ import dotenv from "dotenv";
 dotenv.config();
 
 export let allowList: string[] = [];
+export let allowedOriginRegexes: RegExp[] = [];
 
 export const loadAllowedDomains = async () => {
   try {
@@ -32,10 +33,40 @@ export const loadAllowedDomains = async () => {
       normalizeOrigin(process.env.BASE_URL || ""),
       ...domains.map(({ domain }) => normalizeOrigin(domain)),
     ];
+
+    // Load regex patterns from ALLOWED_ORIGINS environment variable
+    if (process.env.ALLOWED_ORIGINS) {
+      try {
+        const regexPatterns = process.env.ALLOWED_ORIGINS.split(",").map(
+          pattern => pattern.trim()
+        );
+        allowedOriginRegexes = regexPatterns.map(
+          pattern => new RegExp(pattern)
+        );
+      } catch (error) {
+        console.error("Error parsing ALLOWED_ORIGINS regex patterns:", error);
+        allowedOriginRegexes = [];
+      }
+    }
   } catch (error) {
     console.error("Error loading allowed domains:", error);
     // Set default values in case of error
     allowList = ["localhost", normalizeOrigin(process.env.BASE_URL || "")];
+    allowedOriginRegexes = [];
     initAuth(allowList);
   }
+};
+
+export const isOriginAllowed = (origin: string): boolean => {
+  const normalizedOrigin = normalizeOrigin(origin);
+
+  // Check against the regular allow list
+  if (allowList.includes(normalizedOrigin)) {
+    return true;
+  }
+
+  // Check against regex patterns
+  const regexMatch = allowedOriginRegexes.some((regex) => regex.test(origin));
+
+  return regexMatch;
 };

--- a/server/src/tracker/trackEvent.ts
+++ b/server/src/tracker/trackEvent.ts
@@ -6,7 +6,7 @@ import {
   createBasePayload,
   getExistingSession,
   isSiteOverLimit,
-  TotalTrackingPayload,
+  TotalTrackingPayload
 } from "./trackingUtils.js";
 import { db } from "../db/postgres/postgres.js";
 import { activeSessions } from "../db/postgres/schema.js";
@@ -15,6 +15,7 @@ import { getDeviceType } from "../utils.js";
 import { pageviewQueue } from "./pageviewQueue.js";
 import { siteConfig } from "../lib/siteConfig.js";
 import { DISABLE_ORIGIN_CHECK } from "./const.js";
+import { isOriginAllowed } from "../lib/allowedDomains.js";
 
 // Define Zod schema for validation
 export const trackingPayloadSchema = z.discriminatedUnion("type", [
@@ -199,6 +200,11 @@ async function validateOrigin(siteId: string, requestOrigin?: string) {
         success: false,
         error: "Origin header required",
       };
+    }
+
+    // Check if the origin is allowed by regex patterns (e.g., browser extensions)
+    if (isOriginAllowed(requestOrigin)) {
+      return { success: true };
     }
 
     try {


### PR DESCRIPTION
This Pull request adds support for dynamic origins which allows rybbit to be used from browser extensions as they do not run on a fixed origin.