### PR TITLE
Handle errors in the session timeline. These were previously treated …

### DIFF
--- a/client/src/api/analytics/userSessions.ts
+++ b/client/src/api/analytics/userSessions.ts
@@ -36,6 +36,7 @@ export type GetSessionsResponse = {
   exit_page: string;
   pageviews: number;
   events: number;
+  errors: number;
 }[];
 
 export function useGetSessionsInfinite(userId?: string) {
@@ -121,7 +122,7 @@ export interface SessionEvent {
   referrer: string;
   type: string;
   event_name?: string;
-  props?: string;
+  props?: any;
 }
 
 export interface SessionPageviewsAndEvents {

--- a/client/src/components/Sessions/SessionCard.tsx
+++ b/client/src/components/Sessions/SessionCard.tsx
@@ -10,6 +10,7 @@ import {
   ChevronRight,
   FileText,
   MousePointerClick,
+  TriangleAlert,
 } from "lucide-react";
 import { DateTime } from "luxon";
 import { memo, useState } from "react";
@@ -115,6 +116,18 @@ export function SessionCard({ session, onClick, userId }: SessionCardProps) {
                 </Badge>
               </TooltipTrigger>
               <TooltipContent>Events</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Badge
+                  variant="outline"
+                  className="flex items-center gap-1 bg-neutral-800 text-gray-300"
+                >
+                  <TriangleAlert className="w-4 h-4 text-red-500" />
+                  <span>{formatter(session.errors)}</span>
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>Errors</TooltipContent>
             </Tooltip>
           </div>
 

--- a/server/src/api/analytics/getSessions.ts
+++ b/server/src/api/analytics/getSessions.ts
@@ -92,7 +92,8 @@ export async function getSessions(
           argMinIf(pathname, timestamp, type = 'pageview') AS entry_page,
           argMaxIf(pathname, timestamp, type = 'pageview') AS exit_page,
           countIf(type = 'pageview') AS pageviews,
-          countIf(type = 'custom_event') AS events
+          countIf(type = 'custom_event') AS events,
+          countIf(type = 'error') AS errors
       FROM events
       WHERE
           site_id = {siteId:Int32}


### PR DESCRIPTION
…as a custom event.

They looked like this before:
<img width="1578" height="574" alt="image" src="https://github.com/user-attachments/assets/afb0cd38-2503-4a86-8403-1febada4d15e" />

They now look like:
<img width="1589" height="708" alt="image" src="https://github.com/user-attachments/assets/69ba83bc-ad26-4a57-b1fe-6d81351800ff" />

