### PR TITLE
Modify setup.sh script to include`--insecure` and `--force` flags

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -52,7 +52,7 @@ while [[ "$#" -gt 0 ]]; do
     --no-webserver) 
       USE_WEBSERVER="false"
       shift
-      ;;1
+      ;;
     --insecure) 
       GENERATE_PASSWORDS="false"
       shift


### PR DESCRIPTION
## Improve security of setup by adapting `setup.sh` script

Since the setup script is advised to be used in production, we will have to use production-ready passwords. Everything else is bad practice, even if the database is not exposed to the public. 

This PR adds two new flags: `--force` and `--insecure`.

- The `--force` flag will allow overriding the `.env` if setup.sh is executed again. This will prevent overriding the .env file

- The `--insecure` flag will use the old behavior (password: `frog`). If this flag is omitted, the 

I made sure to refactor the existing script before, by creating a method `generate_secret()` which is used to generate the secret `BETTER_AUTH_SECRET` (length: 32) and the passwords for Postgres and Clickhouse (length: 16, which is a sufficient password complexity nowadays).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--insecure` option to skip automatic password generation.
  * Added `--force` option to allow overwriting an existing environment file.

* **Improvements**
  * Enhanced password generation for improved security and flexibility.
  * Added warnings and safeguards when overwriting existing environment files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->