### PR TITLE
Add scrollable height constraint to FunnelForm builder pane

### DIFF
--- a/client/src/app/[site]/funnels/components/FunnelForm.tsx
+++ b/client/src/app/[site]/funnels/components/FunnelForm.tsx
@@ -564,7 +564,7 @@ export function FunnelForm({
               />
             </div>
 
-            <div className="space-y-2">
+            <div className="space-y-2 max-h-[calc(100vh-300px)] overflow-y-auto">
               <Reorder.Group axis="y" values={stepIds} onReorder={handleReorder} className="list-none space-y-2">
                 {stepIds.map((id, index) => (
                   <StepCard


### PR DESCRIPTION
Added `max-h-[calc(100vh-300px)] overflow-y-auto` to prevent the section from overflowing the viewport and enable vertical scrolling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved funnel builder navigation by adding a scrollable step list.
  * Ensured the list stays within the available viewport height for easier access to all steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->