### PR TITLE
fix: guard organization member query

### DIFF
--- a/client/src/api/admin/hooks/useOrganizationMembers.ts
+++ b/client/src/api/admin/hooks/useOrganizationMembers.ts
@@ -1,10 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { getOrganizationMembers, GetOrganizationMembersResponse } from "../endpoints";
 
-export const useOrganizationMembers = (organizationId: string) => {
+export const useOrganizationMembers = (organizationId?: string) => {
   return useQuery<GetOrganizationMembersResponse>({
     queryKey: ["organization-members", organizationId],
-    queryFn: () => getOrganizationMembers(organizationId),
+    queryFn: () => {
+      if (!organizationId) {
+        throw new Error("Organization ID is required");
+      }
+
+      return getOrganizationMembers(organizationId);
+    },
     staleTime: Infinity,
+    enabled: !!organizationId,
   });
 };

--- a/client/src/app/settings/teams/components/CreateEditTeamDialog.tsx
+++ b/client/src/app/settings/teams/components/CreateEditTeamDialog.tsx
@@ -40,7 +40,7 @@ export function CreateEditTeamDialog({
 }: CreateEditTeamDialogProps) {
   const t = useExtracted();
   const { data: activeOrganization } = authClient.useActiveOrganization();
-  const { data: membersData, isLoading: isLoadingMembers } = useOrganizationMembers(activeOrganization?.id || "");
+  const { data: membersData, isLoading: isLoadingMembers } = useOrganizationMembers(activeOrganization?.id);
   const { data: sitesData, isLoading: isLoadingSites } = useGetSitesFromOrg(activeOrganization?.id);
 
   const createTeam = useCreateTeam();

--- a/client/src/app/settings/teams/layout.tsx
+++ b/client/src/app/settings/teams/layout.tsx
@@ -28,7 +28,7 @@ export default function TeamsLayout({ children }: { children: React.ReactNode })
             </ExternalLink>
           </p>
         </div>
-        {!isMember && (
+        {activeOrg?.id && !isMember && (
           <CreateEditTeamDialog
             trigger={
               <Button size="sm">


### PR DESCRIPTION
## Summary

Teams settings no longer request `/api/organizations//members` while the active organization is still loading. The organization-members query now waits for a real organization id, and the create-team dialog only mounts after an active organization exists, matching the existing guards used by the teams and sites queries.

## Validation

- Built the patched client image in a self-host checkout with `docker compose build client`; the Next.js production build completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team management behavior so the “create/edit team” option only appears when an organization is selected and the current user isn’t already a member.
  * Made member data loading more flexible by allowing the organization selection to be optional, and only fetching members when an organization ID is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->