### PR TITLE
fix: Better Auth SSR errors in Docker deployments with reverse proxy

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -1,8 +1,18 @@
 import { adminClient, organizationClient, emailOTPClient, apiKeyClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
+// Use internal backend URL for SSR, external URL for client
+const getBaseURL = () => {
+  // Server-side (SSR)
+  if (typeof window === "undefined") {
+    return process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL;
+  }
+  // Client-side
+  return process.env.NEXT_PUBLIC_BACKEND_URL;
+};
+
 export const authClient = createAuthClient({
-  baseURL: process.env.NEXT_PUBLIC_BACKEND_URL,
+  baseURL: getBaseURL(),
   plugins: [adminClient(), organizationClient(), emailOTPClient(), apiKeyClient()],
   fetchOptions: {
     credentials: "include",

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -5,10 +5,22 @@ import { createAuthClient } from "better-auth/react";
 const getBaseURL = () => {
   // Server-side (SSR)
   if (typeof window === "undefined") {
-    return process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL;
+    const url = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL;
+    if (!url) {
+      throw new Error(
+        "Missing required environment variable: BACKEND_URL or NEXT_PUBLIC_BACKEND_URL must be set for SSR authentication"
+      );
+    }
+    return url;
   }
   // Client-side
-  return process.env.NEXT_PUBLIC_BACKEND_URL;
+  const url = process.env.NEXT_PUBLIC_BACKEND_URL;
+  if (!url) {
+    throw new Error(
+      "Missing required environment variable: NEXT_PUBLIC_BACKEND_URL must be set for client-side authentication"
+    );
+  }
+  return url;
 };
 
 export const authClient = createAuthClient({

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -94,6 +94,7 @@ const pluginList = [
 
 export const auth = betterAuth({
   basePath: "/api/auth",
+  baseURL: process.env.BETTER_AUTH_URL || process.env.BASE_URL,
   database: new pg.Pool({
     host: process.env.POSTGRES_HOST || "postgres",
     port: parseInt(process.env.POSTGRES_PORT || "5432", 10),
@@ -134,7 +135,11 @@ export const auth = betterAuth({
     },
   },
   plugins: pluginList,
-  trustedOrigins: ["http://localhost:3002"],
+  trustedOrigins: [
+    "http://localhost:3002",
+    ...(process.env.BASE_URL ? [process.env.BASE_URL] : []),
+  ],
+  trustHost: process.env.AUTH_TRUST_HOST === "true",
   advanced: {
     useSecureCookies: process.env.NODE_ENV === "production", // don't mark Secure in dev
     defaultCookieAttributes: {

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -145,7 +145,7 @@ export const auth = betterAuth({
   plugins: pluginList,
   trustedOrigins: [
     "http://localhost:3002",
-    ...(process.env.BASE_URL ? [process.env.BASE_URL] : []),
+    baseURL,
   ],
   trustHost: process.env.AUTH_TRUST_HOST === "true",
   advanced: {

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -92,9 +92,17 @@ const pluginList = [
     : []),
 ];
 
+// Validate base URL is configured
+const baseURL = process.env.BETTER_AUTH_URL || process.env.BASE_URL;
+if (!baseURL) {
+  throw new Error(
+    "Missing required environment variable: BETTER_AUTH_URL or BASE_URL must be set for authentication"
+  );
+}
+
 export const auth = betterAuth({
   basePath: "/api/auth",
-  baseURL: process.env.BETTER_AUTH_URL || process.env.BASE_URL,
+  baseURL,
   database: new pg.Pool({
     host: process.env.POSTGRES_HOST || "postgres",
     port: parseInt(process.env.POSTGRES_PORT || "5432", 10),


### PR DESCRIPTION
 ## Description

  Fixes Better Auth SSR errors when deploying Rybbit behind a
  reverse proxy using Docker Compose.

  Resolves #[YOUR_ISSUE_NUMBER] (replace with the issue number
  you created)

  ## Changes

  - **Server (`server/src/lib/auth.ts`)**: Added `baseURL`,
  updated `trustedOrigins`, and added `trustHost` configuration
  - **Client (`client/src/lib/auth.ts`)**: Implemented
  SSR-aware URL selection to use internal backend URL

  ## Problem

  Better Auth was failing with `TypeError: Failed to parse URL
  from /api/auth/get-session` because:
  1. No absolute `baseURL` was configured for SSR contexts
  2. `trustedOrigins` only included localhost
  3. Client tried to reach external domain during SSR instead
  of internal Docker network

  ## Solution

  - Configure Better Auth with proper base URL from environment
   variables
  - Use internal `http://backend:3001` for SSR, external URL
  for client-side requests
  - Add trusted origins and host configuration for proxied
  deployments

  ## Testing

  Tested locally with Traefik reverse proxy deployment:
  - ✅ Dashboard loads without errors
  - ✅ Authentication works correctly
  - ✅ No connection timeouts
  - ✅ Tracking continues to work

  ## Environment Variables Required

  Users need to add these to `.env`:
  ```env
  BETTER_AUTH_URL=https://your-domain.com
  AUTH_TRUST_HOST=true
  BACKEND_URL=http://backend:3001

  Documentation should be updated to reflect these
  requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication to reliably resolve the backend base URL in both server and client contexts, with runtime validation and clearer error reporting.
  * Strengthened origin/host handling: expanded trusted origins and added a configurable host-trust option to better adapt to deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->