### PR TITLE
Fix SiteCard content overflow by adjusting width for larger screens

### DIFF
--- a/client/src/components/SiteCard.tsx
+++ b/client/src/components/SiteCard.tsx
@@ -156,7 +156,7 @@ export function SiteCard({ siteId, domain, tags = [], allTags = [], onTagsUpdate
               </div>
             </div>
             <div className="flex flex-col sm:flex-row gap-2 sm:gap-4 items-start sm:items-center justify-between">
-              <div className="relative rounded-md w-[200px] h-[50px]">
+              <div className="relative rounded-md w-40 h-12.5">
                 <SiteSessionChart data={data?.data ?? []} />
                 {!hasData && (
                   <div className="absolute inset-0 flex items-center justify-center bg-white/70 dark:bg-neutral-900/70 backdrop-blur-sm">


### PR DESCRIPTION
## Changes
- Changed `sm:w-[250px]` to `sm:w-75` in `SiteCard.tsx` to prevent content overflow
- Changed `w-[200px]` to `w-40` in `SiteCard.tsx`  to prevent content overflow
- Changed `h-[50px]` to `h-12.5` in `SiteCard.tsx` to use Tailwind spacing instead of pixels.

## Problem
The content in SiteCard was overflowing with the fixed width of 250px on screens 640px and larger.

## Solution
Replaced the arbitrary pixel value with Tailwind's `w-75` utility class for better content fit on larger viewports.

## Files Modified
- `SiteCard.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "No data available" message that displays when site charts contain no data, providing clearer feedback to users about the status of their data.

* **Style**
  * Enhanced responsive design for site card charts with improved layout adjustments that adapt better across different screen sizes and device widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->