### PR TITLE
feat: include hostname in pages metric for multi-domain sites

### DIFF
--- a/client/src/api/analytics/endpoints/overview.ts
+++ b/client/src/api/analytics/endpoints/overview.ts
@@ -33,6 +33,7 @@ export type GetOverviewBucketedResponse = {
 export type MetricResponse = {
   value: string;
   title?: string;
+  hostname?: string;
   count: number;
   percentage: number;
   pageviews?: number;

--- a/client/src/app/[site]/main/components/sections/Pages.tsx
+++ b/client/src/app/[site]/main/components/sections/Pages.tsx
@@ -49,7 +49,10 @@ export function Pages() {
               getValue={e => e.value}
               getKey={e => e.value}
               getLabel={e => truncateString(e.value, 50) || t("Other")}
-              getLink={e => `https://${siteMetadata?.domain}${e.value}`}
+              getLink={e => {
+                const host = e.hostname || siteMetadata?.domain;
+                return host ? `https://${host}${e.value}` : "#";
+              }}
               expanded={expanded}
               close={close}
             />
@@ -77,7 +80,10 @@ export function Pages() {
               getValue={e => e.value}
               getKey={e => e.value}
               getLabel={e => e.value || t("Other")}
-              getLink={e => `https://${siteMetadata?.domain}${e.value}`}
+              getLink={e => {
+                const host = e.hostname || siteMetadata?.domain;
+                return host ? `https://${host}${e.value}` : "#";
+              }}
               expanded={expanded}
               close={close}
             />
@@ -89,7 +95,10 @@ export function Pages() {
               getValue={e => e.value}
               getKey={e => e.value}
               getLabel={e => e.value || t("Other")}
-              getLink={e => `https://${siteMetadata?.domain}${e.value}`}
+              getLink={e => {
+                const host = e.hostname || siteMetadata?.domain;
+                return host ? `https://${host}${e.value}` : "#";
+              }}
               expanded={expanded}
               close={close}
             />

--- a/client/src/app/[site]/pages/components/PageListItem.tsx
+++ b/client/src/app/[site]/pages/components/PageListItem.tsx
@@ -71,7 +71,11 @@ export function PageListItem({ pageData, isLoading = false }: PageListItemProps)
   const isLoadingTrafficData = isPastMinutesMode ? isLoadingPastMinutes : isLoadingRegular;
 
   // External URL for the page
-  const pageUrl = siteMetadata?.domain ? `https://${siteMetadata.domain}${pageData.value}` : "";
+  const pageUrl = pageData.hostname
+    ? `https://${pageData.hostname}${pageData.value}`
+    : siteMetadata?.domain
+      ? `https://${siteMetadata.domain}${pageData.value}`
+      : "";
 
   // Fetch page metadata using TanStack Query
   const { data: metadata, isLoading: isLoadingMetadata, isError: isMetadataError } = usePageMetadata(pageUrl);

--- a/client/src/app/[site]/user/[userId]/components/UserTopPages.tsx
+++ b/client/src/app/[site]/user/[userId]/components/UserTopPages.tsx
@@ -34,7 +34,10 @@ export function UserTopPages({ userId }: { userId: string }) {
               getValue={e => e.value}
               getKey={e => e.value}
               getLabel={e => truncateString(e.value, 50) || "Other"}
-              getLink={e => `https://${siteMetadata?.domain}${e.value}`}
+              getLink={e => {
+                const host = e.hostname || siteMetadata?.domain;
+                return host ? `https://${host}${e.value}` : "#";
+              }}
               expanded={false}
               close={close}
               customFilters={[{ parameter: "user_id", value: [userId], type: "equals" }]}
@@ -51,7 +54,10 @@ export function UserTopPages({ userId }: { userId: string }) {
               getValue={e => e.value}
               getKey={e => e.value}
               getLabel={e => truncateString(e.value, 50) || "Other"}
-              getLink={e => `https://${siteMetadata?.domain}${e.value}`}
+              getLink={e => {
+                const host = e.hostname || siteMetadata?.domain;
+                return host ? `https://${host}${e.value}` : "#";
+              }}
               expanded={false}
               close={close}
               customFilters={[{ parameter: "user_id", value: [userId], type: "equals" }]}


### PR DESCRIPTION
Problem

  Pages view links use the site's main domain for all pages. For sites with subdomains, /user/123 links to example.com/user/123 instead of app.example.com/user/123. The hostname data already exists in
  ClickHouse but the API never returns it.

Relates to #522 

Changes

  - Server: Added anyHeavy(hostname) to pathname, entry_page, exit_page queries in getMetric.ts — returns the most frequent hostname per pathname
  - Client: Pages.tsx, PageListItem.tsx, UserTopPages.tsx now use e.hostname || siteMetadata.domain for link construction
  - Fully backward compatible — hostname is optional, single-domain sites unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analytics now include per-page hostname when available, enabling richer metric context in dashboards and exports.
  * Page links and external URL resolution (pages, entry/exit lists, user top pages, metadata fetching) now prefer per-page hostname and fall back to site domain, improving link accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->