### PR TITLE
Add HK to exclude country list

### DIFF
--- a/client/src/components/SiteSettings/CountrySelector.tsx
+++ b/client/src/components/SiteSettings/CountrySelector.tsx
@@ -83,6 +83,7 @@ const COUNTRIES = [
   { code: "GY", name: "Guyana" },
   { code: "HT", name: "Haiti" },
   { code: "HN", name: "Honduras" },
+  { code: "HK", name: "Hong Kong" },
   { code: "HU", name: "Hungary" },
   { code: "IS", name: "Iceland" },
   { code: "IN", name: "India" },


### PR DESCRIPTION
Adding this because after singapore these guys are after me now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hong Kong is now available as a selectable country option in the settings, enabling users to manage country preferences and exclusions alongside existing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->