### PR TITLE
Update Drupal docs to reference contributed rybbit module

### DIFF
--- a/docs/content/docs/guides/drupal.mdx
+++ b/docs/content/docs/guides/drupal.mdx
@@ -29,8 +29,7 @@ Replace `YOUR_SITE_ID` with your actual Site ID from your Rybbit dashboard.
 
 ### Download and install the Rybbit module
 
-Follow Drupal's [recommended procedure](https://www.drupal.org/docs/extending-drupal/installing-modules) for installing the Rybbit module from https://www.drupal.org/modules/rybbit:
-
+Follow Drupal's [recommended procedure](https://www.drupal.org/docs/extending-drupal/installing-modules) for installing the Rybbit module from https://www.drupal.org/project/rybbit:
 ```
   $ composer require drupal/rybbit
   $ drush en rybbit

--- a/docs/content/docs/guides/drupal.mdx
+++ b/docs/content/docs/guides/drupal.mdx
@@ -6,7 +6,7 @@ description: Integrate Rybbit Analytics with your Drupal site using theme files 
 import { Steps, Step } from 'fumadocs-ui/components/steps';
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Integrating Rybbit Analytics with your Drupal site can be done by adding the tracking script to your theme or by using a module that allows adding custom JavaScript.
+You can add Rybbit to your site by installing the [Rybbit](https://drupal.org/project/rybbit) module from Drupal.org
 
 <Steps>
 <Step>
@@ -20,92 +20,22 @@ First, you'll need your Rybbit tracking script. You can find this in your Rybbit
 
 Replace `YOUR_SITE_ID` with your actual Site ID from your Rybbit dashboard.
 </Step>
-</Steps>
-
-## Method 1: Adding to Your Theme (Recommended for Themers)
-
-If you are comfortable editing your Drupal theme files, this is a direct way to add the script.
-
-<Steps>
 <Step>
-### Locate your theme's `html.html.twig` file
+### Download and install the Rybbit module
 
-This file is responsible for the overall HTML structure of your pages. You can typically find it in your active theme's directory:
-`themes/custom/your_theme_name/templates/layout/html.html.twig`
+Follow Drupal's [recommended procedure](https://www.drupal.org/docs/extending-drupal/installing-modules) for installing the Rybbit module from https://www.drupal.org/modules/rybbit:
 
-If your custom theme doesn't have one, you might need to copy it from your base theme (e.g., Stable, Classy) or from Drupal core (`core/themes/stable/templates/layout/html.html.twig`).
-</Step>
-
-<Step>
-### Add the script
-
-Open the `html.html.twig` file and paste the Rybbit tracking script just before the closing `</body>` tag.
-
-```twig
-{# ... existing content ... #}
-    <js-bottom-placeholder token="{{ placeholder_token }}">
-  </body>
-</html>
 ```
-
-Modify it to include the script:
-
-```twig
-{# ... existing content ... #}
-    <js-bottom-placeholder token="{{ placeholder_token }}">
-
-    {# Rybbit Analytics Script #}
-    <script async defer src="https://app.rybbit.io/api/script.js" data-site-id="YOUR_SITE_ID"></script>
-  </body>
-</html>
+  $ composer require drupal/rybbit
+  $ drush en rybbit
 ```
-Replace `YOUR_SITE_ID` with your actual Site ID.
 </Step>
-
 <Step>
-### Clear Drupal Caches
+### Configure module settings
 
-After adding the script, you must clear Drupal's caches for the changes to take effect.
-- Go to **Manage > Configuration > Development > Performance** (e.g., `/admin/config/development/performance`).
-- Click the **Clear all caches** button.
-- Alternatively, use Drush: `drush cr`
-</Step>
-</Steps>
+Visit `admin/services/rybbit` and add your Site ID to the site's configuration page.
 
-<Callout type="warn">
-  Be cautious when adding scripts directly to `html.html.twig` if you are not using a custom theme, as core or contrib theme updates might overwrite your changes. Creating a sub-theme is best practice.
-</Callout>
-
-## Method 2: Using a Module (e.g., "Asset Injector")
-
-For users less comfortable with code, or for more flexible management, a module like [Asset Injector](https://www.drupal.org/project/asset_injector) can be used.
-
-<Steps>
-<Step>
-### Install and Enable Asset Injector
-
-- Download and install the Asset Injector module from Drupal.org.
-- Enable the module via **Manage > Extend** (`/admin/modules`).
-</Step>
-
-<Step>
-### Add a JavaScript Asset
-
-- Go to **Manage > Configuration > Development > Asset Injector** (`/admin/config/development/asset-injector`).
-- Click on **JS injector**.
-- Click **+ Add JS inject**.
-- **Label:** Give it a name like "Rybbit Analytics".
-- **Code:** Paste your Rybbit tracking script into the code field.
-- **Pages:** Configure where the script should appear. For sitewide tracking, you might select "Add on every page except the listed pages" and leave the list empty, or use specific conditions if needed.
-- **Preprocess JavaScript:** Usually, you can leave this unchecked for external scripts.
-- **Scope:** Select **Footer** to add the script to the bottom of the page.
-</Step>
-
-<Step>
-### Save and Clear Caches
-
-- Save the asset.
-- Clear Drupal's caches as described in Method 1.
+You can also modify the script's source and loading optimizations, set rules for when the script gets loaded, and configure the site to use the `identify()` method to pass details about logged-in users from Drupal to Rybbit.
 </Step>
 </Steps>
 

--- a/docs/content/docs/guides/drupal.mdx
+++ b/docs/content/docs/guides/drupal.mdx
@@ -1,6 +1,6 @@
 ---
 title: Drupal
-description: Integrate Rybbit Analytics with your Drupal site using theme files or modules
+description: Integrate Rybbit Analytics with your Drupal site using the rybbit module
 ---
 
 import { Steps, Step } from 'fumadocs-ui/components/steps';

--- a/docs/content/docs/guides/drupal.mdx
+++ b/docs/content/docs/guides/drupal.mdx
@@ -10,6 +10,7 @@ You can add Rybbit to your site by installing the [Rybbit](https://drupal.org/pr
 
 <Steps>
 <Step>
+
 ### Get Your Tracking Script
 
 First, you'll need your Rybbit tracking script. You can find this in your Rybbit dashboard under **Site Settings > Tracking Code**. It will look something like this:
@@ -21,6 +22,7 @@ First, you'll need your Rybbit tracking script. You can find this in your Rybbit
 Replace `YOUR_SITE_ID` with your actual Site ID from your Rybbit dashboard.
 </Step>
 <Step>
+
 ### Download and install the Rybbit module
 
 Follow Drupal's [recommended procedure](https://www.drupal.org/docs/extending-drupal/installing-modules) for installing the Rybbit module from https://www.drupal.org/modules/rybbit:
@@ -31,6 +33,7 @@ Follow Drupal's [recommended procedure](https://www.drupal.org/docs/extending-dr
 ```
 </Step>
 <Step>
+
 ### Configure module settings
 
 Visit `admin/services/rybbit` and add your Site ID to the site's configuration page.
@@ -43,6 +46,7 @@ You can also modify the script's source and loading optimizations, set rules for
 
 <Steps>
 <Step>
+
 ### Test Your Integration
 
 - Open your live Drupal website in a browser.

--- a/docs/content/docs/guides/drupal.mdx
+++ b/docs/content/docs/guides/drupal.mdx
@@ -6,6 +6,10 @@ description: Integrate Rybbit Analytics with your Drupal site using theme files 
 import { Steps, Step } from 'fumadocs-ui/components/steps';
 import { Callout } from 'fumadocs-ui/components/callout';
 
+Drupal is a flexible and secure content management system that features robust content modeling and user management tools. You can add Rybbit to Drupal to track anonymous and logged-in users.
+
+## How to Add Rybbit to Drupal
+
 You can add Rybbit to your site by installing the [Rybbit](https://drupal.org/project/rybbit) module from Drupal.org
 
 <Steps>


### PR DESCRIPTION
It is generally not recommended to add javascript directly to the a Drupal theme. It can get lost in a redesign, and without following the [libraries.yml](https://www.drupal.org/docs/develop/theming-drupal/adding-assets-css-js-to-a-drupal-theme-via-librariesyml) convention, this method can interfere with Drupal's built-in performance, caching, and security features.

I was also unsuccessful using Asset Injector using the provided instructions, since that module expects you to remove `<script` and the workarounds are not straightforward.

There is now a Rybbit module for Drupal: https://www.drupal.org/project/rybbit  that

* Follows libraries.yml convention
* Supports self-hosted or proxied URLS
* Includes preconnect and prefetch for end-user performance
* Supports the use of `identify()` for logged-in users and allows site administrators to pass along any user detail (name, role, etc) via traits
* Can be updated to support additional tracking events or new Rybbit features 

This documenation removes the other options and recommends only the module route for similicity and clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote the Drupal integration guide into a step-by-step flow.
  * Removed legacy theme- and asset-injector-based walkthroughs.
  * Added module installation instructions (Composer/Drush) and clear configuration steps for Site ID, script source/loading rules, and identify() behavior via the Drupal admin UI.
  * Kept and reorganized verification and testing steps, with a streamlined closing for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->