### PR TITLE
feat: delete session replays

### DIFF
--- a/client/src/api/analytics/sessionReplay/useDeleteSessionReplay.ts
+++ b/client/src/api/analytics/sessionReplay/useDeleteSessionReplay.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useStore } from "../../../lib/store";
+import { authedFetch } from "../../utils";
+
+interface DeleteSessionReplayParams {
+  sessionId: string;
+}
+
+export function useDeleteSessionReplay() {
+  const { site } = useStore();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ sessionId }: DeleteSessionReplayParams) => {
+      const response = await authedFetch<{ success: boolean }>(
+        `/session-replay/${sessionId}/${site}`,
+        {},
+        {
+          method: "DELETE",
+        }
+      );
+      return response;
+    },
+    onSuccess: () => {
+      // Invalidate the session replay list query to refetch data
+      queryClient.invalidateQueries({ queryKey: ["session-replays", site] });
+    },
+  });
+}

--- a/server/src/api/sessionReplay/deleteSessionReplay.ts
+++ b/server/src/api/sessionReplay/deleteSessionReplay.ts
@@ -1,0 +1,45 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+import { getUserHasAccessToSite } from "../../lib/auth-utils.js";
+import { SessionReplayQueryService } from "../../services/replay/sessionReplayQueryService.js";
+
+export async function deleteSessionReplay(
+  request: FastifyRequest<{
+    Params: {
+      sessionId: string;
+      site: string;
+    };
+  }>,
+  reply: FastifyReply
+) {
+  const { sessionId, site } = request.params;
+
+  try {
+    // Parse site ID
+    const siteId = parseInt(site);
+    if (isNaN(siteId)) {
+      return reply.status(400).send({ error: "Invalid site ID" });
+    }
+
+    // Check user access to site
+    const userHasAccessToSite = await getUserHasAccessToSite(request, site);
+    if (!userHasAccessToSite) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
+
+    // Check if session replay exists
+    const sessionReplayQueryService = new SessionReplayQueryService();
+    const metadata = await sessionReplayQueryService.getSessionReplayMetadata(siteId, sessionId);
+
+    if (!metadata) {
+      return reply.status(404).send({ error: "Session replay not found" });
+    }
+
+    // Delete the session replay
+    await sessionReplayQueryService.deleteSessionReplay(siteId, sessionId);
+
+    return reply.status(200).send({ success: true });
+  } catch (error) {
+    console.error("Error deleting session replay:", error);
+    return reply.status(500).send({ error: "Failed to delete session replay" });
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -45,6 +45,7 @@ import { getConfig } from "./api/getConfig.js";
 import { getSessionReplayEvents } from "./api/sessionReplay/getSessionReplayEvents.js";
 import { getSessionReplays } from "./api/sessionReplay/getSessionReplays.js";
 import { recordSessionReplay } from "./api/sessionReplay/recordSessionReplay.js";
+import { deleteSessionReplay } from "./api/sessionReplay/deleteSessionReplay.js";
 import { addSite } from "./api/sites/addSite.js";
 import { updateSiteConfig } from "./api/sites/updateSiteConfig.js";
 import { deleteSite } from "./api/sites/deleteSite.js";
@@ -346,6 +347,7 @@ server.get("/api/performance/by-dimension/:site", getPerformanceByDimension);
 server.post("/api/session-replay/record/:site", recordSessionReplay);
 server.get("/api/session-replay/list/:site", getSessionReplays);
 server.get("/api/session-replay/:sessionId/:site", getSessionReplayEvents);
+server.delete("/api/session-replay/:sessionId/:site", deleteSessionReplay);
 
 // Administrative
 server.get("/api/config", getConfig);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Session Replay Deletion**: Users can now delete individual session replays with a confirmation dialog to prevent accidental removal.
* Delete button is conveniently located in the replay card interface.
* Deletions are protected by access controls and automatically clean up all associated replay data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->