### PR TITLE
fix: default page param to 1 in funnel/goal step sessions

### DIFF
--- a/server/src/api/analytics/funnels/getFunnelStepSessions.ts
+++ b/server/src/api/analytics/funnels/getFunnelStepSessions.ts
@@ -259,7 +259,7 @@ export async function getFunnelStepSessions(req: FastifyRequest<GetFunnelStepSes
       query_params: {
         siteId: Number(siteId),
         limit: limit || 25,
-        offset: (page - 1) * (limit || 25),
+        offset: ((page || 1) - 1) * (limit || 25),
       },
     });
 

--- a/server/src/api/analytics/goals/getGoalSessions.ts
+++ b/server/src/api/analytics/goals/getGoalSessions.ts
@@ -166,7 +166,7 @@ export async function getGoalSessions(req: FastifyRequest<GetGoalSessionsRequest
       query_params: {
         siteId: Number(siteId),
         limit: limit || 25,
-        offset: (page - 1) * (limit || 25),
+        offset: ((page || 1) - 1) * (limit || 25),
       },
     });
 


### PR DESCRIPTION
## Summary

- Default `page` query parameter to `1` in `getFunnelStepSessions` and `getGoalSessions`
- Fixes 500 error when `page` is omitted from the query string

## Problem

Both endpoints compute the ClickHouse `OFFSET` as `(page - 1) * (limit || 25)`. When `page` is not provided, `undefined - 1` produces `NaN`, which ClickHouse rejects for the `{offset:Int32}` parameter, causing a 500 error.

Other paginated endpoints (e.g. `getSessions`) handle this gracefully. These two were missed.

## Changes

- `server/src/api/analytics/funnels/getFunnelStepSessions.ts`: `(page - 1)` → `((page || 1) - 1)`
- `server/src/api/analytics/goals/getGoalSessions.ts`: `(page - 1)` → `((page || 1) - 1)`

## Test plan

- [ ] Call `POST /api/sites/:siteId/funnels/:step/sessions` **without** `page` param → should return 200
- [ ] Call `GET /api/sites/:siteId/goals/:goalId/sessions` **without** `page` param → should return 200
- [ ] Verify pagination still works correctly when `page` is explicitly provided

Fixes #939

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination handling in funnel and goal analytics queries to gracefully handle missing page parameters, preventing errors and ensuring reliable data retrieval across analytics features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->