### PR TITLE
feat: Add short weekday option to date formatting

### DIFF
--- a/client/src/lib/dateTimeUtils.ts
+++ b/client/src/lib/dateTimeUtils.ts
@@ -169,6 +169,7 @@ export const formatChartDateTime = (dt: DateTime, bucket: TimeBucket) => {
     options.minute = undefined;
     options.hour = undefined;
     options.month = "long";
+    options.weekday = "short";
   }
   if (bucket === "fifteen_minutes" || bucket === "ten_minutes" || bucket === "five_minutes" || bucket === "minute") {
     options.minute = "numeric";


### PR DESCRIPTION
Add the day of week (shorthand) for the day bucket:

<img width="519" height="212" alt="image" src="https://github.com/user-attachments/assets/6db1daa8-aa28-4f3c-9ce2-9b5ff9a87e2a" />

It makes it helpful for observing day-of-week trends and patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart date/time labels now include localized weekday abbreviations (e.g., "Mon", "Tue") when displaying daily data, improving date readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->