### PR TITLE
fix: remove exposed host ports from clickhouse and postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,6 @@ services:
       retries: 5
       start_period: 10s
     restart: unless-stopped
-    ports:
-      - "8123:8123"
 
   postgres:
     image: postgres:17.4
@@ -64,8 +62,6 @@ services:
       retries: 5
       start_period: 10s
     restart: unless-stopped
-    ports:
-      - "5432:5432"
 
   backend:
     image: ghcr.io/rybbit-io/rybbit-backend:${IMAGE_TAG:-latest}


### PR DESCRIPTION
The default docker-compose.yml exposes ClickHouse (8123) and Postgres (5432) to the host with no interface binding and because docker bypasses ufw rules by inserting its own rules in the docker chain, these ports are reachable from the internet on any VPS even when a firewall is configured. (Ask me how i know)

These services do not need port exposure because the backend connects to both via docker's internal network using container names (clickhouse, postgres).
Changes:

Removed ports: from clickhouse service
Removed ports: from postgres service

No breaking changes; the backend, client, and Caddy services are unaffected for general use as those who want to expose these db ports for external tooling can re-add them with a 127.0.0.1 bind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for database services. Port mappings have been adjusted to streamline the service infrastructure without affecting overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->