### PR TITLE
Use the total event count to calculate the percentage of each event type

### DIFF
--- a/client/src/app/[site]/events/components/EventList.tsx
+++ b/client/src/app/[site]/events/components/EventList.tsx
@@ -133,13 +133,13 @@ export function EventList({
     );
   }
 
-  // Find the highest count to calculate percentages
-  const maxCount = Math.max(...events.map((event) => event.count));
+  // Find the total count to calculate percentages
+  const totalCount = events.reduce((sum, event) => sum + event.count, 0);
 
   return (
     <div className="flex flex-col gap-2">
       {events.map((event) => {
-        const percentage = (event.count / maxCount) * 100;
+        const percentage = (event.count / totalCount) * 100;
         const isExpanded = expandedEvent === event.eventName;
 
         return (


### PR DESCRIPTION
When calculating the custom events percentage, it is currently using the max event.count, which is not correct. This shows the event with the most events as 100% and calculates other events incorrectly as well.

<img width="661" height="173" alt="image" src="https://github.com/user-attachments/assets/a8f8d746-efbf-4834-89f3-cb0da3fa98af" />

This is updating the calculation to use the sum of the counts for the percentage calculation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event percentage calculations to use the total count of all events, providing a more accurate representation of each event's proportion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->