### PR TITLE
Remove redis logs

### DIFF
--- a/docs-v2/content/docs/guides/angular.mdx
+++ b/docs-v2/content/docs/guides/angular.mdx
@@ -91,7 +91,7 @@ After building and deploying your application, open your Rybbit dashboard to che
   //   filter(event => event instanceof NavigationEnd)
   // ).subscribe(() => {{
   //   if (window.rybbit) {{
-  //     window.rybbit.trackPageview();
+  //     window.rybbit.pageview();
   //   }}
   // }});
   ```
@@ -110,8 +110,8 @@ import { Component } from '@angular/core';
 declare global {
   interface Window {
     rybbit?: {
-      trackEvent: (eventName: string, eventData?: Record<string, any>) => void;
-      trackPageview: () => void;
+      event: (eventName: string, eventData?: Record<string, any>) => void;
+      pageview: () => void;
       // Add other methods if you use them
     };
   }

--- a/docs-v2/content/docs/guides/astro.mdx
+++ b/docs-v2/content/docs/guides/astro.mdx
@@ -94,7 +94,7 @@ After building and deploying your Astro site, open your Rybbit dashboard to chec
     // In a client-side script, perhaps in your common layout or a global script file
     document.addEventListener('astro:after-swap', () => {
       if (window.rybbit) {
-        window.rybbit.trackPageview();
+        window.rybbit.pageview();
       }
     });
     ```

--- a/docs-v2/content/docs/guides/bubble.mdx
+++ b/docs-v2/content/docs/guides/bubble.mdx
@@ -64,7 +64,7 @@ Open your live Bubble application and navigate through a few pages. Then, check 
   **Page View Tracking in Bubble Apps**: Bubble applications often behave like Single Page Applications (SPAs) for navigation between "pages" (which are often groups shown/hidden on a single actual HTML page). Rybbit's script is designed to detect URL changes in SPAs.
   - If your Bubble app uses actual URL route changes for different views, Rybbit should track these automatically.
   - If navigation primarily involves showing/hiding groups without URL changes, Rybbit will only track the initial page load. For more granular tracking of "virtual" page views in such cases, you would need to use custom event tracking.
-  - If URL changes occur but are not automatically tracked, you might need to trigger `window.rybbit.trackPageview()` manually using a Bubble workflow action that runs JavaScript when a "page" (group) becomes visible.
+  - If URL changes occur but are not automatically tracked, you might need to trigger `window.rybbit.pageview()` manually using a Bubble workflow action that runs JavaScript when a "page" (group) becomes visible.
 </Callout>
 
 ## Custom Event Tracking in Bubble

