### PR TITLE
Enhance WebGL detection

### DIFF
--- a/server/src/analytics-script/botSignals.ts
+++ b/server/src/analytics-script/botSignals.ts
@@ -140,17 +140,30 @@ function calculateBotSignals(): BotSignalResult {
     // 7. WebGL renderer check — headless/containerized Chrome often uses Google SwiftShader
     try {
       const canvas = document.createElement("canvas");
-      const gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+      const gl = (canvas.getContext("webgl") || canvas.getContext("experimental-webgl")) as WebGLRenderingContext | null;
       if (gl) {
-        const debugInfo = (gl as WebGLRenderingContext).getExtension("WEBGL_debug_renderer_info");
-        if (debugInfo) {
-          const renderer = (gl as WebGLRenderingContext).getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
-          if (typeof renderer === "string" && renderer.includes("SwiftShader")) {
-            addSignal(CLIENT_BOT_SIGNAL_MASKS.swiftShader, 1);
+        const rendererParts: string[] = [];
+        const rendererRaw = gl.getParameter(gl.RENDERER);
+        if (typeof rendererRaw === "string") {
+          rendererParts.push(rendererRaw);
+        }
+        try {
+          type WebGlDebugRendererInfo = {UNMASKED_RENDERER_WEBGL:number};
+          const debugInfo = gl.getExtension("WEBGL_debug_renderer_info") as WebGlDebugRendererInfo | null;
+          if (debugInfo) {
+            const unmaskedRaw = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
+            if (typeof unmaskedRaw === "string") {
+              rendererParts.push(unmaskedRaw);
+            }
           }
+        } catch {
+          // Firefox Privacy
+        }
+        if (rendererParts.join(" ").toLowerCase().includes("swiftshader")) {
+          addSignal(CLIENT_BOT_SIGNAL_MASKS.swiftShader, 1);
         }
       }
-    } catch (e) {
+    } catch {
       // WebGL not available — not a bot signal by itself
     }
 


### PR DESCRIPTION
WEBGL_debug_renderer_info is deprecated in Firefox and will be removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust detection of SwiftShader by aggregating available GPU renderer identifiers and using case-insensitive matching.
  * Improved privacy and error handling when querying graphics information to avoid exposing or relying on single values.
  * Increased resilience when interacting with WebGL contexts to reduce false positives and runtime errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rybbit-io/rybbit/pull/1005?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->