### PR TITLE
Fix tracking config booleans (preserve false values)

### DIFF
--- a/server/src/lib/siteConfig.ts
+++ b/server/src/lib/siteConfig.ts
@@ -94,10 +94,10 @@ class SiteConfig {
         sessionReplay: site.sessionReplay || false,
         webVitals: site.webVitals || false,
         trackErrors: site.trackErrors || false,
-        trackOutbound: site.trackOutbound || true,
-        trackUrlParams: site.trackUrlParams || true,
-        trackInitialPageView: site.trackInitialPageView || true,
-        trackSpaNavigation: site.trackSpaNavigation || true,
+        trackOutbound: site.trackOutbound ?? true,
+        trackUrlParams: site.trackUrlParams ?? true,
+        trackInitialPageView: site.trackInitialPageView ?? true,
+        trackSpaNavigation: site.trackSpaNavigation ?? true,
         trackIp: site.trackIp || false,
       };
 


### PR DESCRIPTION
Fixes an issue where disabling tracking flags was ignored because `|| true` coerces `false` to `true`.

Replaced `|| true` with `?? true` for:
- trackOutbound
- trackUrlParams
- trackInitialPageView
- trackSpaNavigation

This preserves explicit `false` values and only falls back to defaults for null/undefined.

I hit this in a self-hosted setup: trackSpaNavigation=false was stored correctly in Postgres, but /api/site/tracking-config/:id still returned true. After changing || true to ?? true, the endpoint now reflects the saved settings correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configuration settings to properly respect explicitly set false values for tracking options (outbound links, URL parameters, initial page view, and SPA navigation).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->