### PR TITLE
feat: display performance and pages sections on self-hosted instance sidebar

### DIFF
--- a/client/src/app/[site]/components/Sidebar/Sidebar.tsx
+++ b/client/src/app/[site]/components/Sidebar/Sidebar.tsx
@@ -72,22 +72,18 @@ export function Sidebar() {
             href={getTabPath("map")}
             icon={<Map className="w-4 h-4" />}
           />
-          {IS_CLOUD && (
-            <SidebarLink
+          <SidebarLink
               label="Pages"
               active={isActiveTab("pages")}
               href={getTabPath("pages")}
               icon={<File className="w-4 h-4" />}
-            />
-          )}
-          {IS_CLOUD && (
-            <SidebarLink
+          />
+          <SidebarLink
               label="Performance"
               active={isActiveTab("performance")}
               href={getTabPath("performance")}
               icon={<Gauge className="w-4 h-4" />}
-            />
-          )}
+          />
           <SidebarLink
             label="Goals"
             active={isActiveTab("goals")}


### PR DESCRIPTION
The Performance and Pages sections are fully available on self-hosted instances. It's unclear why their access points are hidden.