### PR TITLE
Fix placeholder interpolation in event display names

### DIFF
--- a/client/src/lib/events.ts
+++ b/client/src/lib/events.ts
@@ -51,7 +51,7 @@ export function getEventDisplayName(item: EventLike, t?: TranslationFunction): s
     if (!values) return translated;
 
     return Object.entries(values).reduce(
-      (result, [placeholder, value]) => result.replaceAll(`{${placeholder}}`, value),
+      (result, [placeholder, value]) => result.replaceAll(`{${placeholder}}`, () => value),
       translated
     );
   };


### PR DESCRIPTION
`9d47eb9` fixed #875. However, both the timeline and the event list show `Copied "{text}"` without interpolating the placeholder. This pull request fixes this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal translation helper now supports runtime placeholder interpolation for translated text.
  * No immediate user-visible changes; enables future UI messages to include dynamic values without altering existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->