### PR TITLE
Add approaching limit notification email functionality

### DIFF
--- a/client/src/components/SpinningGlobe.tsx
+++ b/client/src/components/SpinningGlobe.tsx
@@ -117,12 +117,24 @@ const SECONDS_PER_REVOLUTION = 120;
 const MAX_SPIN_ZOOM = 5;
 const SLOW_SPIN_ZOOM = 3;
 
+// Mapbox GL v3 requires WebGL 2 (globe projection + standard style won't run otherwise).
+function isWebGL2Supported(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const canvas = document.createElement("canvas");
+    return !!canvas.getContext("webgl2");
+  } catch {
+    return false;
+  }
+}
+
 export function SpinningGlobe() {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const markersMapRef = useRef<Map<string, MarkerData>>(new Map());
   const isUserInteractingRef = useRef(false);
   const [mapLoaded, setMapLoaded] = useState(false);
+  const [isSupported] = useState(isWebGL2Supported);
   const { configs, isLoading: isLoadingConfigs } = useConfigs();
 
   // Fetch demo sessions
@@ -141,23 +153,28 @@ export function SpinningGlobe() {
 
   // Initialize map
   useEffect(() => {
-    if (!containerRef.current || !configs?.mapboxToken || mapRef.current) {
+    if (!containerRef.current || !configs?.mapboxToken || mapRef.current || !isSupported) {
       return;
     }
 
     mapboxgl.accessToken = configs.mapboxToken;
 
-    const map = new mapboxgl.Map({
-      container: containerRef.current,
-      style: "mapbox://styles/mapbox/standard",
-      projection: { name: "globe" },
-      zoom: 1.5,
-      center: [0, 20],
-      pitch: 0,
-      bearing: 0,
-      antialias: true,
-      attributionControl: false,
-    });
+    let map: mapboxgl.Map;
+    try {
+      map = new mapboxgl.Map({
+        container: containerRef.current,
+        style: "mapbox://styles/mapbox/standard",
+        projection: { name: "globe" },
+        zoom: 1.5,
+        center: [0, 20],
+        pitch: 0,
+        bearing: 0,
+        antialias: true,
+        attributionControl: false,
+      });
+    } catch {
+      return;
+    }
 
     mapRef.current = map;
 
@@ -490,7 +507,7 @@ export function SpinningGlobe() {
     };
   }, [sessions, mapLoaded]);
 
-  if (isLoadingConfigs || !configs?.mapboxToken) {
+  if (isLoadingConfigs || !configs?.mapboxToken || !isSupported) {
     return null;
   }
 

--- a/server/drizzle/0004_bored_raider.sql
+++ b/server/drizzle/0004_bored_raider.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organization" ADD COLUMN "approachingLimitNotifiedPeriodStart" text;

--- a/server/drizzle/meta/0004_snapshot.json
+++ b/server/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,2881 @@
+{
+  "id": "d6b943a5-f0a1-489c-85a7-d1e6bfb2422f",
+  "prevId": "328c7e4d-157c-4d6b-b0b4-f2a1f3571518",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.active_sessions": {
+      "name": "active_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_regions": {
+      "name": "agent_regions",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_url": {
+          "name": "endpoint_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_healthy": {
+          "name": "is_healthy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refillInterval": {
+          "name": "refillInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refillAmount": {
+          "name": "refillAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRefillAt": {
+          "name": "lastRefillAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rateLimitEnabled": {
+          "name": "rateLimitEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rateLimitTimeWindow": {
+          "name": "rateLimitTimeWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rateLimitMax": {
+          "name": "rateLimitMax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestCount": {
+          "name": "requestCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRequest": {
+          "name": "lastRequest",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configId": {
+          "name": "configId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_referenceId_user_id_fk": {
+          "name": "apikey_referenceId_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "referenceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cancellation_feedback": {
+      "name": "cancellation_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_details": {
+          "name": "reason_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retention_offer_shown": {
+          "name": "retention_offer_shown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retention_offer_accepted": {
+          "name": "retention_offer_accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_name_at_cancellation": {
+          "name": "plan_name_at_cancellation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_event_count_at_cancellation": {
+          "name": "monthly_event_count_at_cancellation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnels": {
+      "name": "funnels",
+      "schema": "",
+      "columns": {
+        "report_id": {
+          "name": "report_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "funnels_site_id_sites_site_id_fk": {
+          "name": "funnels_site_id_sites_site_id_fk",
+          "tableFrom": "funnels",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "funnels_user_id_user_id_fk": {
+          "name": "funnels_user_id_user_id_fk",
+          "tableFrom": "funnels",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "goal_id": {
+          "name": "goal_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_type": {
+          "name": "goal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goals_site_id_sites_site_id_fk": {
+          "name": "goals_site_id_sites_site_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gsc_connections": {
+      "name": "gsc_connections",
+      "schema": "",
+      "columns": {
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsc_property_url": {
+          "name": "gsc_property_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gsc_connections_site_id_sites_site_id_fk": {
+          "name": "gsc_connections_site_id_sites_site_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.import_status": {
+      "name": "import_status",
+      "schema": "",
+      "columns": {
+        "import_id": {
+          "name": "import_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "import_platform_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_events": {
+          "name": "imported_events",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_events": {
+          "name": "skipped_events",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "invalid_events": {
+          "name": "invalid_events",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "import_status_site_id_sites_site_id_fk": {
+          "name": "import_status_site_id_sites_site_id_fk",
+          "tableFrom": "import_status",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "import_status_organization_id_organization_id_fk": {
+          "name": "import_status_organization_id_organization_id_fk",
+          "tableFrom": "import_status",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviterId": {
+          "name": "inviterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_restricted_site_access": {
+          "name": "has_restricted_site_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "site_ids": {
+          "name": "site_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_inviterId_user_id_fk": {
+          "name": "invitation_inviterId_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitation_organizationId_organization_id_fk": {
+          "name": "invitation_organizationId_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitation_teamId_team_id_fk": {
+          "name": "invitation_teamId_team_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "team",
+          "columnsFrom": [
+            "teamId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_restricted_site_access": {
+          "name": "has_restricted_site_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organizationId_organization_id_fk": {
+          "name": "member_organizationId_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "member_userId_user_id_fk": {
+          "name": "member_userId_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_site_access": {
+      "name": "member_site_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "member_site_access_member_idx": {
+          "name": "member_site_access_member_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_site_access_site_idx": {
+          "name": "member_site_access_site_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_site_access_member_id_member_id_fk": {
+          "name": "member_site_access_member_id_member_id_fk",
+          "tableFrom": "member_site_access",
+          "tableTo": "member",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_site_access_site_id_sites_site_id_fk": {
+          "name": "member_site_access_site_id_sites_site_id_fk",
+          "tableFrom": "member_site_access",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_site_access_created_by_user_id_fk": {
+          "name": "member_site_access_created_by_user_id_fk",
+          "tableFrom": "member_site_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member_site_access_unique": {
+          "name": "member_site_access_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id",
+            "site_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_channels": {
+      "name": "notification_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monitor_ids": {
+          "name": "monitor_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_events": {
+          "name": "trigger_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"down\",\"recovery\"]'::jsonb"
+        },
+        "cooldown_minutes": {
+          "name": "cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "last_notified_at": {
+          "name": "last_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_channels_organization_id_organization_id_fk": {
+          "name": "notification_channels_organization_id_organization_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_channels_created_by_user_id_fk": {
+          "name": "notification_channels_created_by_user_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthlyEventCount": {
+          "name": "monthlyEventCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "overMonthlyLimit": {
+          "name": "overMonthlyLimit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "approachingLimitNotifiedPeriodStart": {
+          "name": "approachingLimitNotifiedPeriodStart",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planOverride": {
+          "name": "planOverride",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_plan": {
+          "name": "custom_plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonatedBy": {
+          "name": "impersonatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeOrganizationId": {
+          "name": "activeOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeTeamId": {
+          "name": "activeTeamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "saltUserIds": {
+          "name": "saltUserIds",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "blockBots": {
+          "name": "blockBots",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "excluded_ips": {
+          "name": "excluded_ips",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "excluded_countries": {
+          "name": "excluded_countries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "sessionReplay": {
+          "name": "sessionReplay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "webVitals": {
+          "name": "webVitals",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "trackErrors": {
+          "name": "trackErrors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "trackOutbound": {
+          "name": "trackOutbound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "trackUrlParams": {
+          "name": "trackUrlParams",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "trackInitialPageView": {
+          "name": "trackInitialPageView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "trackSpaNavigation": {
+          "name": "trackSpaNavigation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "trackIp": {
+          "name": "trackIp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "trackButtonClicks": {
+          "name": "trackButtonClicks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "trackCopy": {
+          "name": "trackCopy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "trackFormInteractions": {
+          "name": "trackFormInteractions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_link_key": {
+          "name": "private_link_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sites_created_by_user_id_fk": {
+          "name": "sites_created_by_user_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sites_organization_id_organization_id_fk": {
+          "name": "sites_organization_id_organization_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_organizationId_organization_id_fk": {
+          "name": "team_organizationId_organization_id_fk",
+          "tableFrom": "team",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teamMember": {
+      "name": "teamMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teamMember_teamId_team_id_fk": {
+          "name": "teamMember_teamId_team_id_fk",
+          "tableFrom": "teamMember",
+          "tableTo": "team",
+          "columnsFrom": [
+            "teamId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teamMember_userId_user_id_fk": {
+          "name": "teamMember_userId_user_id_fk",
+          "tableFrom": "teamMember",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_site_access": {
+      "name": "team_site_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_site_access_team_idx": {
+          "name": "team_site_access_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_site_access_site_idx": {
+          "name": "team_site_access_site_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_site_access_team_id_team_id_fk": {
+          "name": "team_site_access_team_id_team_id_fk",
+          "tableFrom": "team_site_access",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_site_access_site_id_sites_site_id_fk": {
+          "name": "team_site_access_site_id_sites_site_id_fk",
+          "tableFrom": "team_site_access",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_site_access_unique": {
+          "name": "team_site_access_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_id",
+            "site_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telemetry": {
+      "name": "telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_counts": {
+          "name": "table_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clickhouse_size_gb": {
+          "name": "clickhouse_size_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uptime_alert_history": {
+      "name": "uptime_alert_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alert_data": {
+          "name": "alert_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "uptime_alert_history_alert_id_uptime_alerts_id_fk": {
+          "name": "uptime_alert_history_alert_id_uptime_alerts_id_fk",
+          "tableFrom": "uptime_alert_history",
+          "tableTo": "uptime_alerts",
+          "columnsFrom": [
+            "alert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "uptime_alert_history_monitor_id_uptime_monitors_id_fk": {
+          "name": "uptime_alert_history_monitor_id_uptime_monitors_id_fk",
+          "tableFrom": "uptime_alert_history",
+          "tableTo": "uptime_monitors",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uptime_alerts": {
+      "name": "uptime_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_config": {
+          "name": "alert_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "uptime_alerts_monitor_id_uptime_monitors_id_fk": {
+          "name": "uptime_alerts_monitor_id_uptime_monitors_id_fk",
+          "tableFrom": "uptime_alerts",
+          "tableTo": "uptime_monitors",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uptime_incidents": {
+      "name": "uptime_incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "acknowledged_by": {
+          "name": "acknowledged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_type": {
+          "name": "last_error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "uptime_incidents_organization_id_organization_id_fk": {
+          "name": "uptime_incidents_organization_id_organization_id_fk",
+          "tableFrom": "uptime_incidents",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "uptime_incidents_monitor_id_uptime_monitors_id_fk": {
+          "name": "uptime_incidents_monitor_id_uptime_monitors_id_fk",
+          "tableFrom": "uptime_incidents",
+          "tableTo": "uptime_monitors",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uptime_incidents_acknowledged_by_user_id_fk": {
+          "name": "uptime_incidents_acknowledged_by_user_id_fk",
+          "tableFrom": "uptime_incidents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "acknowledged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "uptime_incidents_resolved_by_user_id_fk": {
+          "name": "uptime_incidents_resolved_by_user_id_fk",
+          "tableFrom": "uptime_incidents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uptime_monitor_status": {
+      "name": "uptime_monitor_status",
+      "schema": "",
+      "columns": {
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_check_at": {
+          "name": "next_check_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_status": {
+          "name": "current_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "consecutive_successes": {
+          "name": "consecutive_successes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "uptime_percentage_24h": {
+          "name": "uptime_percentage_24h",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uptime_percentage_7d": {
+          "name": "uptime_percentage_7d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uptime_percentage_30d": {
+          "name": "uptime_percentage_30d",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_response_time_24h": {
+          "name": "average_response_time_24h",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uptime_monitor_status_updated_at_idx": {
+          "name": "uptime_monitor_status_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uptime_monitor_status_monitor_id_uptime_monitors_id_fk": {
+          "name": "uptime_monitor_status_monitor_id_uptime_monitors_id_fk",
+          "tableFrom": "uptime_monitor_status",
+          "tableTo": "uptime_monitors",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "uptime_monitor_status_current_status_check": {
+          "name": "uptime_monitor_status_current_status_check",
+          "value": "current_status IN ('up', 'down', 'unknown')"
+        },
+        "uptime_monitor_status_uptime_24h_check": {
+          "name": "uptime_monitor_status_uptime_24h_check",
+          "value": "uptime_percentage_24h >= 0 AND uptime_percentage_24h <= 100"
+        },
+        "uptime_monitor_status_uptime_7d_check": {
+          "name": "uptime_monitor_status_uptime_7d_check",
+          "value": "uptime_percentage_7d >= 0 AND uptime_percentage_7d <= 100"
+        },
+        "uptime_monitor_status_uptime_30d_check": {
+          "name": "uptime_monitor_status_uptime_30d_check",
+          "value": "uptime_percentage_30d >= 0 AND uptime_percentage_30d <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.uptime_monitors": {
+      "name": "uptime_monitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitor_type": {
+          "name": "monitor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "http_config": {
+          "name": "http_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tcp_config": {
+          "name": "tcp_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_rules": {
+          "name": "validation_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "monitoring_type": {
+          "name": "monitoring_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "selected_regions": {
+          "name": "selected_regions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[\"local\"]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "uptime_monitors_organization_id_organization_id_fk": {
+          "name": "uptime_monitors_organization_id_organization_id_fk",
+          "tableFrom": "uptime_monitors",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "uptime_monitors_created_by_user_id_fk": {
+          "name": "uptime_monitors_created_by_user_id_fk",
+          "tableFrom": "uptime_monitors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "displayUsername": {
+          "name": "displayUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overMonthlyLimit": {
+          "name": "overMonthlyLimit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "monthlyEventCount": {
+          "name": "monthlyEventCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "sendAutoEmailReports": {
+          "name": "sendAutoEmailReports",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "scheduled_tip_email_ids": {
+          "name": "scheduled_tip_email_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_aliases": {
+      "name": "user_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_aliases_user_idx": {
+          "name": "user_aliases_user_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_aliases_anon_idx": {
+          "name": "user_aliases_anon_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_aliases_site_id_sites_site_id_fk": {
+          "name": "user_aliases_site_id_sites_site_id_fk",
+          "tableFrom": "user_aliases",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_aliases_site_anon_unique": {
+          "name": "user_aliases_site_anon_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "site_id",
+            "anonymous_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "site_id": {
+          "name": "site_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_profiles_site_idx": {
+          "name": "user_profiles_site_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_site_id_sites_site_id_fk": {
+          "name": "user_profiles_site_id_sites_site_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "site_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_profiles_site_id_user_id_pk": {
+          "name": "user_profiles_site_id_user_id_pk",
+          "columns": [
+            "site_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.import_platform_enum": {
+      "name": "import_platform_enum",
+      "schema": "public",
+      "values": [
+        "umami",
+        "simple_analytics"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1774763742452,
       "tag": "0003_nice_xavin",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1777182754960,
+      "tag": "0004_bored_raider",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/postgres/schema.ts
+++ b/server/src/db/postgres/schema.ts
@@ -138,6 +138,7 @@ export const organization = pgTable(
     stripeCustomerId: text(),
     monthlyEventCount: integer().default(0),
     overMonthlyLimit: boolean().default(false),
+    approachingLimitNotifiedPeriodStart: text(),
     planOverride: text(), // Plan name override (e.g., "pro1m", "standard500k")
     customPlan: jsonb("custom_plan").$type<{
       events: number;

--- a/server/src/lib/email/email.ts
+++ b/server/src/lib/email/email.ts
@@ -1,6 +1,7 @@
 import { Resend } from "resend";
 import { render } from "@react-email/components";
 import { IS_CLOUD } from "../const.js";
+import { ApproachingLimitEmail } from "./templates/ApproachingLimitEmail.js";
 import { InvitationEmail } from "./templates/InvitationEmail.js";
 import { LimitExceededEmail } from "./templates/LimitExceededEmail.js";
 import { OnboardingTipEmail } from "./templates/OnboardingTipEmail.js";
@@ -175,6 +176,26 @@ export const sendLimitExceededEmail = async (
   );
 
   await sendEmail(email, `Action Required: ${organizationName} has exceeded its monthly event limit`, html);
+};
+
+export const sendApproachingLimitEmail = async (
+  email: string,
+  organizationName: string,
+  eventCount: number,
+  eventLimit: number
+) => {
+  const upgradeLink = "https://app.rybbit.io/settings/subscription";
+
+  const html = await render(
+    ApproachingLimitEmail({
+      organizationName,
+      eventCount,
+      eventLimit,
+      upgradeLink,
+    })
+  );
+
+  await sendEmail(email, `${organizationName} is approaching its monthly event limit`, html);
 };
 
 export const sendWeeklyReportEmail = async (

--- a/server/src/lib/email/templates/ApproachingLimitEmail.tsx
+++ b/server/src/lib/email/templates/ApproachingLimitEmail.tsx
@@ -13,25 +13,26 @@ import {
 } from "@react-email/components";
 import * as React from "react";
 
-interface LimitExceededEmailProps {
+interface ApproachingLimitEmailProps {
   organizationName: string;
   eventCount: number;
   eventLimit: number;
   upgradeLink: string;
 }
 
-export const LimitExceededEmail = ({
+export const ApproachingLimitEmail = ({
   organizationName,
   eventCount,
   eventLimit,
   upgradeLink,
-}: LimitExceededEmailProps) => {
+}: ApproachingLimitEmailProps) => {
   const currentYear = new Date().getFullYear();
+  const usagePercent = Math.min(100, Math.round((eventCount / eventLimit) * 100));
 
   return (
     <Html>
       <Head />
-      <Preview>{organizationName} has exceeded its monthly event limit</Preview>
+      <Preview>{organizationName} is approaching its monthly event limit</Preview>
       <Tailwind
         config={{
           presets: [pixelBasedPreset],
@@ -60,18 +61,20 @@ export const LimitExceededEmail = ({
             <Text className="text-darkText text-base leading-relaxed mb-4">Hi there,</Text>
 
             <Text className="text-darkText text-base leading-relaxed mb-4">
-              Your organization <span className="font-semibold">{organizationName}</span> has exceeded its monthly event
-              limit.
+              Your organization <span className="font-semibold">{organizationName}</span> is on track to exceed its
+              monthly event limit before the end of the month.
             </Text>
 
             <Text className="text-darkText text-base leading-relaxed mb-4">
-              Current usage: <span className="font-semibold">{eventCount.toLocaleString()}</span> events
+              Current usage: <span className="font-semibold">{eventCount.toLocaleString()}</span> events ({usagePercent}
+              %)
               <br />
               Monthly limit: <span className="font-semibold">{eventLimit.toLocaleString()}</span> events
             </Text>
 
             <Text className="text-darkText text-base leading-relaxed mb-4">
-              Analytics tracking has been paused. To resume tracking and access your data, upgrade your plan:
+              Once you reach your limit, analytics tracking will be paused until your plan resets or you upgrade.
+              Upgrading now keeps your data flowing without interruption.
             </Text>
 
             <Text className="text-darkText text-base leading-relaxed mb-4">

--- a/server/src/lib/email/templates/InvitationEmail.tsx
+++ b/server/src/lib/email/templates/InvitationEmail.tsx
@@ -1,12 +1,12 @@
 import {
   Body,
-  Button,
   Container,
   Head,
-  Heading,
+  Hr,
   Html,
+  Img,
+  Link,
   Preview,
-  Section,
   Text,
   Tailwind,
   pixelBasedPreset,
@@ -26,7 +26,7 @@ export const InvitationEmail = ({ email, invitedBy, organizationName, inviteLink
   return (
     <Html>
       <Head />
-      <Preview>You're Invited to Join {organizationName} on Rybbit</Preview>
+      <Preview>You're invited to join {organizationName} on Rybbit</Preview>
       <Tailwind
         config={{
           presets: [pixelBasedPreset],
@@ -34,8 +34,6 @@ export const InvitationEmail = ({ email, invitedBy, organizationName, inviteLink
             extend: {
               colors: {
                 brand: "#10b981",
-                lightBg: "#ffffff",
-                cardBg: "#f9fafb",
                 darkText: "#111827",
                 mutedText: "#6b7280",
                 borderColor: "#e5e7eb",
@@ -44,41 +42,39 @@ export const InvitationEmail = ({ email, invitedBy, organizationName, inviteLink
           },
         }}
       >
-        <Body className="bg-lightBg font-sans">
-          <Container className="mx-auto py-10 px-6 max-w-[600px]">
-            <Section className="text-center">
-              <div className="inline-block bg-brand/10 text-brand px-3 py-1.5 rounded-full text-sm font-medium mb-4">
-                New Invitation
-              </div>
-              <Heading className="text-darkText text-3xl font-semibold mb-6">You've Been Invited!</Heading>
-            </Section>
+        <Body className="bg-white font-sans">
+          <Container className="mx-auto py-8 px-6 max-w-[600px]">
+            <Img
+              src="https://app.rybbit.io/rybbit/horizontal_black.svg"
+              alt="Rybbit"
+              width="120"
+              height="28"
+              className="mb-8"
+            />
 
-            <Section className="mb-8">
-              <Text className="text-darkText text-base leading-relaxed mb-4">
-                {invitedBy} has invited you to join <span className="font-bold text-brand">{organizationName}</span> on
-                Rybbit Analytics.
-              </Text>
-              <Text className="text-darkText text-base leading-relaxed">
-                Rybbit is an open-source analytics platform that helps you understand your website traffic while
-                respecting user privacy.
-              </Text>
-            </Section>
+            <Text className="text-darkText text-base leading-relaxed mb-4">Hi there,</Text>
 
-            <Section className="text-center mb-10">
-              <Button
-                href={inviteLink}
-                className="bg-brand text-white px-8 py-3 rounded-md font-bold text-base no-underline inline-block"
-              >
-                Accept Invitation
-              </Button>
-            </Section>
+            <Text className="text-darkText text-base leading-relaxed mb-4">
+              {invitedBy} has invited you to join <span className="font-semibold">{organizationName}</span> on Rybbit
+              Analytics.
+            </Text>
 
-            <Section className="text-center border-t border-borderColor pt-5">
-              <Text className="text-mutedText text-xs mb-2">
-                This invitation was sent to <span className="text-brand">{email}</span>.
-              </Text>
-              <Text className="text-mutedText text-xs">© {currentYear} Rybbit Analytics</Text>
-            </Section>
+            <Text className="text-darkText text-base leading-relaxed mb-4">
+              Rybbit is an open-source analytics platform that helps you understand your website traffic while
+              respecting user privacy.
+            </Text>
+
+            <Text className="text-darkText text-base leading-relaxed mb-4">
+              <Link href={inviteLink} className="text-brand underline">
+                Accept the invitation
+              </Link>
+            </Text>
+
+            <Text className="text-mutedText text-sm leading-relaxed">This invitation was sent to {email}.</Text>
+
+            <Hr className="border-borderColor my-8" />
+
+            <Text className="text-mutedText text-xs">© {currentYear} Rybbit Analytics</Text>
           </Container>
         </Body>
       </Tailwind>

--- a/server/src/lib/email/templates/OtpEmail.tsx
+++ b/server/src/lib/email/templates/OtpEmail.tsx
@@ -2,8 +2,9 @@ import {
   Body,
   Container,
   Head,
-  Heading,
+  Hr,
   Html,
+  Img,
   Preview,
   Section,
   Text,
@@ -23,26 +24,22 @@ const getContent = (type: OtpEmailType) => {
   switch (type) {
     case "sign-in":
       return {
-        preview: "Your Rybbit Sign-In Code",
-        heading: "Your Sign-In Code",
+        preview: "Your Rybbit sign-in code",
         description: "Here is your one-time password to sign in to Rybbit:",
       };
     case "email-verification":
       return {
-        preview: "Verify Your Email Address",
-        heading: "Verify Your Email",
+        preview: "Verify your email address",
         description: "Here is your verification code for Rybbit:",
       };
     case "forget-password":
       return {
-        preview: "Reset Your Password",
-        heading: "Reset Your Password",
+        preview: "Reset your password",
         description: "You requested to reset your password for Rybbit. Here is your one-time password:",
       };
     case "change-email":
       return {
-        preview: "Change Your Email Address",
-        heading: "Change Your Email",
+        preview: "Change your email address",
         description: "Here is your verification code for Rybbit:",
       };
   }
@@ -63,7 +60,6 @@ export const OtpEmail = ({ otp, type }: OtpEmailProps) => {
             extend: {
               colors: {
                 brand: "#10b981",
-                lightBg: "#ffffff",
                 cardBg: "#f9fafb",
                 darkText: "#111827",
                 mutedText: "#6b7280",
@@ -73,15 +69,19 @@ export const OtpEmail = ({ otp, type }: OtpEmailProps) => {
           },
         }}
       >
-        <Body className="bg-lightBg font-sans">
-          <Container className="mx-auto py-10 px-6 max-w-[600px]">
-            <Section className="text-center">
-              <Heading className="text-darkText text-3xl font-semibold mb-6">{content?.heading}</Heading>
-            </Section>
+        <Body className="bg-white font-sans">
+          <Container className="mx-auto py-8 px-6 max-w-[600px]">
+            <Img
+              src="https://app.rybbit.io/rybbit/horizontal_black.svg"
+              alt="Rybbit"
+              width="120"
+              height="28"
+              className="mb-8"
+            />
 
-            <Section className="mb-6">
-              <Text className="text-darkText text-base leading-relaxed mb-4">{content?.description}</Text>
-            </Section>
+            <Text className="text-darkText text-base leading-relaxed mb-4">Hi there,</Text>
+
+            <Text className="text-darkText text-base leading-relaxed mb-4">{content?.description}</Text>
 
             <Section className="text-center mb-6">
               <div className="bg-cardBg py-5 px-6 rounded-md inline-block">
@@ -89,16 +89,14 @@ export const OtpEmail = ({ otp, type }: OtpEmailProps) => {
               </div>
             </Section>
 
-            <Section className="mb-8">
-              <Text className="text-mutedText text-sm leading-relaxed">This code will expire in 5 minutes.</Text>
-              <Text className="text-mutedText text-sm leading-relaxed">
-                If you didn't request this code, you can safely ignore this email.
-              </Text>
-            </Section>
+            <Text className="text-mutedText text-sm leading-relaxed mb-2">This code will expire in 5 minutes.</Text>
+            <Text className="text-mutedText text-sm leading-relaxed">
+              If you didn't request this code, you can safely ignore this email.
+            </Text>
 
-            <Section className="text-center border-t border-borderColor pt-5">
-              <Text className="text-mutedText text-xs">© {currentYear} Rybbit Analytics</Text>
-            </Section>
+            <Hr className="border-borderColor my-8" />
+
+            <Text className="text-mutedText text-xs">© {currentYear} Rybbit Analytics</Text>
           </Container>
         </Body>
       </Tailwind>

--- a/server/src/lib/email/templates/WeeklyReportEmail.tsx
+++ b/server/src/lib/email/templates/WeeklyReportEmail.tsx
@@ -2,8 +2,9 @@ import {
   Body,
   Container,
   Head,
-  Heading,
+  Hr,
   Html,
+  Img,
   Link,
   Preview,
   Section,
@@ -255,7 +256,6 @@ export const WeeklyReportEmail = ({ userName, organizationReport }: WeeklyReport
             extend: {
               colors: {
                 brand: "#10b981",
-                lightBg: "#ffffff",
                 cardBg: "#f9fafb",
                 darkText: "#111827",
                 mutedText: "#6b7280",
@@ -267,66 +267,22 @@ export const WeeklyReportEmail = ({ userName, organizationReport }: WeeklyReport
           },
         }}
       >
-        <Body className="bg-lightBg font-sans">
-          <Container className="mx-auto py-10 px-6 max-w-[600px]">
-            {/* Header */}
-            <Section className="text-center mb-8">
-              <div className="inline-block bg-brand/10 text-brand px-3 py-1.5 rounded-full text-sm font-medium mb-4">
-                Weekly Report
-              </div>
-              <table
-                style={{
-                  width: "100%",
-                  marginBottom: "8px",
-                }}
-              >
-                <tbody>
-                  <tr>
-                    <td style={{ textAlign: "center" }}>
-                      <table
-                        style={{
-                          display: "inline-block",
-                          verticalAlign: "middle",
-                        }}
-                      >
-                        <tbody>
-                          <tr>
-                            <td
-                              style={{
-                                verticalAlign: "middle",
-                                paddingRight: "12px",
-                              }}
-                            >
-                              <img
-                                src={`https://www.google.com/s2/favicons?domain=${organizationReport.sites[0].siteDomain}&sz=32`}
-                                alt=""
-                                width="24"
-                                height="24"
-                                style={{ borderRadius: "4px", display: "block" }}
-                              />
-                            </td>
-                            <td style={{ verticalAlign: "middle" }}>
-                              <Heading
-                                style={{
-                                  color: "#111827",
-                                  fontSize: "30px",
-                                  fontWeight: 600,
-                                  margin: 0,
-                                  lineHeight: "1.2",
-                                }}
-                              >
-                                {organizationReport.sites[0].siteDomain}
-                              </Heading>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              <Text className="text-mutedText text-base">Hi {userName}, here's your weekly analytics summary</Text>
-            </Section>
+        <Body className="bg-white font-sans">
+          <Container className="mx-auto py-8 px-6 max-w-[600px]">
+            <Img
+              src="https://app.rybbit.io/rybbit/horizontal_black.svg"
+              alt="Rybbit"
+              width="120"
+              height="28"
+              className="mb-8"
+            />
+
+            <Text className="text-darkText text-base leading-relaxed mb-4">Hi {userName},</Text>
+
+            <Text className="text-darkText text-base leading-relaxed mb-8">
+              Here's your weekly analytics summary for{" "}
+              <span className="font-semibold">{organizationReport.sites[0].siteDomain}</span>.
+            </Text>
 
             {/* Sites Reports */}
             {organizationReport.sites.map(site => (
@@ -428,30 +384,26 @@ export const WeeklyReportEmail = ({ userName, organizationReport }: WeeklyReport
                   />
                 </div>
 
-                {/* Dashboard Link */}
-                <div className="text-center mb-6">
-                  <Link
-                    href={`https://app.rybbit.io/${site.siteId}`}
-                    className="inline-block bg-brand text-white px-6 py-2.5 rounded-md font-medium text-sm no-underline"
-                  >
-                    View Full Dashboard
+                <Text className="text-darkText text-base leading-relaxed mb-4">
+                  <Link href={`https://app.rybbit.io/${site.siteId}`} className="text-brand underline">
+                    View full dashboard
                   </Link>
-                </div>
+                </Text>
               </Section>
             ))}
 
-            {/* Footer */}
-            <Section className="text-center border-t border-borderColor pt-5">
-              <Text className="text-mutedText text-xs mb-2">
-                This weekly report covers the last 7 days of analytics data.
-              </Text>
-              <Text className="text-mutedText text-xs mb-3">
-                <Link href="https://app.rybbit.io/settings/account" className="text-brand no-underline">
-                  Unsubscribe from weekly reports
-                </Link>
-              </Text>
-              <Text className="text-mutedText text-xs">© {currentYear} Rybbit Analytics</Text>
-            </Section>
+            <Text className="text-mutedText text-sm leading-relaxed">
+              This report covers the last 7 days of analytics data.
+            </Text>
+
+            <Hr className="border-borderColor my-8" />
+
+            <Text className="text-mutedText text-xs mb-2">
+              <Link href="https://app.rybbit.io/settings/account" className="text-mutedText underline">
+                Unsubscribe from weekly reports
+              </Link>
+            </Text>
+            <Text className="text-mutedText text-xs">© {currentYear} Rybbit Analytics</Text>
           </Container>
         </Body>
       </Tailwind>

--- a/server/src/services/usageService.ts
+++ b/server/src/services/usageService.ts
@@ -5,8 +5,8 @@ import { processResults } from "../api/analytics/utils/utils.js";
 import { clickhouse } from "../db/clickhouse/clickhouse.js";
 import { db } from "../db/postgres/postgres.js";
 import { member, organization, sites, user } from "../db/postgres/schema.js";
-import { DEFAULT_EVENT_LIMIT, IS_CLOUD } from "../lib/const.js";
-import { sendLimitExceededEmail } from "../lib/email/email.js";
+import { IS_CLOUD } from "../lib/const.js";
+import { sendApproachingLimitEmail, sendLimitExceededEmail } from "../lib/email/email.js";
 import { createServiceLogger } from "../lib/logger/logger.js";
 import { getBestSubscription } from "../lib/subscriptionUtils.js";
 
@@ -221,8 +221,15 @@ class UsageService {
           stripeCustomerId: organization.stripeCustomerId,
           createdAt: organization.createdAt,
           overMonthlyLimit: organization.overMonthlyLimit,
+          approachingLimitNotifiedPeriodStart: organization.approachingLimitNotifiedPeriodStart,
         })
         .from(organization);
+
+      const monthStart = this.getStartOfMonth();
+      const now = DateTime.now();
+      const totalDaysInMonth = now.daysInMonth ?? 30;
+      const daysElapsed = now.diff(now.startOf("month"), "days").days;
+      const daysRemaining = totalDaysInMonth - daysElapsed;
 
       // Step 5: Process each organization
       for (const orgData of organizations) {
@@ -231,24 +238,24 @@ class UsageService {
           const eventCount = orgStats?.eventCount || 0;
           const siteIds = orgStats?.siteIds || [];
 
-          // Only fetch subscription info for organizations with > 3000 events
-          // This avoids slow Stripe API calls for low-usage orgs
-          let eventLimit: number;
-          let isOverLimit: boolean;
-
-          if (eventCount <= DEFAULT_EVENT_LIMIT) {
-            // Free tier limit is 3000, so they're definitely not over limit
-            eventLimit = DEFAULT_EVENT_LIMIT;
-            isOverLimit = false;
-            this.logger.debug(`Organization ${orgData.name} has ${eventCount} events, skipping subscription check`);
-          } else {
-            // High usage - need to check their actual subscription
-            const [fetchedLimit, periodStart] = await this.getOrganizationSubscriptionInfo(orgData);
-            eventLimit = fetchedLimit;
-            isOverLimit = eventCount > eventLimit;
-          }
-
           const wasOverLimit = orgData.overMonthlyLimit ?? false;
+          const alreadyNotifiedApproaching = orgData.approachingLimitNotifiedPeriodStart === monthStart;
+
+          const [eventLimit] = await this.getOrganizationSubscriptionInfo(orgData);
+          const isOverLimit = eventCount > eventLimit;
+
+          let sendApproaching = false;
+          if (
+            !alreadyNotifiedApproaching &&
+            !isOverLimit &&
+            Number.isFinite(eventLimit) &&
+            daysRemaining >= 2
+          ) {
+            const projected = daysElapsed >= 1 ? eventCount * (totalDaysInMonth / daysElapsed) : 0;
+            const trigger90 = eventCount >= eventLimit * 0.9;
+            const triggerProjection = daysElapsed >= 7 && projected >= eventLimit;
+            sendApproaching = trigger90 || triggerProjection;
+          }
 
           // Update organization's monthlyEventCount and overMonthlyLimit fields
           await db
@@ -256,6 +263,7 @@ class UsageService {
             .set({
               monthlyEventCount: eventCount,
               overMonthlyLimit: isOverLimit,
+              ...(sendApproaching ? { approachingLimitNotifiedPeriodStart: monthStart } : {}),
             })
             .where(eq(organization.id, orgData.id));
 
@@ -278,6 +286,29 @@ class UsageService {
               }
             } else {
               this.logger.warn(`No owners found for organization ${orgData.name}, skipping limit exceeded email`);
+            }
+          }
+
+          if (sendApproaching) {
+            const ownerEmails = await this.getOrganizationOwnerEmails(orgData.id);
+            if (ownerEmails.length > 0) {
+              for (const ownerEmail of ownerEmails) {
+                try {
+                  await sendApproachingLimitEmail(ownerEmail, orgData.name, eventCount, eventLimit);
+                  this.logger.info(
+                    `Sent approaching-limit email to owner ${ownerEmail} for organization ${orgData.name}`
+                  );
+                } catch (error) {
+                  this.logger.error(
+                    error as Error,
+                    `Failed to send approaching-limit email to owner ${ownerEmail} for organization ${orgData.name}`
+                  );
+                }
+              }
+            } else {
+              this.logger.warn(
+                `No owners found for organization ${orgData.name}, skipping approaching-limit email`
+              );
             }
           }
 


### PR DESCRIPTION
- Introduced a new email template and function to notify organizations when they are approaching their monthly event limit.
- Updated the database schema to track the notification period start for approaching limits.
- Enhanced the usage service to send notifications based on event usage projections and remaining days in the month.
- Refactored existing email templates for consistency and improved user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “approaching monthly event limit” email notifications to warn organizations before they hit their event cap.

* **Style**
  * Redesigned email templates (invitation, OTP, limit alerts, weekly report) for improved layout, branding, and clearer CTAs.

* **Bug Fixes**
  * Map/globe component now safely handles environments without WebGL2 or failing map initialization, preventing rendering errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->