--- a/docs-v2/content/docs/guides/docusaurus.mdx
+++ b/docs-v2/content/docs/guides/docusaurus.mdx
@@ -86,7 +86,7 @@ After rebuilding and deploying your Docusaurus site (e.g., `npm run build` and `
 
 <Callout type="info">
   **Page View Tracking**: Docusaurus builds a Single Page Application (SPA). Rybbit's tracking script is designed to automatically detect route changes in SPAs and track them as page views. If you find that page views are not being tracked correctly after client-side navigation (which is uncommon), you might need to manually trigger page views. Docusaurus uses React Router internally. You could potentially use a client module or swizzle a component to tap into navigation events if manual tracking is absolutely necessary, but **test the default behavior first**.
-  If manual tracking is required, you would call `window.rybbit.trackPageview()` after a route change.
+  If manual tracking is required, you would call `window.rybbit.pageview()` after a route change.
 </Callout>
 
 ## Custom Event Tracking
@@ -132,7 +132,7 @@ export function onRouteUpdate({location, previousLocation}) {
 
   if (typeof window !== 'undefined' && window.rybbit && location.pathname !== previousLocation?.pathname) {
     // Rybbit should auto-track pageviews, but if needed:
-    // window.rybbit.trackPageview();
+    // window.rybbit.pageview();
   }
 
   // Example: Add event listeners for specific elements

--- a/docs-v2/content/docs/guides/framer.mdx
+++ b/docs-v2/content/docs/guides/framer.mdx
@@ -38,7 +38,7 @@ Navigate to your Rybbit dashboard to obtain your code snippet.
 </Steps>
 
 <Callout type="info">
-  **Page View Tracking in Framer**: Framer sites often behave like Single Page Applications (SPAs). Rybbit's tracking script is designed to automatically detect URL changes and track them as page views. If you use Framer's navigation features (like links between pages or components that change the URL), Rybbit should capture these. If you notice page views are not tracked correctly after navigation, you might need to manually trigger `window.rybbit.trackPageview()` using a Framer code override or code component when a "virtual" page change occurs. Test the default behavior first.
+  **Page View Tracking in Framer**: Framer sites often behave like Single Page Applications (SPAs). Rybbit's tracking script is designed to automatically detect URL changes and track them as page views. If you use Framer's navigation features (like links between pages or components that change the URL), Rybbit should capture these. If you notice page views are not tracked correctly after navigation, you might need to manually trigger `window.rybbit.pageview()` using a Framer code override or code component when a "virtual" page change occurs. Test the default behavior first.
 </Callout>
 
 ## Custom Event Tracking in Framer

--- a/docs-v2/content/docs/guides/react/gatsby.mdx
+++ b/docs-v2/content/docs/guides/react/gatsby.mdx
@@ -81,7 +81,7 @@ The `onRenderBody` method is generally simpler for a basic async script like Ryb
   export const onRouteUpdate = ({ location, prevLocation }) => {
     if (typeof window !== 'undefined' && window.rybbit && location.pathname !== prevLocation?.pathname) {
       // Rybbit should auto-track, but if needed:
-      // window.rybbit.trackPageview();
+      // window.rybbit.pageview();
       console.log("Rybbit: Route updated to", location.pathname); // For debugging
     }
   };

--- a/docs-v2/content/docs/guides/react/next-js.mdx
+++ b/docs-v2/content/docs/guides/react/next-js.mdx
@@ -122,7 +122,7 @@ Note that this rewrite will consume the bandwidth of your server, as all trackin
 
 
 <Callout type="info">
-  **Page View Tracking in Next.js**: Rybbit's tracking script is designed to automatically detect route changes when using Next.js's `&lt;Link&gt;` component or `router.push()` and track them as page views. If you encounter a rare scenario where page views are not being tracked correctly after client-side navigation, you might need to manually trigger page views using `window.rybbit.trackPageview()`. However, test the default behavior first, as manual tracking is typically not necessary.
+  **Page View Tracking in Next.js**: Rybbit's tracking script is designed to automatically detect route changes when using Next.js's `&lt;Link&gt;` component or `router.push()` and track them as page views. If you encounter a rare scenario where page views are not being tracked correctly after client-side navigation, you might need to manually trigger page views using `window.rybbit.pageview()`. However, test the default behavior first, as manual tracking is typically not necessary.
 </Callout>
 
 ## Custom Event Tracking
@@ -138,8 +138,8 @@ Once the Rybbit script is loaded via the Next.js `Script` component, you can tra
 // declare global {
 //   interface Window {
 //     rybbit?: {
-//       trackEvent: (eventName: string, eventData?: Record<string, any>) => void;
-//       trackPageview: () => void;
+//       event: (eventName: string, eventData?: Record<string, any>) => void;
+//       pageview: () => void;
 //       // Add other methods if you use them
 //     };
 //   }

--- a/docs-v2/content/docs/guides/react/remix.mdx
+++ b/docs-v2/content/docs/guides/react/remix.mdx
@@ -78,7 +78,7 @@ After restarting your Remix development server or deploying your application, op
   **SPA Page View Tracking**: Rybbit's tracking script is designed to automatically detect route changes in most modern SPAs. Remix handles client-side navigation after the initial server render. If you find that page views are not being tracked correctly after client-side navigations (which can sometimes happen depending on the specifics of the script's SPA detection), you might need to manually trigger page views.
 
   One way to do this in Remix is to leverage a component that re-renders on navigation, or potentially by creating a custom `useLocationChange` hook if more granular control is needed, though this is often more complex. A simpler approach if manual tracking is needed might involve a root-level effect that listens to location changes. However, **test the default behavior first**, as manual tracking might not be necessary.
-  If manual tracking is required, you would call `window.rybbit.trackPageview()` after a route change.
+  If manual tracking is required, you would call `window.rybbit.pageview()` after a route change.
 </Callout>
 
 ## Custom Event Tracking

--- a/docs-v2/content/docs/guides/react/vite-cra.mdx
+++ b/docs-v2/content/docs/guides/react/vite-cra.mdx
@@ -72,7 +72,7 @@ After deploying your application, open your Rybbit dashboard to see if data is b
 </Steps>
 
 <Callout type="info">
-  **SPA Page View Tracking**: Rybbit's tracking script is designed to automatically detect route changes in most modern SPAs (including those using React Router or similar libraries) and track them as page views. If you find that page views are not being tracked correctly after navigation, you might need to manually trigger page views using `window.rybbit.trackPageview()` after each route change. However, try the standard installation first.
+  **SPA Page View Tracking**: Rybbit's tracking script is designed to automatically detect route changes in most modern SPAs (including those using React Router or similar libraries) and track them as page views. If you find that page views are not being tracked correctly after navigation, you might need to manually trigger page views using `window.rybbit.pageview()` after each route change. However, try the standard installation first.
 </Callout>
 
 ## Custom Event Tracking

--- a/docs-v2/content/docs/guides/svelte/sveltekit.mdx
+++ b/docs-v2/content/docs/guides/svelte/sveltekit.mdx
@@ -74,7 +74,7 @@ Deploy your application and check your Rybbit dashboard for incoming data.
 
   afterNavigate(() => {
     if (typeof window !== 'undefined' && window.rybbit) {
-      window.rybbit.trackPageview();
+      window.rybbit.pageview();
     }
   });
   ```

--- a/docs-v2/content/docs/guides/svelte/vite.mdx
+++ b/docs-v2/content/docs/guides/svelte/vite.mdx
@@ -67,7 +67,7 @@ Deploy your application and check your Rybbit dashboard for incoming data. You c
 </Steps>
 
 <Callout type="info">
-  **SPA Page View Tracking**: Rybbit's script is designed to automatically track route changes in client-side Svelte SPAs using common routers (like `svelte-routing` or `svelte-spa-router`). If page views aren't tracked correctly after navigation, you might need to manually trigger `window.rybbit.trackPageview()` after each route change, using your router's specific API for navigation events.
+  **SPA Page View Tracking**: Rybbit's script is designed to automatically track route changes in client-side Svelte SPAs using common routers (like `svelte-routing` or `svelte-spa-router`). If page views aren't tracked correctly after navigation, you might need to manually trigger `window.rybbit.pageview()` after each route change, using your router's specific API for navigation events.
 </Callout>
 
 ## Custom Event Tracking

--- a/docs-v2/content/docs/guides/vue/nuxt.mdx
+++ b/docs-v2/content/docs/guides/vue/nuxt.mdx
@@ -70,7 +70,7 @@ After restarting your Nuxt.js development server or deploying your application, 
 </Steps>
 
 <Callout type="info">
-  **SPA Page View Tracking**: Rybbit's tracking script is designed to automatically detect route changes in Nuxt.js applications and track them as page views. If you find that page views are not being tracked correctly after navigation (which is uncommon for Nuxt), you might need to manually trigger page views using `window.rybbit.trackPageview()` after each route change. You could use Nuxt's router events or middleware for this if necessary, but test the default behavior first.
+  **SPA Page View Tracking**: Rybbit's tracking script is designed to automatically detect route changes in Nuxt.js applications and track them as page views. If you find that page views are not being tracked correctly after navigation (which is uncommon for Nuxt), you might need to manually trigger page views using `window.rybbit.pageview()` after each route change. You could use Nuxt's router events or middleware for this if necessary, but test the default behavior first.
 </Callout>
 
 ## Custom Event Tracking

--- a/docs-v2/content/docs/guides/vue/vite.mdx
+++ b/docs-v2/content/docs/guides/vue/vite.mdx
@@ -69,7 +69,7 @@ Deploy your application and check your Rybbit dashboard for incoming data. You c
 </Steps>
 
 <Callout type="info">
-  **SPA Page View Tracking**: Rybbit's script is designed to automatically track route changes in SPAs using Vue Router. If page views aren't tracked correctly after navigation, you might need to manually trigger them using `window.rybbit.trackPageview()` after each route change. This can be done using Vue Router's navigation guards:
+  **SPA Page View Tracking**: Rybbit's script is designed to automatically track route changes in SPAs using Vue Router. If page views aren't tracked correctly after navigation, you might need to manually trigger them using `window.rybbit.pageview()` after each route change. This can be done using Vue Router's navigation guards:
   ```javascript
   // Example with Vue Router in your router setup file (e.g., src/router/index.js)
   import { createRouter, createWebHistory } from 'vue-router';
@@ -81,8 +81,8 @@ Deploy your application and check your Rybbit dashboard for incoming data. You c
   });
 
   router.afterEach((to, from) => {
-    if (window.rybbit && typeof window.rybbit.trackPageview === 'function') {
-      window.rybbit.trackPageview();
+    if (window.rybbit && typeof window.rybbit.pageview === 'function') {
+      window.rybbit.pageview();
     }
   });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -421,18 +421,18 @@ const start = async () => {
       server.log.info({ axiom: true, dataset: process.env.AXIOM_DATASET }, "Axiom logging is configured");
     }
 
-    if (process.env.NODE_ENV === "production") {
-      // Initialize uptime monitoring service in the background (non-blocking)
-      uptimeService
-        .initialize()
-        .then(() => {
-          server.log.info("Uptime monitoring service initialized successfully");
-        })
-        .catch((error) => {
-          server.log.error("Failed to initialize uptime service:", error);
-          // Continue running without uptime monitoring
-        });
-    }
+    // if (process.env.NODE_ENV === "production") {
+    //   // Initialize uptime monitoring service in the background (non-blocking)
+    //   uptimeService
+    //     .initialize()
+    //     .then(() => {
+    //       server.log.info("Uptime monitoring service initialized successfully");
+    //     })
+    //     .catch((error) => {
+    //       server.log.error("Failed to initialize uptime service:", error);
+    //       // Continue running without uptime monitoring
+    //     });
+    // }
   } catch (err) {
     server.log.error(err);
     process.exit(1);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -65,19 +65,6 @@ import { handleWebhook } from "./api/stripe/webhook.js";
 import { addUserToOrganization } from "./api/user/addUserToOrganization.js";
 import { getUserOrganizations } from "./api/user/getUserOrganizations.js";
 import { listOrganizationMembers } from "./api/user/listOrganizationMembers.js";
-import { getMonitors } from "./api/uptime/getMonitors.js";
-import { getMonitor } from "./api/uptime/getMonitor.js";
-import { createMonitor } from "./api/uptime/createMonitor.js";
-import { updateMonitor } from "./api/uptime/updateMonitor.js";
-import { deleteMonitor } from "./api/uptime/deleteMonitor.js";
-import { getMonitorEvents } from "./api/uptime/getMonitorEvents.js";
-import { getMonitorStats } from "./api/uptime/getMonitorStats.js";
-import { getMonitorUptimeBuckets } from "./api/uptime/getMonitorUptimeBuckets.js";
-import { getMonitorStatus } from "./api/uptime/getMonitorStatus.js";
-import { getMonitorUptime } from "./api/uptime/getMonitorUptime.js";
-import { getRegions } from "./api/uptime/getRegions.js";
-import { incidentsRoutes } from "./api/uptime/incidents.js";
-import { notificationRoutes } from "./api/uptime/notifications.js";
 import { initializeClickhouse } from "./db/clickhouse/clickhouse.js";
 import { initPostgres } from "./db/postgres/initPostgres.js";
 import { loadAllowedDomains } from "./lib/allowedDomains.js";
@@ -88,7 +75,6 @@ import { siteConfig } from "./lib/siteConfig.js";
 import { trackEvent } from "./services/tracker/trackEvent.js";
 // need to import telemetry service here to start it
 import { telemetryService } from "./services/telemetryService.js";
-import { uptimeService } from "./services/uptime/uptimeService.js";
 import { extractSiteId, isSitePublic } from "./utils.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -367,23 +353,41 @@ server.get("/api/user/organizations", getUserOrganizations);
 server.post("/api/add-user-to-organization", addUserToOrganization);
 
 // UPTIME MONITORING
-server.get("/api/uptime/monitors", getMonitors);
-server.get("/api/uptime/monitors/:monitorId", getMonitor);
-server.post("/api/uptime/monitors", createMonitor);
-server.put("/api/uptime/monitors/:monitorId", updateMonitor);
-server.delete("/api/uptime/monitors/:monitorId", deleteMonitor);
-server.get("/api/uptime/monitors/:monitorId/events", getMonitorEvents);
-server.get("/api/uptime/monitors/:monitorId/stats", getMonitorStats);
-server.get("/api/uptime/monitors/:monitorId/status", getMonitorStatus);
-server.get("/api/uptime/monitors/:monitorId/uptime", getMonitorUptime);
-server.get("/api/uptime/monitors/:monitorId/buckets", getMonitorUptimeBuckets);
-server.get("/api/uptime/regions", getRegions);
+// Only register uptime routes when IS_CLOUD is true (Redis is available)
+if (IS_CLOUD) {
+  // Dynamically import uptime modules only when needed
+  const { getMonitors } = await import("./api/uptime/getMonitors.js");
+  const { getMonitor } = await import("./api/uptime/getMonitor.js");
+  const { createMonitor } = await import("./api/uptime/createMonitor.js");
+  const { updateMonitor } = await import("./api/uptime/updateMonitor.js");
+  const { deleteMonitor } = await import("./api/uptime/deleteMonitor.js");
+  const { getMonitorEvents } = await import("./api/uptime/getMonitorEvents.js");
+  const { getMonitorStats } = await import("./api/uptime/getMonitorStats.js");
+  const { getMonitorUptimeBuckets } = await import("./api/uptime/getMonitorUptimeBuckets.js");
+  const { getMonitorStatus } = await import("./api/uptime/getMonitorStatus.js");
+  const { getMonitorUptime } = await import("./api/uptime/getMonitorUptime.js");
+  const { getRegions } = await import("./api/uptime/getRegions.js");
+  const { incidentsRoutes } = await import("./api/uptime/incidents.js");
+  const { notificationRoutes } = await import("./api/uptime/notifications.js");
 
-// Register incidents routes
-server.register(incidentsRoutes);
-
-// Register notification routes
-server.register(notificationRoutes);
+  server.get("/api/uptime/monitors", getMonitors);
+  server.get("/api/uptime/monitors/:monitorId", getMonitor);
+  server.post("/api/uptime/monitors", createMonitor);
+  server.put("/api/uptime/monitors/:monitorId", updateMonitor);
+  server.delete("/api/uptime/monitors/:monitorId", deleteMonitor);
+  server.get("/api/uptime/monitors/:monitorId/events", getMonitorEvents);
+  server.get("/api/uptime/monitors/:monitorId/stats", getMonitorStats);
+  server.get("/api/uptime/monitors/:monitorId/status", getMonitorStatus);
+  server.get("/api/uptime/monitors/:monitorId/uptime", getMonitorUptime);
+  server.get("/api/uptime/monitors/:monitorId/buckets", getMonitorUptimeBuckets);
+  server.get("/api/uptime/regions", getRegions);
+  
+  // Register incidents routes
+  server.register(incidentsRoutes);
+  
+  // Register notification routes
+  server.register(notificationRoutes);
+}
 
 // STRIPE & ADMIN
 
@@ -465,8 +469,8 @@ const shutdown = async (signal: string) => {
     server.log.info("Server closed");
 
     // Shutdown uptime service
-    await uptimeService.shutdown();
-    server.log.info("Uptime service shut down");
+    // await uptimeService.shutdown();
+    // server.log.info("Uptime service shut down");
 
     // Clear the timeout since we're done
     clearTimeout(forceExitTimeout);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated analytics API references across guides: use window.rybbit.pageview() (formerly trackPageview()) and window.rybbit.event() (formerly trackEvent()); refreshed samples for Angular, React, Vue, Svelte, Astro, Docusaurus, Framer, Bubble, Gatsby/Next.js/Remix/Vite.

- Chores
  - Uptime monitoring now enabled only in cloud environments; local/non-cloud startups no longer initialize uptime monitoring or related startup/shutdown hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->