### PR TITLE
fix: set high API key rate limit for self-hosted instances

### DIFF
--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -34,7 +34,7 @@ const pluginList = [
             maxRequests: STANDARD_API_RATE_LIMIT,
           },
         }
-      : {}),
+      : { rateLimit: { maxRequests: 10000, timeWindow: 86400000 } }),
   }),
   dash(),
   organization({


### PR DESCRIPTION
### Problem

The `@better-auth/api-key` plugin in `server/src/lib/auth.ts` configures rate limiting conditionally based on `IS_CLOUD`:

```ts
apiKey({
  ...(IS_CLOUD
    ? {
        rateLimit: {
          enabled: true,
          timeWindow: API_RATE_LIMIT_WINDOW,
          maxRequests: STANDARD_API_RATE_LIMIT,
        },
      }
    : {}),  // <-- empty config inherits plugin defaults
}),
```

The self-hosted branch passes `{}`, which inherits `@better-auth/api-key`'s default rate limit of **10 requests per 24 hours**. This contradicts the Rybbit API docs which state: "Self-hosted instances have no rate limits."

Any API integration making more than 10 authenticated requests in a 24-hour window receives 429 responses. Once triggered, all API key-authenticated requests fail for up to 24 hours with no indication of the cause or how to resolve it.

Note: `rateLimit: { enabled: false }` cannot be used here; it disables the entire API key plugin, not just rate limiting.

### Fix

Set a high rate limit ceiling for self-hosted instances (until the `enabled: false` approach above is corrected by the devs):

```diff
-     : {}),
+     : { rateLimit: { maxRequests: 10000, timeWindow: 86400000 } }),
```

This gives self-hosted instances 10,000 requests per 24 hours, effectively removing the constraint while keeping the plugin functional.

Cloud instances are unaffected, they continue using `STANDARD_API_RATE_LIMIT` / `API_RATE_LIMIT_WINDOW`.

### Tested

Verified on a self-hosted instance: 24 consecutive API key-authenticated requests returned 200 with this change applied. Without it, requests 11+ return 429.

### File

`server/src/lib/auth.ts` — line 37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated rate limiting configuration to apply default limits in non-cloud deployments, allowing up to 10,000 requests per day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->