### PR TITLE
Update api url in docs

### DIFF
--- a/docs/content/docs/api/organizations.mdx
+++ b/docs/content/docs/api/organizations.mdx
@@ -188,14 +188,14 @@ Each site in the `sites` array contains:
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/organizations" \
+curl -X GET "https://app.rybbit.io/api/organizations" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/organizations',
+  'https://app.rybbit.io/api/organizations',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -211,7 +211,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/organizations',
+    'https://app.rybbit.io/api/organizations',
     headers={
         'Authorization': 'Bearer your_api_key_here'
     }
@@ -223,7 +223,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, "https://api.rybbit.io/api/organizations");
+curl_setopt($ch, CURLOPT_URL, "https://app.rybbit.io/api/organizations");
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -240,7 +240,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/organizations')
+uri = URI('https://app.rybbit.io/api/organizations')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -250,7 +250,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/organizations", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/organizations", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -265,7 +265,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/organizations")
+    .get("https://app.rybbit.io/api/organizations")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -277,7 +277,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/organizations"))
+    .uri(URI.create("https://app.rybbit.io/api/organizations"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -290,7 +290,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/organizations");
+var response = await client.GetAsync("https://app.rybbit.io/api/organizations");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -503,7 +503,7 @@ Returns the created site object with the assigned `siteId`.
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X POST "https://api.rybbit.io/api/organizations/org_123/sites" \
+curl -X POST "https://app.rybbit.io/api/organizations/org_123/sites" \
   -H "Authorization: Bearer your_api_key_here" \
   -H "Content-Type: application/json" \
   -d '{"domain": "example.com", "name": "My Website", "blockBots": true}'
@@ -513,7 +513,7 @@ curl -X POST "https://api.rybbit.io/api/organizations/org_123/sites" \
 ```javascript title="Request"
 const organizationId = 'org_123';
 const response = await fetch(
-  `https://api.rybbit.io/api/organizations/${organizationId}/sites`,
+  `https://app.rybbit.io/api/organizations/${organizationId}/sites`,
   {
     method: 'POST',
     headers: {
@@ -537,7 +537,7 @@ import requests
 
 organization_id = 'org_123'
 response = requests.post(
-    f'https://api.rybbit.io/api/organizations/{organization_id}/sites',
+    f'https://app.rybbit.io/api/organizations/{organization_id}/sites',
     json={
         'domain': 'example.com',
         'name': 'My Website',
@@ -555,7 +555,7 @@ data = response.json()
 ```php title="Request"
 $organizationId = 'org_123';
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, "https://api.rybbit.io/api/organizations/{$organizationId}/sites");
+curl_setopt($ch, CURLOPT_URL, "https://app.rybbit.io/api/organizations/{$organizationId}/sites");
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_POST, true);
 curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode([
@@ -580,7 +580,7 @@ require 'net/http'
 require 'json'
 
 organization_id = 'org_123'
-uri = URI("https://api.rybbit.io/api/organizations/#{organization_id}/sites")
+uri = URI("https://app.rybbit.io/api/organizations/#{organization_id}/sites")
 req = Net::HTTP::Post.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 req['Content-Type'] = 'application/json'
@@ -602,7 +602,7 @@ body := bytes.NewBuffer([]byte(`{
   "name": "My Website",
   "blockBots": true
 }`))
-req, _ := http.NewRequest("POST", "https://api.rybbit.io/api/organizations/"+organizationId+"/sites", body)
+req, _ := http.NewRequest("POST", "https://app.rybbit.io/api/organizations/"+organizationId+"/sites", body)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 req.Header.Set("Content-Type", "application/json")
 
@@ -619,7 +619,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 let organization_id = "org_123";
 let client = reqwest::Client::new();
 let res = client
-    .post(format!("https://api.rybbit.io/api/organizations/{}/sites", organization_id))
+    .post(format!("https://app.rybbit.io/api/organizations/{}/sites", organization_id))
     .header("Authorization", "Bearer your_api_key_here")
     .json(&serde_json::json!({
         "domain": "example.com",
@@ -638,7 +638,7 @@ String organizationId = "org_123";
 HttpClient client = HttpClient.newHttpClient();
 String json = "{\"domain\": \"example.com\", \"name\": \"My Website\", \"blockBots\": true}";
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/organizations/" + organizationId + "/sites"))
+    .uri(URI.create("https://app.rybbit.io/api/organizations/" + organizationId + "/sites"))
     .header("Authorization", "Bearer your_api_key_here")
     .header("Content-Type", "application/json")
     .POST(HttpRequest.BodyPublishers.ofString(json))
@@ -659,7 +659,7 @@ var content = new StringContent(
     "application/json"
 );
 
-var response = await client.PostAsync($"https://api.rybbit.io/api/organizations/{organizationId}/sites", content);
+var response = await client.PostAsync($"https://app.rybbit.io/api/organizations/{organizationId}/sites", content);
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -782,7 +782,7 @@ Each member in the `data` array contains:
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/organizations/org_123/members" \
+curl -X GET "https://app.rybbit.io/api/organizations/org_123/members" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
@@ -790,7 +790,7 @@ curl -X GET "https://api.rybbit.io/api/organizations/org_123/members" \
 ```javascript title="Request"
 const organizationId = 'org_123';
 const response = await fetch(
-  `https://api.rybbit.io/api/organizations/${organizationId}/members`,
+  `https://app.rybbit.io/api/organizations/${organizationId}/members`,
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -807,7 +807,7 @@ import requests
 
 organization_id = 'org_123'
 response = requests.get(
-    f'https://api.rybbit.io/api/organizations/{organization_id}/members',
+    f'https://app.rybbit.io/api/organizations/{organization_id}/members',
     headers={
         'Authorization': 'Bearer your_api_key_here'
     }
@@ -820,7 +820,7 @@ data = response.json()
 ```php title="Request"
 $organizationId = 'org_123';
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, "https://api.rybbit.io/api/organizations/{$organizationId}/members");
+curl_setopt($ch, CURLOPT_URL, "https://app.rybbit.io/api/organizations/{$organizationId}/members");
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -838,7 +838,7 @@ require 'net/http'
 require 'json'
 
 organization_id = 'org_123'
-uri = URI("https://api.rybbit.io/api/organizations/#{organization_id}/members")
+uri = URI("https://app.rybbit.io/api/organizations/#{organization_id}/members")
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -849,7 +849,7 @@ data = JSON.parse(res.body)
   <Tab value="Go">
 ```go title="Request"
 organizationId := "org_123"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/organizations/"+organizationId+"/members", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/organizations/"+organizationId+"/members", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -865,7 +865,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 let organization_id = "org_123";
 let client = reqwest::Client::new();
 let res = client
-    .get(format!("https://api.rybbit.io/api/organizations/{}/members", organization_id))
+    .get(format!("https://app.rybbit.io/api/organizations/{}/members", organization_id))
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -878,7 +878,7 @@ let data: serde_json::Value = res.json().await?;
 String organizationId = "org_123";
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/organizations/" + organizationId + "/members"))
+    .uri(URI.create("https://app.rybbit.io/api/organizations/" + organizationId + "/members"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -892,7 +892,7 @@ var organizationId = "org_123";
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync($"https://api.rybbit.io/api/organizations/{organizationId}/members");
+var response = await client.GetAsync($"https://app.rybbit.io/api/organizations/{organizationId}/members");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -1019,7 +1019,7 @@ Returns a success message when the user is added successfully.
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X POST "https://api.rybbit.io/api/organizations/org_123/members" \
+curl -X POST "https://app.rybbit.io/api/organizations/org_123/members" \
   -H "Authorization: Bearer your_api_key_here" \
   -H "Content-Type: application/json" \
   -d '{"email": "newuser@example.com", "role": "member"}'
@@ -1029,7 +1029,7 @@ curl -X POST "https://api.rybbit.io/api/organizations/org_123/members" \
 ```javascript title="Request"
 const organizationId = 'org_123';
 const response = await fetch(
-  `https://api.rybbit.io/api/organizations/${organizationId}/members`,
+  `https://app.rybbit.io/api/organizations/${organizationId}/members`,
   {
     method: 'POST',
     headers: {
@@ -1052,7 +1052,7 @@ import requests
 
 organization_id = 'org_123'
 response = requests.post(
-    f'https://api.rybbit.io/api/organizations/{organization_id}/members',
+    f'https://app.rybbit.io/api/organizations/{organization_id}/members',
     json={
         'email': 'newuser@example.com',
         'role': 'member'
@@ -1069,7 +1069,7 @@ data = response.json()
 ```php title="Request"
 $organizationId = 'org_123';
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, "https://api.rybbit.io/api/organizations/{$organizationId}/members");
+curl_setopt($ch, CURLOPT_URL, "https://app.rybbit.io/api/organizations/{$organizationId}/members");
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_POST, true);
 curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode([
@@ -1093,7 +1093,7 @@ require 'net/http'
 require 'json'
 
 organization_id = 'org_123'
-uri = URI("https://api.rybbit.io/api/organizations/#{organization_id}/members")
+uri = URI("https://app.rybbit.io/api/organizations/#{organization_id}/members")
 req = Net::HTTP::Post.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 req['Content-Type'] = 'application/json'
@@ -1113,7 +1113,7 @@ body := bytes.NewBuffer([]byte(`{
   "email": "newuser@example.com",
   "role": "member"
 }`))
-req, _ := http.NewRequest("POST", "https://api.rybbit.io/api/organizations/"+organizationId+"/members", body)
+req, _ := http.NewRequest("POST", "https://app.rybbit.io/api/organizations/"+organizationId+"/members", body)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 req.Header.Set("Content-Type", "application/json")
 
@@ -1130,7 +1130,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 let organization_id = "org_123";
 let client = reqwest::Client::new();
 let res = client
-    .post(format!("https://api.rybbit.io/api/organizations/{}/members", organization_id))
+    .post(format!("https://app.rybbit.io/api/organizations/{}/members", organization_id))
     .header("Authorization", "Bearer your_api_key_here")
     .json(&serde_json::json!({
         "email": "newuser@example.com",
@@ -1148,7 +1148,7 @@ String organizationId = "org_123";
 HttpClient client = HttpClient.newHttpClient();
 String json = "{\"email\": \"newuser@example.com\", \"role\": \"member\"}";
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/organizations/" + organizationId + "/members"))
+    .uri(URI.create("https://app.rybbit.io/api/organizations/" + organizationId + "/members"))
     .header("Authorization", "Bearer your_api_key_here")
     .header("Content-Type", "application/json")
     .POST(HttpRequest.BodyPublishers.ofString(json))
@@ -1169,7 +1169,7 @@ var content = new StringContent(
     "application/json"
 );
 
-var response = await client.PostAsync($"https://api.rybbit.io/api/organizations/{organizationId}/members", content);
+var response = await client.PostAsync($"https://app.rybbit.io/api/organizations/{organizationId}/members", content);
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>

--- a/docs/content/docs/api/sites.mdx
+++ b/docs/content/docs/api/sites.mdx
@@ -150,14 +150,14 @@ Returns detailed information about a specific site including its configuration.
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/123" \
+curl -X GET "https://app.rybbit.io/api/sites/123" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123',
+  'https://app.rybbit.io/api/sites/123',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -173,7 +173,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/123',
+    'https://app.rybbit.io/api/sites/123',
     headers={
         'Authorization': 'Bearer your_api_key_here'
     }
@@ -185,7 +185,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -202,7 +202,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123')
+uri = URI('https://app.rybbit.io/api/sites/123')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -212,7 +212,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/123", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/123", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -227,7 +227,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/123")
+    .get("https://app.rybbit.io/api/sites/123")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -239,7 +239,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -252,7 +252,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/123");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/123");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -325,14 +325,14 @@ Permanently deletes a site and all its associated data. This action cannot be un
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X DELETE "https://api.rybbit.io/api/sites/123" \
+curl -X DELETE "https://app.rybbit.io/api/sites/123" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123',
+  'https://app.rybbit.io/api/sites/123',
   {
     method: 'DELETE',
     headers: {
@@ -349,7 +349,7 @@ const data = await response.json();
 import requests
 
 response = requests.delete(
-    'https://api.rybbit.io/api/sites/123',
+    'https://app.rybbit.io/api/sites/123',
     headers={
         'Authorization': 'Bearer your_api_key_here'
     }
@@ -361,7 +361,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
@@ -379,7 +379,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123')
+uri = URI('https://app.rybbit.io/api/sites/123')
 req = Net::HTTP::Delete.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -389,7 +389,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("DELETE", "https://api.rybbit.io/api/sites/123", nil)
+req, _ := http.NewRequest("DELETE", "https://app.rybbit.io/api/sites/123", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -404,7 +404,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .delete("https://api.rybbit.io/api/sites/123")
+    .delete("https://app.rybbit.io/api/sites/123")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -416,7 +416,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123"))
     .header("Authorization", "Bearer your_api_key_here")
     .DELETE()
     .build();
@@ -429,7 +429,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.DeleteAsync("https://api.rybbit.io/api/sites/123");
+var response = await client.DeleteAsync("https://app.rybbit.io/api/sites/123");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -559,7 +559,7 @@ Updates site configuration settings. All fields are optional - only include the 
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X PUT "https://api.rybbit.io/api/sites/123/config" \
+curl -X PUT "https://app.rybbit.io/api/sites/123/config" \
   -H "Authorization: Bearer your_api_key_here" \
   -H "Content-Type: application/json" \
   -d '{"public": true, "blockBots": true, "excludedCountries": ["CN", "RU"]}'
@@ -568,7 +568,7 @@ curl -X PUT "https://api.rybbit.io/api/sites/123/config" \
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123/config',
+  'https://app.rybbit.io/api/sites/123/config',
   {
     method: 'PUT',
     headers: {
@@ -591,7 +591,7 @@ const data = await response.json();
 import requests
 
 response = requests.put(
-    'https://api.rybbit.io/api/sites/123/config',
+    'https://app.rybbit.io/api/sites/123/config',
     json={
         'public': True,
         'blockBots': True,
@@ -608,7 +608,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123/config');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123/config');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
 curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode([
@@ -632,7 +632,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123/config')
+uri = URI('https://app.rybbit.io/api/sites/123/config')
 req = Net::HTTP::Put.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 req['Content-Type'] = 'application/json'
@@ -645,7 +645,7 @@ data = JSON.parse(res.body)
   <Tab value="Go">
 ```go title="Request"
 body := bytes.NewBuffer([]byte(`{"public": true, "blockBots": true, "excludedCountries": ["CN", "RU"]}`))
-req, _ := http.NewRequest("PUT", "https://api.rybbit.io/api/sites/123/config", body)
+req, _ := http.NewRequest("PUT", "https://app.rybbit.io/api/sites/123/config", body)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 req.Header.Set("Content-Type", "application/json")
 
@@ -661,7 +661,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .put("https://api.rybbit.io/api/sites/123/config")
+    .put("https://app.rybbit.io/api/sites/123/config")
     .header("Authorization", "Bearer your_api_key_here")
     .json(&serde_json::json!({
         "public": true,
@@ -679,7 +679,7 @@ let data: serde_json::Value = res.json().await?;
 HttpClient client = HttpClient.newHttpClient();
 String json = "{\"public\": true, \"blockBots\": true, \"excludedCountries\": [\"CN\", \"RU\"]}";
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123/config"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123/config"))
     .header("Authorization", "Bearer your_api_key_here")
     .header("Content-Type", "application/json")
     .PUT(HttpRequest.BodyPublishers.ofString(json))
@@ -699,7 +699,7 @@ var content = new StringContent(
     "application/json"
 );
 
-var response = await client.PutAsync("https://api.rybbit.io/api/sites/123/config", content);
+var response = await client.PutAsync("https://app.rybbit.io/api/sites/123/config", content);
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -773,14 +773,14 @@ Returns the list of IP addresses and CIDR ranges that are excluded from tracking
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/123/excluded-ips" \
+curl -X GET "https://app.rybbit.io/api/sites/123/excluded-ips" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123/excluded-ips',
+  'https://app.rybbit.io/api/sites/123/excluded-ips',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -796,7 +796,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/123/excluded-ips',
+    'https://app.rybbit.io/api/sites/123/excluded-ips',
     headers={
         'Authorization': 'Bearer your_api_key_here'
     }
@@ -808,7 +808,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123/excluded-ips');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123/excluded-ips');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -825,7 +825,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123/excluded-ips')
+uri = URI('https://app.rybbit.io/api/sites/123/excluded-ips')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -835,7 +835,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/123/excluded-ips", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/123/excluded-ips", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -850,7 +850,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/123/excluded-ips")
+    .get("https://app.rybbit.io/api/sites/123/excluded-ips")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -862,7 +862,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123/excluded-ips"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123/excluded-ips"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -875,7 +875,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/123/excluded-ips");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/123/excluded-ips");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -941,14 +941,14 @@ Returns the list of country codes that are excluded from tracking.
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/123/excluded-countries" \
+curl -X GET "https://app.rybbit.io/api/sites/123/excluded-countries" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123/excluded-countries',
+  'https://app.rybbit.io/api/sites/123/excluded-countries',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -964,7 +964,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/123/excluded-countries',
+    'https://app.rybbit.io/api/sites/123/excluded-countries',
     headers={
         'Authorization': 'Bearer your_api_key_here'
     }
@@ -976,7 +976,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123/excluded-countries');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123/excluded-countries');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -993,7 +993,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123/excluded-countries')
+uri = URI('https://app.rybbit.io/api/sites/123/excluded-countries')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -1003,7 +1003,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/123/excluded-countries", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/123/excluded-countries", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -1018,7 +1018,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/123/excluded-countries")
+    .get("https://app.rybbit.io/api/sites/123/excluded-countries")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -1030,7 +1030,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123/excluded-countries"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123/excluded-countries"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -1043,7 +1043,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/123/excluded-countries");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/123/excluded-countries");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -1120,14 +1120,14 @@ Returns the private link key configuration. Private links allow sharing analytic
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/123/private-link-config" \
+curl -X GET "https://app.rybbit.io/api/sites/123/private-link-config" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123/private-link-config',
+  'https://app.rybbit.io/api/sites/123/private-link-config',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -1143,7 +1143,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/123/private-link-config',
+    'https://app.rybbit.io/api/sites/123/private-link-config',
     headers={
         'Authorization': 'Bearer your_api_key_here'
     }
@@ -1155,7 +1155,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123/private-link-config');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123/private-link-config');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -1172,7 +1172,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123/private-link-config')
+uri = URI('https://app.rybbit.io/api/sites/123/private-link-config')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -1182,7 +1182,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/123/private-link-config", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/123/private-link-config", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -1197,7 +1197,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/123/private-link-config")
+    .get("https://app.rybbit.io/api/sites/123/private-link-config")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -1209,7 +1209,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123/private-link-config"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123/private-link-config"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -1222,7 +1222,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/123/private-link-config");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/123/private-link-config");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -1310,7 +1310,7 @@ Generates or revokes a private link key for sharing analytics without authentica
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X POST "https://api.rybbit.io/api/sites/123/private-link-config" \
+curl -X POST "https://app.rybbit.io/api/sites/123/private-link-config" \
   -H "Authorization: Bearer your_api_key_here" \
   -H "Content-Type: application/json" \
   -d '{"action": "generate_private_link_key"}'
@@ -1319,7 +1319,7 @@ curl -X POST "https://api.rybbit.io/api/sites/123/private-link-config" \
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123/private-link-config',
+  'https://app.rybbit.io/api/sites/123/private-link-config',
   {
     method: 'POST',
     headers: {
@@ -1340,7 +1340,7 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    'https://api.rybbit.io/api/sites/123/private-link-config',
+    'https://app.rybbit.io/api/sites/123/private-link-config',
     json={
         'action': 'generate_private_link_key'
     },
@@ -1355,7 +1355,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123/private-link-config');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123/private-link-config');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_POST, true);
 curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode([
@@ -1377,7 +1377,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123/private-link-config')
+uri = URI('https://app.rybbit.io/api/sites/123/private-link-config')
 req = Net::HTTP::Post.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 req['Content-Type'] = 'application/json'
@@ -1390,7 +1390,7 @@ data = JSON.parse(res.body)
   <Tab value="Go">
 ```go title="Request"
 body := bytes.NewBuffer([]byte(`{"action": "generate_private_link_key"}`))
-req, _ := http.NewRequest("POST", "https://api.rybbit.io/api/sites/123/private-link-config", body)
+req, _ := http.NewRequest("POST", "https://app.rybbit.io/api/sites/123/private-link-config", body)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 req.Header.Set("Content-Type", "application/json")
 
@@ -1406,7 +1406,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .post("https://api.rybbit.io/api/sites/123/private-link-config")
+    .post("https://app.rybbit.io/api/sites/123/private-link-config")
     .header("Authorization", "Bearer your_api_key_here")
     .json(&serde_json::json!({
         "action": "generate_private_link_key"
@@ -1422,7 +1422,7 @@ let data: serde_json::Value = res.json().await?;
 HttpClient client = HttpClient.newHttpClient();
 String json = "{\"action\": \"generate_private_link_key\"}";
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123/private-link-config"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123/private-link-config"))
     .header("Authorization", "Bearer your_api_key_here")
     .header("Content-Type", "application/json")
     .POST(HttpRequest.BodyPublishers.ofString(json))
@@ -1442,7 +1442,7 @@ var content = new StringContent(
     "application/json"
 );
 
-var response = await client.PostAsync("https://api.rybbit.io/api/sites/123/private-link-config", content);
+var response = await client.PostAsync("https://app.rybbit.io/api/sites/123/private-link-config", content);
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>

--- a/docs/content/docs/api/stats/errors.mdx
+++ b/docs/content/docs/api/stats/errors.mdx
@@ -114,14 +114,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31" \
+curl -X GET "https://app.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31',
+  'https://app.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -137,7 +137,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/error-names23',
+    'https://app.rybbit.io/api/sites/1/error-names23',
     params={
         'start_date': '2024-01-01',
         'end_date': '2024-01-31'
@@ -153,7 +153,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -170,7 +170,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31')
+uri = URI('https://app.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -180,7 +180,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -195,7 +195,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31")
+    .get("https://app.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -207,7 +207,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -220,7 +220,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/error-names23?start_date=2024-01-01&end_date=2024-01-31");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -391,14 +391,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10" \
+curl -X GET "https://app.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  `https://api.rybbit.io/api/sites/1/error-events23?errorMessage=${encodeURIComponent("Cannot read property 'map' of undefined")}&limit=10`,
+  `https://app.rybbit.io/api/sites/1/error-events23?errorMessage=${encodeURIComponent("Cannot read property 'map' of undefined")}&limit=10`,
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -414,7 +414,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/error-events23',
+    'https://app.rybbit.io/api/sites/1/error-events23',
     params={
         'errorMessage': "Cannot read property 'map' of undefined",
         'limit': 10
@@ -430,7 +430,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -447,7 +447,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10')
+uri = URI('https://app.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -457,7 +457,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -472,7 +472,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10")
+    .get("https://app.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -484,7 +484,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -497,7 +497,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/error-events23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&limit=10");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -612,14 +612,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC" \
+curl -X GET "https://app.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  `https://api.rybbit.io/api/sites/1/error-bucketed23?errorMessage=${encodeURIComponent("Cannot read property 'map' of undefined")}&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC`,
+  `https://app.rybbit.io/api/sites/1/error-bucketed23?errorMessage=${encodeURIComponent("Cannot read property 'map' of undefined")}&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC`,
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -635,7 +635,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/error-bucketed23',
+    'https://app.rybbit.io/api/sites/1/error-bucketed23',
     params={
         'errorMessage': "Cannot read property 'map' of undefined",
         'bucket': 'hour',
@@ -654,7 +654,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -671,7 +671,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC')
+uri = URI('https://app.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -681,7 +681,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -696,7 +696,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC")
+    .get("https://app.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -708,7 +708,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -721,7 +721,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/error-bucketed23?errorMessage=Cannot%20read%20property%20%27map%27%20of%20undefined&bucket=hour&start_date=2024-01-30&end_date=2024-01-31&time_zone=UTC");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>

--- a/docs/content/docs/api/stats/events.mdx
+++ b/docs/content/docs/api/stats/events.mdx
@@ -156,14 +156,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31" \
+curl -X GET "https://app.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31',
+  'https://app.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -179,7 +179,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/events23',
+    'https://app.rybbit.io/api/sites/1/events23',
     params={
         'page': 1,
         'page_size': 20,
@@ -197,7 +197,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -214,7 +214,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31')
+uri = URI('https://app.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -224,7 +224,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -239,7 +239,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31")
+    .get("https://app.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -251,7 +251,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -264,7 +264,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/events23?page=1&page_size=20&start_date=2024-01-01&end_date=2024-01-31");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -375,14 +375,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) (ti
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31" \
+curl -X GET "https://app.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31',
+  'https://app.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -398,7 +398,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/events/names23',
+    'https://app.rybbit.io/api/sites/1/events/names23',
     params={
         'start_date': '2024-01-01',
         'end_date': '2024-01-31'
@@ -414,7 +414,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -431,7 +431,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31')
+uri = URI('https://app.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -441,7 +441,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -456,7 +456,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31")
+    .get("https://app.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -468,7 +468,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -481,7 +481,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/events/names23?start_date=2024-01-01&end_date=2024-01-31");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -588,14 +588,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31" \
+curl -X GET "https://app.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31',
+  'https://app.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -611,7 +611,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/events/properties23',
+    'https://app.rybbit.io/api/sites/1/events/properties23',
     params={
         'event_name': 'signup',
         'start_date': '2024-01-01',
@@ -628,7 +628,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -645,7 +645,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31')
+uri = URI('https://app.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -655,7 +655,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -670,7 +670,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31")
+    .get("https://app.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -682,7 +682,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -695,7 +695,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/events/properties23?event_name=signup&start_date=2024-01-01&end_date=2024-01-31");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -802,14 +802,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) (ti
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31" \
+curl -X GET "https://app.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31',
+  'https://app.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -825,7 +825,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/events/outbound23',
+    'https://app.rybbit.io/api/sites/1/events/outbound23',
     params={
         'start_date': '2024-01-01',
         'end_date': '2024-01-31'
@@ -841,7 +841,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -858,7 +858,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31')
+uri = URI('https://app.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -868,7 +868,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -883,7 +883,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31")
+    .get("https://app.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -895,7 +895,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -908,7 +908,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/events/outbound23?start_date=2024-01-01&end_date=2024-01-31");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>

--- a/docs/content/docs/api/stats/funnels.mdx
+++ b/docs/content/docs/api/stats/funnels.mdx
@@ -105,14 +105,14 @@ Returns all saved funnels for a site.
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/funnels23" \
+curl -X GET "https://app.rybbit.io/api/sites/1/funnels23" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/funnels23',
+  'https://app.rybbit.io/api/sites/1/funnels23',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -128,7 +128,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/funnels23',
+    'https://app.rybbit.io/api/sites/1/funnels23',
     headers={
         'Authorization': 'Bearer your_api_key_here'
     }
@@ -140,7 +140,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/funnels23');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/funnels23');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -157,7 +157,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/funnels23')
+uri = URI('https://app.rybbit.io/api/sites/1/funnels23')
 request = Net::HTTP::Get.new(uri)
 request['Authorization'] = 'Bearer your_api_key_here'
 
@@ -180,7 +180,7 @@ import (
 
 func main() {
     client := &http.Client{}
-    req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/funnels23", nil)
+    req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/funnels23", nil)
     req.Header.Set("Authorization", "Bearer your_api_key_here")
 
     resp, _ := client.Do(req)
@@ -201,7 +201,7 @@ use serde_json::Value;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = reqwest::Client::new();
     let response = client
-        .get("https://api.rybbit.io/api/sites/1/funnels23")
+        .get("https://app.rybbit.io/api/sites/1/funnels23")
         .header("Authorization", "Bearer your_api_key_here")
         .send()
         .await?;
@@ -220,7 +220,7 @@ import java.net.http.HttpResponse;
 
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/funnels23"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/funnels23"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -240,7 +240,7 @@ client.DefaultRequestHeaders.Authorization =
     new AuthenticationHeaderValue("Bearer", "your_api_key_here");
 
 var response = await client.GetAsync(
-    "https://api.rybbit.io/api/sites/1/funnels23");
+    "https://app.rybbit.io/api/sites/1/funnels23");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -393,7 +393,7 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) (ti
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X POST "https://api.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31" \
+curl -X POST "https://app.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31" \
   -H "Authorization: Bearer your_api_key_here" \
   -H "Content-Type: application/json" \
   -d '{
@@ -409,7 +409,7 @@ curl -X POST "https://api.rybbit.io/api/sites/1/funnels/analyze23?start_date=202
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31',
+  'https://app.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31',
   {
     method: 'POST',
     headers: {
@@ -435,7 +435,7 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    'https://api.rybbit.io/api/sites/1/funnels/analyze23',
+    'https://app.rybbit.io/api/sites/1/funnels/analyze23',
     params={
         'start_date': '2024-01-01',
         'end_date': '2024-01-31'
@@ -468,7 +468,7 @@ $body = [
 ];
 
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_POST, true);
 curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($body));
@@ -488,7 +488,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31')
+uri = URI('https://app.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31')
 request = Net::HTTP::Post.new(uri)
 request['Authorization'] = 'Bearer your_api_key_here'
 request['Content-Type'] = 'application/json'
@@ -531,7 +531,7 @@ func main() {
     jsonBody, _ := json.Marshal(body)
 
     client := &http.Client{}
-    req, _ := http.NewRequest("POST", "https://api.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31", bytes.NewBuffer(jsonBody))
+    req, _ := http.NewRequest("POST", "https://app.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31", bytes.NewBuffer(jsonBody))
     req.Header.Set("Authorization", "Bearer your_api_key_here")
     req.Header.Set("Content-Type", "application/json")
 
@@ -562,7 +562,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let client = reqwest::Client::new();
     let response = client
-        .post("https://api.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31")
+        .post("https://app.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31")
         .header("Authorization", "Bearer your_api_key_here")
         .header("Content-Type", "application/json")
         .json(&body)
@@ -594,7 +594,7 @@ String json = """
 
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31"))
     .header("Authorization", "Bearer your_api_key_here")
     .header("Content-Type", "application/json")
     .POST(HttpRequest.BodyPublishers.ofString(json))
@@ -633,7 +633,7 @@ var content = new StringContent(
     "application/json");
 
 var response = await client.PostAsync(
-    "https://api.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31",
+    "https://app.rybbit.io/api/sites/1/funnels/analyze23?start_date=2024-01-01&end_date=2024-01-31",
     content);
 var data = await response.Content.ReadAsStringAsync();
 ```
@@ -762,7 +762,7 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Get sessions that dropped off at step 2"
-curl -X POST "https://api.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1" \
+curl -X POST "https://app.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1" \
   -H "Authorization: Bearer your_api_key_here" \
   -H "Content-Type: application/json" \
   -d '{
@@ -777,7 +777,7 @@ curl -X POST "https://api.rybbit.io/api/sites/1/funnels/2/sessions23?mode=droppe
   <Tab value="JavaScript">
 ```javascript title="Get sessions that reached step 3"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/funnels/3/sessions23?mode=reached&page=1',
+  'https://app.rybbit.io/api/sites/1/funnels/3/sessions23?mode=reached&page=1',
   {
     method: 'POST',
     headers: {
@@ -802,7 +802,7 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    'https://api.rybbit.io/api/sites/1/funnels/2/sessions23',
+    'https://app.rybbit.io/api/sites/1/funnels/2/sessions23',
     params={
         'mode': 'dropped',
         'page': 1
@@ -833,7 +833,7 @@ $body = [
 ];
 
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_POST, true);
 curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($body));
@@ -853,7 +853,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1')
+uri = URI('https://app.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1')
 request = Net::HTTP::Post.new(uri)
 request['Authorization'] = 'Bearer your_api_key_here'
 request['Content-Type'] = 'application/json'
@@ -883,7 +883,7 @@ body := map[string]interface{}{
 }
 jsonBody, _ := json.Marshal(body)
 
-req, _ := http.NewRequest("POST", "https://api.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1", bytes.NewBuffer(jsonBody))
+req, _ := http.NewRequest("POST", "https://app.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1", bytes.NewBuffer(jsonBody))
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 req.Header.Set("Content-Type", "application/json")
 
@@ -907,7 +907,7 @@ let body = serde_json::json!({
 
 let client = reqwest::Client::new();
 let res = client
-    .post("https://api.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1")
+    .post("https://app.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1")
     .header("Authorization", "Bearer your_api_key_here")
     .json(&body)
     .send()
@@ -930,7 +930,7 @@ String json = """
 
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1"))
     .header("Authorization", "Bearer your_api_key_here")
     .header("Content-Type", "application/json")
     .POST(HttpRequest.BodyPublishers.ofString(json))
@@ -960,7 +960,7 @@ var content = new StringContent(
     "application/json");
 
 var response = await client.PostAsync(
-    "https://api.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1",
+    "https://app.rybbit.io/api/sites/1/funnels/2/sessions23?mode=dropped&page=1",
     content);
 var data = await response.Content.ReadAsStringAsync();
 ```
@@ -1061,7 +1061,7 @@ Creates or updates a saved funnel. If `reportId` is provided, updates the existi
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Create New Funnel"
-curl -X POST "https://api.rybbit.io/api/sites/1/funnels23" \
+curl -X POST "https://app.rybbit.io/api/sites/1/funnels23" \
   -H "Authorization: Bearer your_api_key_here" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1078,7 +1078,7 @@ curl -X POST "https://api.rybbit.io/api/sites/1/funnels23" \
   <Tab value="JavaScript">
 ```javascript title="Update Existing Funnel"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/funnels23',
+  'https://app.rybbit.io/api/sites/1/funnels23',
   {
     method: 'POST',
     headers: {
@@ -1106,7 +1106,7 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    'https://api.rybbit.io/api/sites/1/funnels23',
+    'https://app.rybbit.io/api/sites/1/funnels23',
     json={
         'name': 'Onboarding Funnel',
         'steps': [
@@ -1137,7 +1137,7 @@ $body = [
 ];
 
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/funnels23');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/funnels23');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_POST, true);
 curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($body));
@@ -1157,7 +1157,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/funnels23')
+uri = URI('https://app.rybbit.io/api/sites/1/funnels23')
 request = Net::HTTP::Post.new(uri)
 request['Authorization'] = 'Bearer your_api_key_here'
 request['Content-Type'] = 'application/json'
@@ -1191,7 +1191,7 @@ body := map[string]interface{}{
 }
 jsonBody, _ := json.Marshal(body)
 
-req, _ := http.NewRequest("POST", "https://api.rybbit.io/api/sites/1/funnels23", bytes.NewBuffer(jsonBody))
+req, _ := http.NewRequest("POST", "https://app.rybbit.io/api/sites/1/funnels23", bytes.NewBuffer(jsonBody))
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 req.Header.Set("Content-Type", "application/json")
 
@@ -1217,7 +1217,7 @@ let body = serde_json::json!({
 
 let client = reqwest::Client::new();
 let res = client
-    .post("https://api.rybbit.io/api/sites/1/funnels23")
+    .post("https://app.rybbit.io/api/sites/1/funnels23")
     .header("Authorization", "Bearer your_api_key_here")
     .json(&body)
     .send()
@@ -1242,7 +1242,7 @@ String json = """
 
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/funnels23"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/funnels23"))
     .header("Authorization", "Bearer your_api_key_here")
     .header("Content-Type", "application/json")
     .POST(HttpRequest.BodyPublishers.ofString(json))
@@ -1273,7 +1273,7 @@ var content = new StringContent(
     Encoding.UTF8,
     "application/json");
 
-var response = await client.PostAsync("https://api.rybbit.io/api/sites/1/funnels23", content);
+var response = await client.PostAsync("https://app.rybbit.io/api/sites/1/funnels23", content);
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -1336,14 +1336,14 @@ Deletes a saved funnel. This action cannot be undone.
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X DELETE "https://api.rybbit.io/api/sites/1/funnels/123" \
+curl -X DELETE "https://app.rybbit.io/api/sites/1/funnels/123" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/funnels/123',
+  'https://app.rybbit.io/api/sites/1/funnels/123',
   {
     method: 'DELETE',
     headers: {
@@ -1360,7 +1360,7 @@ const data = await response.json();
 import requests
 
 response = requests.delete(
-    'https://api.rybbit.io/api/sites/1/funnels/123',
+    'https://app.rybbit.io/api/sites/1/funnels/123',
     headers={
         'Authorization': 'Bearer your_api_key_here'
     }
@@ -1372,7 +1372,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/funnels/123');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/funnels/123');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
@@ -1390,7 +1390,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/funnels/123')
+uri = URI('https://app.rybbit.io/api/sites/1/funnels/123')
 request = Net::HTTP::Delete.new(uri)
 request['Authorization'] = 'Bearer your_api_key_here'
 
@@ -1403,7 +1403,7 @@ data = JSON.parse(response.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("DELETE", "https://api.rybbit.io/api/sites/1/funnels/123", nil)
+req, _ := http.NewRequest("DELETE", "https://app.rybbit.io/api/sites/1/funnels/123", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -1418,7 +1418,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .delete("https://api.rybbit.io/api/sites/1/funnels/123")
+    .delete("https://app.rybbit.io/api/sites/1/funnels/123")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -1430,7 +1430,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/funnels/123"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/funnels/123"))
     .header("Authorization", "Bearer your_api_key_here")
     .DELETE()
     .build();
@@ -1443,7 +1443,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.DeleteAsync("https://api.rybbit.io/api/sites/1/funnels/123");
+var response = await client.DeleteAsync("https://app.rybbit.io/api/sites/1/funnels/123");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>

--- a/docs/content/docs/api/stats/goals.mdx
+++ b/docs/content/docs/api/stats/goals.mdx
@@ -179,14 +179,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31" \
+curl -X GET "https://app.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31',
+  'https://app.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -202,7 +202,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/goals23',
+    'https://app.rybbit.io/api/sites/1/goals23',
     params={
         'start_date': '2024-01-01',
         'end_date': '2024-01-31'
@@ -220,7 +220,7 @@ data = response.json()
 <?php
 $ch = curl_init();
 
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -239,7 +239,7 @@ require 'net/http'
 require 'json'
 require 'uri'
 
-uri = URI('https://api.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31')
+uri = URI('https://app.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -261,7 +261,7 @@ import (
 )
 
 func main() {
-    url := "https://api.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31"
+    url := "https://app.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31"
 
     req, _ := http.NewRequest("GET", url, nil)
     req.Header.Add("Authorization", "Bearer your_api_key_here")
@@ -287,7 +287,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = reqwest::Client::new();
 
     let response = client
-        .get("https://api.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31")
+        .get("https://app.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31")
         .header("Authorization", "Bearer your_api_key_here")
         .send()
         .await?;
@@ -310,7 +310,7 @@ public class Main {
         HttpClient client = HttpClient.newHttpClient();
 
         HttpRequest request = HttpRequest.newBuilder()
-            .uri(URI.create("https://api.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31"))
+            .uri(URI.create("https://app.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31"))
             .header("Authorization", "Bearer your_api_key_here")
             .GET()
             .build();
@@ -338,7 +338,7 @@ class Program
         client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
         var response = await client.GetAsync(
-            "https://api.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31");
+            "https://app.rybbit.io/api/sites/1/goals23?start_date=2024-01-01&end_date=2024-01-31");
 
         var data = await response.Content.ReadAsStringAsync();
     }
@@ -512,14 +512,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10" \
+curl -X GET "https://app.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10',
+  'https://app.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -535,7 +535,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/goals/1/sessions23',
+    'https://app.rybbit.io/api/sites/1/goals/1/sessions23',
     params={
         'page': 1,
         'limit': 10
@@ -553,7 +553,7 @@ data = response.json()
 <?php
 $ch = curl_init();
 
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -572,7 +572,7 @@ require 'net/http'
 require 'json'
 require 'uri'
 
-uri = URI('https://api.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10')
+uri = URI('https://app.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -594,7 +594,7 @@ import (
 )
 
 func main() {
-    url := "https://api.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10"
+    url := "https://app.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10"
 
     req, _ := http.NewRequest("GET", url, nil)
     req.Header.Add("Authorization", "Bearer your_api_key_here")
@@ -620,7 +620,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = reqwest::Client::new();
 
     let response = client
-        .get("https://api.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10")
+        .get("https://app.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10")
         .header("Authorization", "Bearer your_api_key_here")
         .send()
         .await?;
@@ -643,7 +643,7 @@ public class Main {
         HttpClient client = HttpClient.newHttpClient();
 
         HttpRequest request = HttpRequest.newBuilder()
-            .uri(URI.create("https://api.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10"))
+            .uri(URI.create("https://app.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10"))
             .header("Authorization", "Bearer your_api_key_here")
             .GET()
             .build();
@@ -671,7 +671,7 @@ class Program
         client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
         var response = await client.GetAsync(
-            "https://api.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10");
+            "https://app.rybbit.io/api/sites/1/goals/1/sessions23?page=1&limit=10");
 
         var data = await response.Content.ReadAsStringAsync();
     }
@@ -810,7 +810,7 @@ Creates a new goal for tracking conversions.
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Path Goal"
-curl -X POST "https://api.rybbit.io/api/sites/1/goals23" \
+curl -X POST "https://app.rybbit.io/api/sites/1/goals23" \
   -H "Authorization: Bearer your_api_key_here" \
   -H "Content-Type: application/json" \
   -d '{
@@ -825,7 +825,7 @@ curl -X POST "https://api.rybbit.io/api/sites/1/goals23" \
   <Tab value="JavaScript">
 ```javascript title="Event Goal"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/goals23',
+  'https://app.rybbit.io/api/sites/1/goals23',
   {
     method: 'POST',
     headers: {
@@ -852,7 +852,7 @@ const data = await response.json();
 import requests
 
 response = requests.post(
-    'https://api.rybbit.io/api/sites/1/goals23',
+    'https://app.rybbit.io/api/sites/1/goals23',
     json={
         'name': 'Signup Complete',
         'goalType': 'path',
@@ -879,7 +879,7 @@ $body = [
 ];
 
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/goals23');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/goals23');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_POST, true);
 curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($body));
@@ -899,7 +899,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/goals23')
+uri = URI('https://app.rybbit.io/api/sites/1/goals23')
 request = Net::HTTP::Post.new(uri)
 request['Authorization'] = 'Bearer your_api_key_here'
 request['Content-Type'] = 'application/json'
@@ -927,7 +927,7 @@ body := map[string]interface{}{
 }
 jsonBody, _ := json.Marshal(body)
 
-req, _ := http.NewRequest("POST", "https://api.rybbit.io/api/sites/1/goals23", bytes.NewBuffer(jsonBody))
+req, _ := http.NewRequest("POST", "https://app.rybbit.io/api/sites/1/goals23", bytes.NewBuffer(jsonBody))
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 req.Header.Set("Content-Type", "application/json")
 
@@ -951,7 +951,7 @@ let body = serde_json::json!({
 
 let client = reqwest::Client::new();
 let res = client
-    .post("https://api.rybbit.io/api/sites/1/goals23")
+    .post("https://app.rybbit.io/api/sites/1/goals23")
     .header("Authorization", "Bearer your_api_key_here")
     .json(&body)
     .send()
@@ -974,7 +974,7 @@ String json = """
 
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/goals23"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/goals23"))
     .header("Authorization", "Bearer your_api_key_here")
     .header("Content-Type", "application/json")
     .POST(HttpRequest.BodyPublishers.ofString(json))
@@ -1000,7 +1000,7 @@ var content = new StringContent(
     Encoding.UTF8,
     "application/json");
 
-var response = await client.PostAsync("https://api.rybbit.io/api/sites/1/goals23", content);
+var response = await client.PostAsync("https://app.rybbit.io/api/sites/1/goals23", content);
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -1090,7 +1090,7 @@ Updates an existing goal.
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X PUT "https://api.rybbit.io/api/sites/1/goals/123" \
+curl -X PUT "https://app.rybbit.io/api/sites/1/goals/123" \
   -H "Authorization: Bearer your_api_key_here" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1105,7 +1105,7 @@ curl -X PUT "https://api.rybbit.io/api/sites/1/goals/123" \
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/goals/123',
+  'https://app.rybbit.io/api/sites/1/goals/123',
   {
     method: 'PUT',
     headers: {
@@ -1130,7 +1130,7 @@ const data = await response.json();
 import requests
 
 response = requests.put(
-    'https://api.rybbit.io/api/sites/1/goals/123',
+    'https://app.rybbit.io/api/sites/1/goals/123',
     json={
         'name': 'Signup Completed (Updated)',
         'goalType': 'path',
@@ -1157,7 +1157,7 @@ $body = [
 ];
 
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/goals/123');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/goals/123');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
 curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($body));
@@ -1177,7 +1177,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/goals/123')
+uri = URI('https://app.rybbit.io/api/sites/1/goals/123')
 request = Net::HTTP::Put.new(uri)
 request['Authorization'] = 'Bearer your_api_key_here'
 request['Content-Type'] = 'application/json'
@@ -1205,7 +1205,7 @@ body := map[string]interface{}{
 }
 jsonBody, _ := json.Marshal(body)
 
-req, _ := http.NewRequest("PUT", "https://api.rybbit.io/api/sites/1/goals/123", bytes.NewBuffer(jsonBody))
+req, _ := http.NewRequest("PUT", "https://app.rybbit.io/api/sites/1/goals/123", bytes.NewBuffer(jsonBody))
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 req.Header.Set("Content-Type", "application/json")
 
@@ -1229,7 +1229,7 @@ let body = serde_json::json!({
 
 let client = reqwest::Client::new();
 let res = client
-    .put("https://api.rybbit.io/api/sites/1/goals/123")
+    .put("https://app.rybbit.io/api/sites/1/goals/123")
     .header("Authorization", "Bearer your_api_key_here")
     .json(&body)
     .send()
@@ -1252,7 +1252,7 @@ String json = """
 
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/goals/123"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/goals/123"))
     .header("Authorization", "Bearer your_api_key_here")
     .header("Content-Type", "application/json")
     .PUT(HttpRequest.BodyPublishers.ofString(json))
@@ -1278,7 +1278,7 @@ var content = new StringContent(
     Encoding.UTF8,
     "application/json");
 
-var response = await client.PutAsync("https://api.rybbit.io/api/sites/1/goals/123", content);
+var response = await client.PutAsync("https://app.rybbit.io/api/sites/1/goals/123", content);
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -1341,14 +1341,14 @@ Deletes a goal. This action cannot be undone.
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X DELETE "https://api.rybbit.io/api/sites/1/goals/123" \
+curl -X DELETE "https://app.rybbit.io/api/sites/1/goals/123" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/goals/123',
+  'https://app.rybbit.io/api/sites/1/goals/123',
   {
     method: 'DELETE',
     headers: {
@@ -1365,7 +1365,7 @@ const data = await response.json();
 import requests
 
 response = requests.delete(
-    'https://api.rybbit.io/api/sites/1/goals/123',
+    'https://app.rybbit.io/api/sites/1/goals/123',
     headers={
         'Authorization': 'Bearer your_api_key_here'
     }
@@ -1377,7 +1377,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/goals/123');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/goals/123');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
@@ -1395,7 +1395,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/goals/123')
+uri = URI('https://app.rybbit.io/api/sites/1/goals/123')
 request = Net::HTTP::Delete.new(uri)
 request['Authorization'] = 'Bearer your_api_key_here'
 
@@ -1408,7 +1408,7 @@ data = JSON.parse(response.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("DELETE", "https://api.rybbit.io/api/sites/1/goals/123", nil)
+req, _ := http.NewRequest("DELETE", "https://app.rybbit.io/api/sites/1/goals/123", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -1423,7 +1423,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .delete("https://api.rybbit.io/api/sites/1/goals/123")
+    .delete("https://app.rybbit.io/api/sites/1/goals/123")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -1435,7 +1435,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/goals/123"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/goals/123"))
     .header("Authorization", "Bearer your_api_key_here")
     .DELETE()
     .build();
@@ -1448,7 +1448,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.DeleteAsync("https://api.rybbit.io/api/sites/1/goals/123");
+var response = await client.DeleteAsync("https://app.rybbit.io/api/sites/1/goals/123");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>

--- a/docs/content/docs/api/stats/misc.mdx
+++ b/docs/content/docs/api/stats/misc.mdx
@@ -122,14 +122,14 @@ Returns cohort-based retention analysis data. Users are grouped into cohorts bas
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/retention23?mode=week&range=90" \
+curl -X GET "https://app.rybbit.io/api/sites/1/retention23?mode=week&range=90" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/retention23?mode=week&range=90',
+  'https://app.rybbit.io/api/sites/1/retention23?mode=week&range=90',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -145,7 +145,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/retention23',
+    'https://app.rybbit.io/api/sites/1/retention23',
     params={
         'mode': 'week',
         'range': 90
@@ -161,7 +161,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/retention23?mode=week&range=90');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/retention23?mode=week&range=90');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -178,7 +178,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/retention23?mode=week&range=90')
+uri = URI('https://app.rybbit.io/api/sites/1/retention23?mode=week&range=90')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -188,7 +188,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/retention23?mode=week&range=90", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/retention23?mode=week&range=90", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -203,7 +203,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/retention23?mode=week&range=90")
+    .get("https://app.rybbit.io/api/sites/1/retention23?mode=week&range=90")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -215,7 +215,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/retention23?mode=week&range=90"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/retention23?mode=week&range=90"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -228,7 +228,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/retention23?mode=week&range=90");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/retention23?mode=week&range=90");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -387,14 +387,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31" \
+curl -X GET "https://app.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31',
+  'https://app.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -410,7 +410,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/journeys23',
+    'https://app.rybbit.io/api/sites/1/journeys23',
     params={
         'steps': 4,
         'limit': 20,
@@ -428,7 +428,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -445,7 +445,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31')
+uri = URI('https://app.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -455,7 +455,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -470,7 +470,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31")
+    .get("https://app.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -482,7 +482,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -495,7 +495,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/journeys23?steps=4&limit=20&start_date=2024-01-01&end_date=2024-01-31");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -540,7 +540,7 @@ You can filter journeys that include specific pages at specific steps:
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Filter journeys starting from homepage"
-curl -X GET "https://api.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D" \
+curl -X GET "https://app.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
@@ -549,7 +549,7 @@ curl -X GET "https://api.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7
 const stepFilters = JSON.stringify({ "0": "/" });
 
 const response = await fetch(
-  `https://api.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=${encodeURIComponent(stepFilters)}`,
+  `https://app.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=${encodeURIComponent(stepFilters)}`,
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -563,7 +563,7 @@ const response = await fetch(
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D',
+    'https://app.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D',
     headers={
         'Authorization': 'Bearer your_api_key_here'
     }
@@ -575,7 +575,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -592,7 +592,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D')
+uri = URI('https://app.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -602,7 +602,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -617,7 +617,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D")
+    .get("https://app.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -629,7 +629,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -642,7 +642,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/journeys23?steps=3&stepFilters=%7B%220%22%3A%22%2F%22%7D");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>

--- a/docs/content/docs/api/stats/overview.mdx
+++ b/docs/content/docs/api/stats/overview.mdx
@@ -97,14 +97,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) (ti
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York" \
+curl -X GET "https://app.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York',
+  'https://app.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -120,7 +120,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/123/overview',
+    'https://app.rybbit.io/api/sites/123/overview',
     params={
         'start_date': '2024-01-01',
         'end_date': '2024-01-31',
@@ -137,7 +137,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -154,7 +154,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York')
+uri = URI('https://app.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -164,7 +164,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -179,7 +179,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York")
+    .get("https://app.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -191,7 +191,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -204,7 +204,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/123/overview?start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -320,14 +320,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York" \
+curl -X GET "https://app.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York',
+  'https://app.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -343,7 +343,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/123/overview-bucketed',
+    'https://app.rybbit.io/api/sites/123/overview-bucketed',
     params={
         'bucket': 'day',
         'start_date': '2024-01-01',
@@ -361,7 +361,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -378,7 +378,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York')
+uri = URI('https://app.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -388,7 +388,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -403,7 +403,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York")
+    .get("https://app.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -415,7 +415,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -428,7 +428,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/123/overview-bucketed?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=America/New_York");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -575,14 +575,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10" \
+curl -X GET "https://app.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10',
+  'https://app.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -598,7 +598,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/123/metric',
+    'https://app.rybbit.io/api/sites/123/metric',
     params={
         'parameter': 'country',
         'start_date': '2024-01-01',
@@ -617,7 +617,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -634,7 +634,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10')
+uri = URI('https://app.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -644,7 +644,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -659,7 +659,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10")
+    .get("https://app.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -671,7 +671,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -684,7 +684,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/123/metric?parameter=country&start_date=2024-01-01&end_date=2024-01-31&time_zone=America/New_York&limit=10");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -783,14 +783,14 @@ Returns the count of unique active sessions within the specified time window. Us
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/123/live-user-count?minutes=5" \
+curl -X GET "https://app.rybbit.io/api/sites/123/live-user-count?minutes=5" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123/live-user-count?minutes=5',
+  'https://app.rybbit.io/api/sites/123/live-user-count?minutes=5',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -807,7 +807,7 @@ console.log(`Live visitors: ${count}`);
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/123/live-user-count',
+    'https://app.rybbit.io/api/sites/123/live-user-count',
     params={'minutes': 5},
     headers={
         'Authorization': 'Bearer your_api_key_here'
@@ -821,7 +821,7 @@ print(f"Live visitors: {data['count']}")
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123/live-user-count?minutes=5');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123/live-user-count?minutes=5');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -839,7 +839,7 @@ echo "Live visitors: " . $data['count'];
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123/live-user-count?minutes=5')
+uri = URI('https://app.rybbit.io/api/sites/123/live-user-count?minutes=5')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -850,7 +850,7 @@ puts "Live visitors: #{data['count']}"
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/123/live-user-count?minutes=5", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/123/live-user-count?minutes=5", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -866,7 +866,7 @@ fmt.Printf("Live visitors: %v\n", data["count"])
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/123/live-user-count?minutes=5")
+    .get("https://app.rybbit.io/api/sites/123/live-user-count?minutes=5")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -879,7 +879,7 @@ println!("Live visitors: {}", data["count"]);
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123/live-user-count?minutes=5"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123/live-user-count?minutes=5"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -892,7 +892,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/123/live-user-count?minutes=5");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/123/live-user-count?minutes=5");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -909,7 +909,7 @@ var data = await response.Content.ReadAsStringAsync();
 ```javascript title="Real-time Widget"
 async function updateLiveCount() {
   const response = await fetch(
-    'https://api.rybbit.io/api/sites/123/live-user-count?minutes=5',
+    'https://app.rybbit.io/api/sites/123/live-user-count?minutes=5',
     {
       headers: {
         'Authorization': 'Bearer your_api_key'

--- a/docs/content/docs/api/stats/performance.mdx
+++ b/docs/content/docs/api/stats/performance.mdx
@@ -117,14 +117,14 @@ Each metric (lcp, cls, inp, fcp, ttfb) includes the following percentiles:
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31" \
+curl -X GET "https://app.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31',
+  'https://app.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -140,7 +140,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/performance/overview23',
+    'https://app.rybbit.io/api/sites/1/performance/overview23',
     params={
         'start_date': '2024-01-01',
         'end_date': '2024-01-31'
@@ -156,7 +156,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -173,7 +173,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31')
+uri = URI('https://app.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -183,7 +183,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -198,7 +198,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31")
+    .get("https://app.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -210,7 +210,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -223,7 +223,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/performance/overview23?start_date=2024-01-01&end_date=2024-01-31");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -335,14 +335,14 @@ Each point includes all percentiles for each metric plus:
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC" \
+curl -X GET "https://app.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC',
+  'https://app.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -358,7 +358,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/performance/time-series23',
+    'https://app.rybbit.io/api/sites/1/performance/time-series23',
     params={
         'bucket': 'day',
         'start_date': '2024-01-01',
@@ -376,7 +376,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -393,7 +393,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC')
+uri = URI('https://app.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -403,7 +403,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -418,7 +418,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC")
+    .get("https://app.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -430,7 +430,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -443,7 +443,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/performance/time-series23?bucket=day&start_date=2024-01-01&end_date=2024-01-07&time_zone=UTC");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -606,14 +606,14 @@ Each object includes the dimension value plus all percentiles:
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10" \
+curl -X GET "https://app.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10',
+  'https://app.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -629,7 +629,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/performance/by-dimension23',
+    'https://app.rybbit.io/api/sites/1/performance/by-dimension23',
     params={
         'dimension': 'pathname',
         'sort_by': 'lcp_p75',
@@ -647,7 +647,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -664,7 +664,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10')
+uri = URI('https://app.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -674,7 +674,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -689,7 +689,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10")
+    .get("https://app.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -701,7 +701,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -714,7 +714,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/performance/by-dimension23?dimension=pathname&sort_by=lcp_p75&sort_order=desc&limit=10");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>

--- a/docs/content/docs/api/stats/sessions.mdx
+++ b/docs/content/docs/api/stats/sessions.mdx
@@ -195,14 +195,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31" \
+curl -X GET "https://app.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31',
+  'https://app.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -218,7 +218,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/sessions23',
+    'https://app.rybbit.io/api/sites/1/sessions23',
     params={
         'page': 1,
         'limit': 20,
@@ -236,7 +236,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -253,7 +253,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31')
+uri = URI('https://app.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -263,7 +263,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -278,7 +278,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31")
+    .get("https://app.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -290,7 +290,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -303,7 +303,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/sessions23?page=1&limit=20&start_date=2024-01-01&end_date=2024-01-31");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -468,14 +468,14 @@ Returns detailed information about a specific session including all events and p
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50" \
+curl -X GET "https://app.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50',
+  'https://app.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -491,7 +491,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/123/sessions/sess_abc123/123',
+    'https://app.rybbit.io/api/sites/123/sessions/sess_abc123/123',
     params={'limit': 50},
     headers={
         'Authorization': 'Bearer your_api_key_here'
@@ -504,7 +504,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -521,7 +521,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50')
+uri = URI('https://app.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -531,7 +531,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -546,7 +546,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50")
+    .get("https://app.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -558,7 +558,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -571,7 +571,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/123/sessions/sess_abc123/123?limit=50");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -699,14 +699,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) (ti
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31" \
+curl -X GET "https://app.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31',
+  'https://app.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -722,7 +722,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/session-locations23',
+    'https://app.rybbit.io/api/sites/1/session-locations23',
     params={
         'start_date': '2024-01-01',
         'end_date': '2024-01-31'
@@ -738,7 +738,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -755,7 +755,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31')
+uri = URI('https://app.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -765,7 +765,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -780,7 +780,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31")
+    .get("https://app.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -792,7 +792,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -805,7 +805,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/session-locations23?start_date=2024-01-01&end_date=2024-01-31");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>

--- a/docs/content/docs/api/stats/users.mdx
+++ b/docs/content/docs/api/stats/users.mdx
@@ -194,14 +194,14 @@ Accepts all [Common Parameters](/docs/api/getting-started#common-parameters) plu
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc" \
+curl -X GET "https://app.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc',
+  'https://app.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -217,7 +217,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/users23',
+    'https://app.rybbit.io/api/sites/1/users23',
     params={
         'page': 1,
         'page_size': 10,
@@ -235,7 +235,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -252,7 +252,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc')
+uri = URI('https://app.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -262,7 +262,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -277,7 +277,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc")
+    .get("https://app.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -289,7 +289,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -302,7 +302,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/users23?page=1&page_size=10&sort_by=last_seen&sort_order=desc");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -418,14 +418,14 @@ Returns the number of sessions per day for a specific user. Useful for visualizi
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York" \
+curl -X GET "https://app.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York',
+  'https://app.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -441,7 +441,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/1/users/session-count23',
+    'https://app.rybbit.io/api/sites/1/users/session-count23',
     params={
         'user_id': 'abc123def456',
         'time_zone': 'America/New_York'
@@ -457,7 +457,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -474,7 +474,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York')
+uri = URI('https://app.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -484,7 +484,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -499,7 +499,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York")
+    .get("https://app.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -511,7 +511,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -524,7 +524,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/1/users/session-count23?user_id=abc123def456&time_zone=America/New_York");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>
@@ -712,14 +712,14 @@ Returns detailed information about a specific user, including their profile trai
 <Tabs items={['cURL', 'JavaScript', 'Python', 'PHP', 'Ruby', 'Go', 'Rust', 'Java', '.NET']}>
   <Tab value="cURL">
 ```bash title="Request"
-curl -X GET "https://api.rybbit.io/api/sites/123/users/user@example.com/123" \
+curl -X GET "https://app.rybbit.io/api/sites/123/users/user@example.com/123" \
   -H "Authorization: Bearer your_api_key_here"
 ```
   </Tab>
   <Tab value="JavaScript">
 ```javascript title="Request"
 const response = await fetch(
-  'https://api.rybbit.io/api/sites/123/users/user@example.com/123',
+  'https://app.rybbit.io/api/sites/123/users/user@example.com/123',
   {
     headers: {
       'Authorization': 'Bearer your_api_key_here'
@@ -735,7 +735,7 @@ const data = await response.json();
 import requests
 
 response = requests.get(
-    'https://api.rybbit.io/api/sites/123/users/user@example.com/123',
+    'https://app.rybbit.io/api/sites/123/users/user@example.com/123',
     headers={
         'Authorization': 'Bearer your_api_key_here'
     }
@@ -747,7 +747,7 @@ data = response.json()
   <Tab value="PHP">
 ```php title="Request"
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://api.rybbit.io/api/sites/123/users/user@example.com/123');
+curl_setopt($ch, CURLOPT_URL, 'https://app.rybbit.io/api/sites/123/users/user@example.com/123');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer your_api_key_here'
@@ -764,7 +764,7 @@ $data = json_decode($response, true);
 require 'net/http'
 require 'json'
 
-uri = URI('https://api.rybbit.io/api/sites/123/users/user@example.com/123')
+uri = URI('https://app.rybbit.io/api/sites/123/users/user@example.com/123')
 req = Net::HTTP::Get.new(uri)
 req['Authorization'] = 'Bearer your_api_key_here'
 
@@ -774,7 +774,7 @@ data = JSON.parse(res.body)
   </Tab>
   <Tab value="Go">
 ```go title="Request"
-req, _ := http.NewRequest("GET", "https://api.rybbit.io/api/sites/123/users/user@example.com/123", nil)
+req, _ := http.NewRequest("GET", "https://app.rybbit.io/api/sites/123/users/user@example.com/123", nil)
 req.Header.Set("Authorization", "Bearer your_api_key_here")
 
 client := &http.Client{}
@@ -789,7 +789,7 @@ json.NewDecoder(resp.Body).Decode(&data)
 ```rust title="Request"
 let client = reqwest::Client::new();
 let res = client
-    .get("https://api.rybbit.io/api/sites/123/users/user@example.com/123")
+    .get("https://app.rybbit.io/api/sites/123/users/user@example.com/123")
     .header("Authorization", "Bearer your_api_key_here")
     .send()
     .await?;
@@ -801,7 +801,7 @@ let data: serde_json::Value = res.json().await?;
 ```java title="Request"
 HttpClient client = HttpClient.newHttpClient();
 HttpRequest request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.rybbit.io/api/sites/123/users/user@example.com/123"))
+    .uri(URI.create("https://app.rybbit.io/api/sites/123/users/user@example.com/123"))
     .header("Authorization", "Bearer your_api_key_here")
     .GET()
     .build();
@@ -814,7 +814,7 @@ HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.o
 using var client = new HttpClient();
 client.DefaultRequestHeaders.Add("Authorization", "Bearer your_api_key_here");
 
-var response = await client.GetAsync("https://api.rybbit.io/api/sites/123/users/user@example.com/123");
+var response = await client.GetAsync("https://app.rybbit.io/api/sites/123/users/user@example.com/123");
 var data = await response.Content.ReadAsStringAsync();
 ```
   </Tab>

--- a/docs/content/docs/script.mdx
+++ b/docs/content/docs/script.mdx
@@ -83,7 +83,7 @@ data-mask-patterns='["/users/*/settings", "/accounts/**", "/orders/*/details"]'
 
 ```html
 <script
-  src="https://api.rybbit.io/api/script.js"
+  src="https://app.rybbit.io/api/script.js"
   defer
   data-site-id="456"
   data-skip-patterns='["/admin/**", "/preview/*"]'

--- a/docs/content/docs/sdks/node.mdx
+++ b/docs/content/docs/sdks/node.mdx
@@ -31,7 +31,7 @@ const rybbit = new Rybbit(config: RybbitConfig);
 import { Rybbit } from "@rybbit/node";
 
 const rybbit = new Rybbit({
-  analyticsHost: "https://api.rybbit.io/api",
+  analyticsHost: "https://app.rybbit.io/api",
   siteId: "1",
   apiKey: "your-secret-api-key",
 });

--- a/docs/content/docs/sdks/web.mdx
+++ b/docs/content/docs/sdks/web.mdx
@@ -50,7 +50,7 @@ async rybbit.init(config: RybbitConfig): Promise<void>;
 import rybbit from "@rybbit/js";
 
 await rybbit.init({
-  analyticsHost: "https://api.rybbit.io/api",
+  analyticsHost: "https://app.rybbit.io/api",
   siteId: "1",
 });
 ```
@@ -329,7 +329,7 @@ Session replay includes privacy-focused defaults and configuration options:
 
 ```javascript
 await rybbit.init({
-  analyticsHost: "https://api.rybbit.io/api",
+  analyticsHost: "https://app.rybbit.io/api",
   siteId: "1",
   replayPrivacyConfig: {
     maskAllInputs: true, // Mask all input values (default: true)
@@ -468,7 +468,7 @@ rybbit.cleanup();
 // In React
 useEffect(() => {
   rybbit.init({
-    analyticsHost: "https://api.rybbit.io/api",
+    analyticsHost: "https://app.rybbit.io/api",
     siteId: "1",
   });
 


### PR DESCRIPTION
While integrating rybbit cloud via the js sdk, I found out the url is outdated.

This pr replaces the non-existent https://api.rybbit.io url in the docs with https://app.rybbit.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API endpoint documentation across all sections (Organizations, Sites, Stats, Sessions, Users, etc.) to use the new base URL domain.
  * Updated SDK initialization examples (Node.js and Web) to reference the new analytics host.
  * Updated script tag source URL in debugging documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->