### PR TITLE
Update bot detection to reduce WebView false positives

### DIFF
--- a/server/public/script-full.js
+++ b/server/public/script-full.js
@@ -393,7 +393,7 @@
       if (navigator.connection?.rtt === 0) {
         score++;
       }
-      if (!window.chrome && /Chrome\//.test(navigator.userAgent)) {
+      if (!window.chrome && /Chrome\//.test(navigator.userAgent) && !/\bwv\b|; wv\)/.test(navigator.userAgent)) {
         score++;
       }
       try {
@@ -410,7 +410,7 @@
         }
       } catch (e2) {
       }
-      if (navigator.plugins.length === 0 && /Chrome\//.test(navigator.userAgent)) {
+      if (navigator.plugins.length === 0 && /Chrome\//.test(navigator.userAgent) && !/\bwv\b|; wv\)/.test(navigator.userAgent)) {
         score++;
       }
       try {
@@ -817,11 +817,13 @@
         }));
       }));
     }
-    return { get firstHiddenTime() {
-      return u;
-    }, onHidden(e2) {
-      l.add(e2);
-    } };
+    return {
+      get firstHiddenTime() {
+        return u;
+      }, onHidden(e2) {
+        l.add(e2);
+      }
+    };
   };
   var g = (e2) => {
     document.prerendering ? addEventListener("prerenderingchange", (() => e2()), true) : e2();
@@ -1210,7 +1212,7 @@
   };
 
   // index.ts
-  (async function() {
+  (async function () {
     const scriptTag = document.currentScript;
     if (!scriptTag) {
       console.error("Could not find current script tag");
@@ -1304,7 +1306,7 @@
     const trackPageview = () => tracker.trackPageview();
     const debouncedTrackPageview = config.debounceDuration > 0 ? debounce(trackPageview, config.debounceDuration) : trackPageview;
     function setupEventListeners() {
-      document.addEventListener("click", function(e2) {
+      document.addEventListener("click", function (e2) {
         let target = e2.target;
         while (target && target !== document.documentElement) {
           if (target.hasAttribute("data-rybbit-event")) {
@@ -1333,12 +1335,12 @@
       if (config.autoTrackSpa) {
         const originalPushState = history.pushState;
         const originalReplaceState = history.replaceState;
-        history.pushState = function(...args) {
+        history.pushState = function (...args) {
           originalPushState.apply(this, args);
           debouncedTrackPageview();
           tracker.onPageChange();
         };
-        history.replaceState = function(...args) {
+        history.replaceState = function (...args) {
           originalReplaceState.apply(this, args);
           debouncedTrackPageview();
           tracker.onPageChange();

--- a/server/src/analytics-script/botSignals.ts
+++ b/server/src/analytics-script/botSignals.ts
@@ -26,7 +26,8 @@ export function getBotScore(): number {
     }
 
     // 4. Missing window.chrome on a Chrome UA — real Chrome always exposes this object
-    if (!((window as any).chrome) && /Chrome\//.test(navigator.userAgent)) {
+    //    Only flag for non-WebView Chrome UAs; Android WebView doesn't expose window.chrome
+    if (!((window as any).chrome) && /Chrome\//.test(navigator.userAgent) && !/\bwv\b|; wv\)/.test(navigator.userAgent)) {
       score++;
     }
 
@@ -48,8 +49,8 @@ export function getBotScore(): number {
     }
 
     // 6. No plugins — headless Chrome has 0 plugins, real Chrome has at least PDF viewer
-    //    Only flag for Chrome UAs since Firefox legitimately has 0
-    if (navigator.plugins.length === 0 && /Chrome\//.test(navigator.userAgent)) {
+    //    Only flag for non-WebView Chrome UAs; Firefox and Android WebView can legitimately have 0
+    if (navigator.plugins.length === 0 && /Chrome\//.test(navigator.userAgent) && !/\bwv\b|; wv\)/.test(navigator.userAgent)) {
       score++;
     }
 


### PR DESCRIPTION
## Summary

This PR updates client-side bot detection to reduce false positives in Android WebView environments.

## Background

#971 [Issue: False positive bot filtering in Android WebView after upgrading to v2.5.0](https://github.com/rybbit-io/rybbit/issues/971)

After recent bot detection changes, legitimate Android WebView traffic could be filtered as bots due to Chrome-UA-based heuristics.  
In WebView, it is normal to see:

- `Chrome/...` in `navigator.userAgent`
- missing `window.chrome`
- `navigator.plugins.length === 0`

These characteristics can look bot-like under desktop Chrome assumptions, but are valid in WebView.

## What changed

File updated:
- `server/src/analytics-script/botSignals.ts`
- `server/public/script-full.js`

Minimal inline condition changes were applied to two checks:

1. **Missing `window.chrome` on Chrome UA**
2. **No plugins on Chrome UA**


In both checks, the following condition was added:

```javascript
!/\bwv\b|; wv\)/.test(navigator.userAgent)
```

Additionally, the related comment was updated to reflect that this rule now targets **non-WebView Chrome** behavior.

## Expected impact

- Fewer false-positive bot classifications for Android WebView traffic.
- Improved analytics/event capture accuracy for legitimate in-app users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined bot detection heuristics for Chrome-based browsers to reduce false positives, ensuring more accurate differentiation between legitimate users and automated traffic.
  * Improved overall traffic classification reliability and filtering effectiveness.

* **Style**
  * Code formatting improvements for consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->