### PR TITLE
Fix invalid empty array literal in identifyService traits upsert

### DIFF
--- a/server/src/services/tracker/identifyService.ts
+++ b/server/src/services/tracker/identifyService.ts
@@ -139,13 +139,20 @@ export async function handleIdentify(request: FastifyRequest, reply: FastifyRepl
           .filter(([_, v]) => v === null)
           .map(([k]) => k);
 
+        // When nullKeys is empty, drizzle serializes [] as `()` which is invalid
+        // Postgres array literal syntax. Skip the subtract clause in that case.
+        const traitsExpr =
+          nullKeys.length > 0
+            ? sql`(${userProfiles.traits} - ${nullKeys}::text[]) || ${JSON.stringify(filteredTraits)}::jsonb`
+            : sql`${userProfiles.traits} || ${JSON.stringify(filteredTraits)}::jsonb`;
+
         await db
           .insert(userProfiles)
           .values({ siteId, userId: user_id, traits: filteredTraits })
           .onConflictDoUpdate({
             target: [userProfiles.siteId, userProfiles.userId],
             set: {
-              traits: sql`(${userProfiles.traits} - ${nullKeys}::text[]) || ${JSON.stringify(filteredTraits)}::jsonb`,
+              traits: traitsExpr,
               updatedAt: sql`now()`,
             },
           });


### PR DESCRIPTION
Commit 0d3410a (Enhance user profile handling in identifyService) introduced this UPSERT clause:

```ts
traits: sql`(${userProfiles.traits} - ${nullKeys}::text[]) || ${JSON.stringify(filteredTraits)}::jsonb`
```

When `nullKeys` is an empty array (the common case — most identify calls only add traits, never explicitly null them), drizzle serialises `[]` as `()`, producing invalid Postgres syntax:

```
"user_profiles"."traits" - ()::text[]
```

Postgres rejects this with `syntax error at or near ")"` (code 42601, position 216), so every identify call without null traits fails silently in the catch block. Result: traits never get persisted for users who don't pass null keys.

Reproduction: any `identify(user_id, { username: "x" })` call (no nulls).

Fix: skip the subtract clause when `nullKeys.length === 0`.

Verified on a production instance with ~20 identify calls/sec — error log went from constant to zero, traits start updating correctly (38 successful upserts in the first minute after deploy, 0 SQL errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue with user profile trait updates that could cause errors in certain edge cases. Updates now process correctly across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->