### PR TITLE
Make drizzle ignore tables starting with pg

### DIFF
--- a/server/drizzle.config.ts
+++ b/server/drizzle.config.ts
@@ -16,4 +16,5 @@ export default defineConfig({
     ssl: false,
   },
   verbose: true,
+  tablesFilter: ['!pg_*'],
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration to exclude system tables from schema generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->