### PR TITLE
fix: raise bodyLimit to 50MB on import batch endpoint

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -305,7 +305,11 @@ async function sitesRoutes(fastify: FastifyInstance) {
   // Site Imports
   fastify.get("/sites/:siteId/imports", adminSite, getSiteImports);
   fastify.post("/sites/:siteId/imports", adminSite, createSiteImport);
-  fastify.post("/sites/:siteId/imports/:importId/events", adminSite, batchImportEvents);
+  fastify.post(
+    "/sites/:siteId/imports/:importId/events",
+    { ...adminSite, bodyLimit: 50 * 1024 * 1024 },
+    batchImportEvents
+  );
   fastify.delete("/sites/:siteId/imports/:importId", adminSite, deleteSiteImport);
 }
 


### PR DESCRIPTION
The import client (csvParser.ts) chunks files into 5MB CSV slices, but JSON serialization of Umami/Plausible rows expands 2-3x due to URLs, user agents, referrers, and JSON key overhead. Real-world imports routinely produce 10-15MB payloads, exceeding the global 10MB bodyLimit and returning 413.

Failure mode is silent: the client error is not surfaced, the import_status row stays with completed_at = NULL, and the org-level concurrent-import lock holds for up to 2 hours.

Apply the larger limit per-route on the admin-gated import-events endpoint only. Global limit unchanged so public /api/track and /api/identify keep their 10MB ceiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum payload limit for batch event imports to 50MB, enabling support for larger data transfers during batch event import operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rybbit-io/rybbit/pull/986)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->