### PR TITLE
Fix `update.sh` "Please commit your changes or stash them before you merge.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -5,6 +5,10 @@ set -e
 
 echo "Updating to the latest version..."
 
+# Stash any local changes
+echo "Stashing local changes, if any..."
+git stash
+
 # Pull latest changes from git repository
 echo "Pulling latest code..."
 git pull


### PR DESCRIPTION
As of this morning, running `update.sh` will throw:
```
Updating c47a077a..18045289
error: Your local changes to the following files would be overwritten by merge:
        setup.sh
Please commit your changes or stash them before you merge.
Aborting
```

This fixes the issue by calling `git stash` automatically before pulling.