### PR TITLE
fix: return 429 for rate-limited API key requests

### DIFF
--- a/server/src/lib/auth-middleware.ts
+++ b/server/src/lib/auth-middleware.ts
@@ -51,6 +51,10 @@ export const requireAuth: AuthMiddleware = async (request, reply) => {
     return;
   }
 
+  if (apiKeyResult.rateLimited) {
+    return reply.status(429).send({ error: "Rate limit exceeded" });
+  }
+
   return reply.status(401).send({ error: "Unauthorized" });
 };
 
@@ -83,12 +87,17 @@ export const requireSiteAccess: AuthMiddleware = async (request, reply) => {
 
   // Check session-based access
   const hasAccess = await getUserHasAccessToSite(request, siteId);
-  if (!hasAccess) {
-    return reply.status(403).send({ error: "Forbidden" });
+  if (hasAccess) {
+    const session = await getSessionFromReq(request);
+    if (session?.user) request.user = session.user;
+    return;
   }
 
-  const session = await getSessionFromReq(request);
-  if (session?.user) request.user = session.user;
+  if (apiKeyResult.rateLimited) {
+    return reply.status(429).send({ error: "Rate limit exceeded" });
+  }
+
+  return reply.status(403).send({ error: "Forbidden" });
 };
 
 /**
@@ -108,12 +117,17 @@ export const requireSiteAdminAccess: AuthMiddleware = async (request, reply) => 
 
   // Check session-based admin access
   const hasAdminAccess = await getUserHasAdminAccessToSite(request, siteId);
-  if (!hasAdminAccess) {
-    return reply.status(403).send({ error: "Forbidden" });
+  if (hasAdminAccess) {
+    const session = await getSessionFromReq(request);
+    if (session?.user) request.user = session.user;
+    return;
   }
 
-  const session = await getSessionFromReq(request);
-  if (session?.user) request.user = session.user;
+  if (apiKeyResult.rateLimited) {
+    return reply.status(429).send({ error: "Rate limit exceeded" });
+  }
+
+  return reply.status(403).send({ error: "Forbidden" });
 };
 
 /**
@@ -137,6 +151,10 @@ export const allowPublicSiteAccess: AuthMiddleware = async (request, reply) => {
     return;
   }
 
+  if (apiKeyResult.rateLimited) {
+    return reply.status(429).send({ error: "Rate limit exceeded" });
+  }
+
   return reply.status(403).send({ error: "Forbidden" });
 };
 
@@ -157,12 +175,17 @@ export const requireOrgMember: AuthMiddleware = async (request, reply) => {
   }
 
   const isMember = await getUserIsInOrg(request, organizationId);
-  if (!isMember) {
-    return reply.status(403).send({ error: "Forbidden" });
+  if (isMember) {
+    const session = await getSessionFromReq(request);
+    if (session?.user) request.user = session.user;
+    return;
   }
 
-  const session = await getSessionFromReq(request);
-  if (session?.user) request.user = session.user;
+  if (apiKeyResult.rateLimited) {
+    return reply.status(429).send({ error: "Rate limit exceeded" });
+  }
+
+  return reply.status(403).send({ error: "Forbidden" });
 };
 
 /**
@@ -187,6 +210,9 @@ export const requireOrgAdminFromParams: AuthMiddleware = async (request, reply) 
   // Check session-based access - must be admin/owner of org
   const session = await getSessionFromReq(request);
   if (!session?.user?.id) {
+    if (apiKeyResult.rateLimited) {
+      return reply.status(429).send({ error: "Rate limit exceeded" });
+    }
     return reply.status(401).send({ error: "Unauthorized" });
   }
 

--- a/server/src/lib/auth-utils.ts
+++ b/server/src/lib/auth-utils.ts
@@ -164,7 +164,14 @@ export function invalidateSitesAccessCache(userId: string) {
   sitesAccessCache.del(`${userId}:false`);
 }
 
-export async function checkApiKey(req: FastifyRequest, options: { organizationId?: string; siteId?: string | number }) {
+/**
+ * Verify an API key from the request and check organization membership.
+ * Returns rateLimited flag when the key is rejected due to rate limiting.
+ */
+export async function checkApiKey(
+  req: FastifyRequest,
+  options: { organizationId?: string; siteId?: string | number }
+): Promise<{ valid: boolean; role: string | null; rateLimited?: boolean }> {
   // Check if a valid API key was provided
   // Priority: 1. Authorization: Bearer header (recommended), 2. Query parameter (testing only)
   const authHeader = req.headers["authorization"];
@@ -216,6 +223,11 @@ export async function checkApiKey(req: FastifyRequest, options: { organizationId
           }
         }
         return { valid: false, role: null };
+      }
+
+      // Check if the key was rejected due to rate limiting
+      if (!result.valid && result.error?.code === "RATE_LIMITED") {
+        return { valid: false, role: null, rateLimited: true };
       }
     } catch (error) {
       logger.error(error, "Error verifying API key");


### PR DESCRIPTION
## Summary
- `checkApiKey()` now distinguishes rate-limited keys from invalid keys via `rateLimited` flag
- All auth middleware returns HTTP 429 instead of generic 403 when API key is rate-limited

Fixes #858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication now enforces rate limits across all auth flows: requests that exceed limits receive HTTP 429 with an explanatory error.
  * Rate-limit checks are applied earlier and consistently, ensuring 429 responses are returned before other access checks and improving access decision consistency for authenticated sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->