### PR TITLE
Custom Event Fixes & Tweaks

### DIFF
--- a/client/src/app/[site]/events/components/EventLogItem.tsx
+++ b/client/src/app/[site]/events/components/EventLogItem.tsx
@@ -181,10 +181,21 @@ export function EventLogItem({ event }: EventLogItemProps) {
               <Badge
                 key={key}
                 variant="outline"
-                className="px-1.5 py-0 h-5 text-xs bg-neutral-800 text-neutral-100 font-medium"
+                className="px-1.5 py-0 h-5 text-xs bg-neutral-800 text-neutral-100 font-medium truncate max-w-[90%]"
               >
                 <span className="text-neutral-300 font-light mr-1">{key}:</span>{" "}
-                {String(value)}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="truncate">
+                      {(typeof value === 'object') ? JSON.stringify(value) : String(value)}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <span className="max-w-7xl">
+                      {(typeof value === 'object') ? JSON.stringify(value) : String(value)}
+                    </span>
+                  </TooltipContent>
+                </Tooltip>
               </Badge>
             ))}
           </div>

--- a/client/src/app/[site]/events/components/EventProperties.tsx
+++ b/client/src/app/[site]/events/components/EventProperties.tsx
@@ -63,9 +63,6 @@ export function EventProperties({
     return sumB - sumA;
   });
 
-  // Find the highest count to calculate percentages for values
-  const maxCount = Math.max(...properties.map((prop) => prop.count));
-
   return (
     <div
       className={cn(
@@ -93,7 +90,9 @@ export function EventProperties({
             {/* Property Values */}
             <div className="pl-4 flex flex-col gap-2">
               {values.map((property) => {
-                const percentage = (property.count / maxCount) * 100;
+                const totalCount = properties.filter(event => event.propertyKey === property.propertyKey)
+                  .reduce((sum, event) => sum + event.count, 0);
+                const percentage = (property.count / totalCount) * 100;
 
                 return (
                   <div

--- a/client/src/app/[site]/events/components/EventProperties.tsx
+++ b/client/src/app/[site]/events/components/EventProperties.tsx
@@ -4,7 +4,9 @@ import NumberFlow from "@number-flow/react";
 import { Info } from "lucide-react";
 import { memo } from "react";
 import { EventProperty } from "../../../../api/analytics/events/useGetEventProperties";
-import { cn } from "../../../../lib/utils";
+import { cn, getCountryName } from "../../../../lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { CountryFlag } from "@/app/[site]/components/shared/icons/CountryFlag";
 
 interface EventPropertiesProps {
   properties: EventProperty[];
@@ -108,7 +110,18 @@ export function EventProperties({
                     ></div>
                     <div className="z-10 flex justify-between items-center w-full">
                       <div className="truncate max-w-[70%]">
-                        {property.propertyValue}
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="flex items-center">
+                              {property.propertyValue}
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p className="max-w-7xl">
+                              {property.propertyValue}
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
                       </div>
                       <div className="flex gap-2">
                         <div className="hidden group-hover:block text-neutral-400">

--- a/client/src/app/[site]/events/components/EventProperties.tsx
+++ b/client/src/app/[site]/events/components/EventProperties.tsx
@@ -4,9 +4,8 @@ import NumberFlow from "@number-flow/react";
 import { Info } from "lucide-react";
 import { memo } from "react";
 import { EventProperty } from "../../../../api/analytics/events/useGetEventProperties";
-import { cn, getCountryName } from "../../../../lib/utils";
+import { cn } from "../../../../lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { CountryFlag } from "@/app/[site]/components/shared/icons/CountryFlag";
 
 interface EventPropertiesProps {
   properties: EventProperty[];


### PR DESCRIPTION
This includes:

- Fix percentage calculation for custom event properties
- Add tooltip on custom event properties with the full value so it can be seen if its been truncated
- Fix object type custom event properties from being displayed as `[object Object]` on the Event Log
- Add truncate and tooltip to custom event properties in the Event Log so it can be seen if its been truncated