### PR TITLE
Fix timezone handling for current-day buckets

### DIFF
--- a/server/src/api/analytics/getOverviewBucketed.ts
+++ b/server/src/api/analytics/getOverviewBucketed.ts
@@ -20,7 +20,7 @@ function getTimeStatementFill(params: FilterParams, bucket: TimeBucket) {
       )
       TO if(
         toDate(${SqlString.escape(end_date)}) = toDate(now(), ${SqlString.escape(time_zone)}),
-        now(),
+        toTimeZone(now(), 'UTC'),
         toTimeZone(
           toDateTime(${TimeBucketToFn[validatedBucket]}(toDateTime(${SqlString.escape(end_date)}, ${SqlString.escape(
             time_zone

--- a/server/src/api/analytics/performance/getPerformanceTimeSeries.ts
+++ b/server/src/api/analytics/performance/getPerformanceTimeSeries.ts
@@ -20,7 +20,7 @@ function getTimeStatementFill(params: FilterParams, bucket: TimeBucket) {
       )
       TO if(
         toDate(${SqlString.escape(end_date)}) = toDate(now(), ${SqlString.escape(time_zone)}),
-        now(),
+        toTimeZone(now(), 'UTC'),
         toTimeZone(
           toDateTime(${TimeBucketToFn[validatedBucket]}(toDateTime(${SqlString.escape(end_date)}, ${SqlString.escape(
             time_zone

--- a/server/src/api/analytics/utils/utils.ts
+++ b/server/src/api/analytics/utils/utils.ts
@@ -38,7 +38,7 @@ export function getTimeStatement(
       )
       AND timestamp < if(
         toDate(${SqlString.escape(end_date)}) = toDate(now(), ${SqlString.escape(time_zone)}),
-        now(),
+        toTimeZone(now(), 'UTC'),
         toTimeZone(
           toStartOfDay(toDateTime(${SqlString.escape(end_date)}, ${SqlString.escape(time_zone)})) + INTERVAL 1 DAY,
           'UTC'


### PR DESCRIPTION
Fix incorrect handling of current-day time ranges for non-UTC timezones.

The API already buckets timestamps using toTimeZone(...), but the upper bound
for current-day queries used now() directly. This caused missing or truncated
current-hour buckets for timezones like Europe/Berlin.

This patch ensures that comparisons against timestamp remain in UTC by
replacing now() with toTimeZone(now(), 'UTC') in:

- getTimeStatementFill
- getTimeStatement

This keeps filtering consistent with stored UTC timestamps while preserving
timezone-aware bucketing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved timezone handling for analytics time-series queries: when reports include the current date, the system now normalizes the reference "current time" to a consistent timezone, ensuring accurate timestamp boundaries and more reliable metric results across time zones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->