### PR TITLE
Handle insert error

### DIFF
--- a/server/src/services/tracker/pageviewQueue.ts
+++ b/server/src/services/tracker/pageviewQueue.ts
@@ -124,7 +124,9 @@ class PageviewQueue {
         format: "JSONEachRow",
       });
     } catch (error) {
-      this.logger.error(error, "Error processing pageview queue");
+      this.logger.error(error, `Error processing pageview queue, re-adding ${batch.length} items to the start of the queue`);
+      // Re-queue the failed batch so it can be retried on the next interval
+      this.queue.unshift(...batch);
     } finally {
       this.processing = false;
     }


### PR DESCRIPTION
This re-adds pageviews to the queue if there is an error inserting into Clickhouse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced page view queue error handling to preserve and retry failed batches, with improved error messages showing the count of affected items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->