### PR TITLE
Redesign user detail page

### DIFF
--- a/client/src/api/analytics/hooks/useGetUserSessions.ts
+++ b/client/src/api/analytics/hooks/useGetUserSessions.ts
@@ -52,6 +52,8 @@ export function useGetSessions({
       });
     },
     staleTime: Infinity,
+    // Wait for the store to hydrate; an empty site produces a malformed URL
+    enabled: !!site,
   });
 }
 

--- a/client/src/app/[site]/user/[userId]/components/SidebarPrimitives.tsx
+++ b/client/src/app/[site]/user/[userId]/components/SidebarPrimitives.tsx
@@ -12,6 +12,19 @@ export function SidebarCard({ children, className = "" }: { children: ReactNode;
   );
 }
 
+// Uniform section header: micro-label title on the left, optional control or
+// hint on the right (edit button, "p75", ...)
+export function SidebarHeader({ title, right }: { title: ReactNode; right?: ReactNode }) {
+  return (
+    <div className="mb-2 flex items-center justify-between gap-2">
+      <h3 className="text-[11px] font-medium uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+        {title}
+      </h3>
+      {right}
+    </div>
+  );
+}
+
 // Info row component for consistent styling
 export function InfoRow({ icon, label, value }: { icon?: ReactNode; label: ReactNode; value: ReactNode }) {
   return (
@@ -38,40 +51,6 @@ export function InfoRowSkeleton({ labelWidth = "w-14", valueWidth = "w-24", with
         {withIcon && <Skeleton className="w-4 h-4 rounded" />}
         <Skeleton className={`h-3 ${valueWidth} rounded`} />
       </div>
-    </div>
-  );
-}
-
-// Stat card component
-export function StatCard({
-  icon,
-  label,
-  value,
-  isLoading,
-}: {
-  icon: ReactNode;
-  label: string;
-  value: ReactNode;
-  isLoading: boolean;
-}) {
-  if (isLoading) {
-    return (
-      <div className="flex flex-col gap-0.5">
-        <div className="text-[10px] text-neutral-500 dark:text-neutral-400 flex items-center gap-1 uppercase tracking-wide">
-          <Skeleton className="w-3 h-3 rounded" />
-          <Skeleton className="h-2.5 w-14 rounded" />
-        </div>
-        <Skeleton className="h-4 w-16 rounded" />
-      </div>
-    );
-  }
-  return (
-    <div className="flex flex-col gap-0.5">
-      <div className="text-[10px] text-neutral-500 dark:text-neutral-400 flex items-center gap-1 uppercase tracking-wide">
-        {icon}
-        {label}
-      </div>
-      <div className="text-sm">{value}</div>
     </div>
   );
 }

--- a/client/src/app/[site]/user/[userId]/components/UserActions.tsx
+++ b/client/src/app/[site]/user/[userId]/components/UserActions.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 
 import { UserInfo } from "@/api/analytics/endpoints";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DeleteUserDialog } from "./DeleteUserDialog";
 import { IdentifyUserDialog } from "./IdentifyUserDialog";
 
@@ -29,15 +30,20 @@ export function UserActions({ userId, data }: UserActionsProps) {
           {t("Identify User")}
         </Button>
       )}
-      <Button
-        variant="ghost"
-        size="smIcon"
-        aria-label={t("Delete User")}
-        className="text-neutral-500 hover:bg-red-500/10 hover:text-red-500 dark:hover:text-red-400"
-        onClick={() => setDeleteOpen(true)}
-      >
-        <Trash2 className="w-3.5 h-3.5" />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="smIcon"
+            aria-label={t("Delete User")}
+            className="text-neutral-500 hover:bg-red-500/10 hover:text-red-500 dark:hover:text-red-400"
+            onClick={() => setDeleteOpen(true)}
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t("Delete User")}</TooltipContent>
+      </Tooltip>
 
       <IdentifyUserDialog anonymousId={data.user_id || userId} open={identifyOpen} onOpenChange={setIdentifyOpen} />
       <DeleteUserDialog userId={userId} open={deleteOpen} onOpenChange={setDeleteOpen} />

--- a/client/src/app/[site]/user/[userId]/components/UserHeader.tsx
+++ b/client/src/app/[site]/user/[userId]/components/UserHeader.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { Check, Clock, Copy } from "lucide-react";
+import { DateTime } from "luxon";
+import { useExtracted, useLocale } from "next-intl";
+import { useRef, useState } from "react";
+import { UserInfo } from "../../../../../api/analytics/endpoints";
+import { Avatar } from "../../../../../components/Avatar";
+import { IdentifiedBadge } from "../../../../../components/IdentifiedBadge";
+import { Skeleton } from "../../../../../components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../../../../components/ui/tooltip";
+import { useDateTimeFormat } from "../../../../../hooks/useDateTimeFormat";
+import { getTimezone } from "../../../../../lib/store";
+import { userStore } from "../../../../../lib/userStore";
+import { UserActions } from "./UserActions";
+
+// Considered "online" when the latest event is under five minutes old — the
+// same window the session avatars use for their presence dot.
+const ONLINE_WINDOW_SECONDS = 300;
+
+function CopyUserId({ value }: { value: string }) {
+  const t = useExtracted();
+  const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard unavailable (permissions/insecure context); leave the id selectable
+    }
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="inline-flex min-w-0 items-center gap-1 rounded-sm font-mono text-neutral-500 transition-colors hover:text-neutral-800 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400 dark:text-neutral-400 dark:hover:text-neutral-200"
+        >
+          <span className="max-w-[160px] truncate sm:max-w-[260px]">{value}</span>
+          {copied ? (
+            <Check className="h-3 w-3 shrink-0 text-emerald-500" />
+          ) : (
+            <Copy className="h-3 w-3 shrink-0 text-neutral-400 dark:text-neutral-500" />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{copied ? t("Copied!") : t("Copy user ID")}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+interface UserHeaderProps {
+  userId: string;
+  displayName: string;
+  data: UserInfo | undefined;
+  isLoading: boolean;
+}
+
+export function UserHeader({ userId, displayName, data, isLoading }: UserHeaderProps) {
+  const t = useExtracted();
+  const locale = useLocale();
+  const { user } = userStore();
+  const { formatRelative, formatDateTime, hour12 } = useDateTimeFormat();
+
+  const isIdentified = !!data?.identified_user_id;
+  const traitsEmail = data?.traits?.email as string | undefined;
+
+  // The user's clock, from the timezone captured on their latest event
+  const localTime = data?.timezone ? DateTime.now().setZone(data.timezone) : null;
+  const localTimeValid = localTime?.isValid ? localTime : null;
+  const timezoneCity = data?.timezone?.split("/").pop()?.replace(/_/g, " ");
+
+  const lastSeen = data?.last_seen ? DateTime.fromSQL(data.last_seen, { zone: "utc" }) : null;
+  // Empty ranges come back as epoch-zero timestamps; treat them as absent
+  const lastSeenValid = lastSeen?.isValid && lastSeen.year > 1970 ? lastSeen.setZone(getTimezone()) : null;
+  const isOnline = !!lastSeenValid && -lastSeenValid.diffNow().as("seconds") < ONLINE_WINDOW_SECONDS;
+
+  return (
+    <header className="mb-4 mt-4 flex flex-wrap items-start justify-between gap-x-6 gap-y-3">
+      <div className="flex min-w-0 items-center gap-3.5">
+        <Avatar size={52} id={userId} />
+        <div className="min-w-0">
+          {isLoading ? (
+            <>
+              <Skeleton className="h-6 w-44 rounded" />
+              <Skeleton className="mt-1.5 h-3.5 w-64 rounded" />
+            </>
+          ) : (
+            <>
+              <div className="flex min-w-0 items-center gap-2">
+                <h1 className="truncate text-lg font-semibold leading-tight text-neutral-900 dark:text-neutral-50">
+                  {displayName}
+                </h1>
+                {isIdentified && <IdentifiedBadge traits={data?.traits} userId={data?.identified_user_id} />}
+              </div>
+              <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-neutral-500 dark:text-neutral-400">
+                {isOnline ? (
+                  <span className="inline-flex items-center gap-1.5 font-medium text-emerald-700 dark:text-emerald-400">
+                    <span className="relative flex h-2 w-2">
+                      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-60 motion-reduce:hidden" />
+                      <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+                    </span>
+                    {t("Online")}
+                  </span>
+                ) : (
+                  lastSeenValid && (
+                    <span
+                      title={formatDateTime(lastSeenValid, {
+                        year: "numeric",
+                        month: "short",
+                        day: "numeric",
+                        hour: "numeric",
+                        minute: "2-digit",
+                        hour12,
+                        timeZone: getTimezone(),
+                      })}
+                    >
+                      {t("Active {time}", { time: formatRelative(lastSeenValid) })}
+                    </span>
+                  )
+                )}
+                {traitsEmail && (
+                  <span className="min-w-0 max-w-[240px] truncate" title={traitsEmail}>
+                    {traitsEmail}
+                  </span>
+                )}
+                <CopyUserId value={userId} />
+                {localTimeValid && (
+                  <span
+                    className="inline-flex items-center gap-1 whitespace-nowrap"
+                    title={`${t("Local time")} · ${data?.timezone}`}
+                  >
+                    <Clock className="h-3 w-3 text-neutral-400 dark:text-neutral-500" />
+                    {localTimeValid.setLocale(locale).toLocaleString(DateTime.TIME_SIMPLE)}
+                    {timezoneCity && <span className="text-neutral-400 dark:text-neutral-500">{timezoneCity}</span>}
+                  </span>
+                )}
+                {data?.ip && (
+                  <span className="whitespace-nowrap font-mono" title={t("IP address")}>
+                    {data.ip}
+                  </span>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+      {user && data && (
+        <div className="shrink-0">
+          <UserActions userId={userId} data={data} />
+        </div>
+      )}
+    </header>
+  );
+}

--- a/client/src/app/[site]/user/[userId]/components/UserJourneys.tsx
+++ b/client/src/app/[site]/user/[userId]/components/UserJourneys.tsx
@@ -1,15 +1,39 @@
 "use client";
 
+import { Route } from "lucide-react";
 import { useState } from "react";
 import { useExtracted } from "next-intl";
 import { useGetSite } from "../../../../../api/admin/hooks/useSites";
 import { useJourneys } from "../../../../../api/analytics/hooks/useGetJourneys";
-import { Card, CardContent } from "../../../../../components/ui/card";
+import { ErrorState } from "../../../../../components/ErrorState";
+import { Card, CardContent, CardLoader } from "../../../../../components/ui/card";
+import { Skeleton } from "../../../../../components/ui/skeleton";
 import { Slider } from "../../../../../components/ui/slider";
 import { useStore } from "../../../../../lib/store";
 import { SankeyDiagram } from "../../../journeys/components/SankeyDiagram";
 
 const MAX_JOURNEYS = 50;
+
+// Sankey-shaped placeholder: three columns of node blocks thinning to the right
+const SKELETON_COLUMNS: string[][] = [
+  ["h-12", "h-7", "h-4"],
+  ["h-9", "h-5", "h-3"],
+  ["h-6", "h-4"],
+];
+
+function JourneysSkeleton() {
+  return (
+    <div className="flex min-h-[160px] items-start gap-10 py-2" aria-hidden>
+      {SKELETON_COLUMNS.map((column, i) => (
+        <div key={i} className="flex flex-1 flex-col gap-2.5">
+          {column.map((height, j) => (
+            <Skeleton key={j} className={`${height} w-full rounded`} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export function UserJourneys({ userId }: { userId: string }) {
   const t = useExtracted();
@@ -18,7 +42,7 @@ export function UserJourneys({ userId }: { userId: string }) {
   const { data: siteMetadata } = useGetSite();
   const { time } = useStore();
 
-  const { data, isLoading, error } = useJourneys({
+  const { data, isLoading, isFetching, error, refetch } = useJourneys({
     siteId: siteMetadata?.siteId,
     steps,
     time,
@@ -30,11 +54,14 @@ export function UserJourneys({ userId }: { userId: string }) {
 
   return (
     <Card>
-      <CardContent className="mt-2">
-        <div className="flex items-center justify-between gap-4 mb-3">
-          <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-200">{t("Journeys")}</h3>
-          <div className="flex items-center gap-3 w-[160px]">
-            <span className="text-sm text-neutral-600 dark:text-neutral-300 whitespace-nowrap">
+      <CardContent className="pt-3">
+        {/* Step changes keep the previous diagram on screen; signal the refresh
+            the same way StandardSection does */}
+        {isFetching && !isLoading && <CardLoader />}
+        <div className="mb-3 flex items-center justify-between gap-4">
+          <h2 className="text-sm font-medium text-neutral-700 dark:text-neutral-200">{t("Journeys")}</h2>
+          <div className="flex w-[150px] items-center gap-2.5">
+            <span className="whitespace-nowrap text-xs tabular-nums text-neutral-500 dark:text-neutral-400">
               {t("{steps} steps", { steps: String(steps) })}
             </span>
             <Slider
@@ -47,29 +74,21 @@ export function UserJourneys({ userId }: { userId: string }) {
             />
           </div>
         </div>
-        <div className="relative min-h-[80px]">
-          {isLoading && (
-            <div className="absolute inset-0 bg-white/30 dark:bg-neutral-900/30 backdrop-blur-sm z-10 flex items-center justify-center">
-              <div className="flex flex-col items-center gap-2">
-                <div className="h-8 w-8 rounded-full border-2 border-accent-400 border-t-transparent animate-spin"></div>
-                <span className="text-sm text-neutral-600 dark:text-neutral-300">{t("Loading journey data...")}</span>
-              </div>
-            </div>
-          )}
-          {journeys.length > 0 && siteMetadata?.domain ? (
-            <SankeyDiagram journeys={journeys} steps={steps} maxJourneys={MAX_JOURNEYS} domain={siteMetadata.domain} />
-          ) : null}
-          {error && (
-            <p className="text-sm text-neutral-500 dark:text-neutral-400 py-4">
-              {t("Failed to load journey data. Please try again.")}
+        {isLoading ? (
+          <JourneysSkeleton />
+        ) : error ? (
+          <ErrorState title={t("Failed to load data")} message={error.message} refetch={refetch} />
+        ) : journeys.length > 0 && siteMetadata?.domain ? (
+          <SankeyDiagram journeys={journeys} steps={steps} maxJourneys={MAX_JOURNEYS} domain={siteMetadata.domain} />
+        ) : (
+          <div className="flex min-h-[160px] flex-col items-center justify-center gap-1 py-4 text-center">
+            <Route className="mb-1 h-5 w-5 text-neutral-400 dark:text-neutral-500" />
+            <p className="text-sm text-neutral-700 dark:text-neutral-200">{t("No journeys in this range")}</p>
+            <p className="max-w-[340px] text-xs text-neutral-500 dark:text-neutral-400">
+              {t("Journeys map the paths this user takes through your site. Try a wider date range.")}
             </p>
-          )}
-          {journeys.length === 0 && !isLoading && !error && (
-            <p className="text-sm text-neutral-500 dark:text-neutral-400 py-4">
-              {t("No journey data found for the selected criteria.")}
-            </p>
-          )}
-        </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/client/src/app/[site]/user/[userId]/components/UserLocationMap.tsx
+++ b/client/src/app/[site]/user/[userId]/components/UserLocationMap.tsx
@@ -5,15 +5,18 @@ import "mapbox-gl/dist/mapbox-gl.css";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { useTheme } from "next-themes";
+import { cn } from "../../../../../lib/utils";
+import { Skeleton } from "../../../../../components/ui/skeleton";
 import { useConfigs } from "../../../../../lib/configs";
 
 interface UserLocationMapProps {
   country: string;
   region: string;
   city: string;
+  className?: string;
 }
 
-export function UserLocationMap({ country, region, city }: UserLocationMapProps) {
+export function UserLocationMap({ country, region, city, className }: UserLocationMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const markerRef = useRef<mapboxgl.Marker | null>(null);
@@ -24,7 +27,7 @@ export function UserLocationMap({ country, region, city }: UserLocationMapProps)
 
   const style = resolvedTheme === "dark" ? "mapbox://styles/mapbox/dark-v11" : "mapbox://styles/mapbox/light-v11";
 
-  const { data: coordinates } = useQuery({
+  const { data: coordinates, isLoading } = useQuery({
     queryKey: ["user-location-geocode", configs?.mapboxToken, query],
     queryFn: () => geocodeUserLocation(configs!.mapboxToken, query),
     enabled: Boolean(configs?.mapboxToken && query),
@@ -48,12 +51,14 @@ export function UserLocationMap({ country, region, city }: UserLocationMapProps)
       container: containerRef.current,
       style,
       center: coordinates,
-      zoom: 1,
+      zoom: 4,
       pitch: 0,
       bearing: 0,
       antialias: true,
       attributionControl: false,
-      interactive: true,
+      // Static locator: panning/zooming a thumbnail this small only steals the
+      // page's scroll wheel
+      interactive: false,
     });
 
     mapRef.current = map;
@@ -68,12 +73,22 @@ export function UserLocationMap({ country, region, city }: UserLocationMapProps)
     };
   }, [configs?.mapboxToken, coordinates, style]);
 
-  if (!query || coordinates === null) return null;
+  if (!query) return null;
+
+  // Reserve the slot while geocoding so the card doesn't jump
+  if (isLoading) return <Skeleton className={cn("w-full rounded-md", className)} />;
+
+  // Geocoding failed: drop the section instead of framing an empty box
+  if (!coordinates) return null;
 
   return (
     <div
       ref={containerRef}
-      className="w-full h-full rounded-md overflow-hidden [&_.mapboxgl-ctrl-bottom-left]:hidden! [&_.mapboxgl-ctrl-logo]:hidden! [&_.mapboxgl-ctrl-bottom-right]:hidden!"
+      className={cn(
+        "w-full overflow-hidden rounded-md border border-neutral-100 dark:border-neutral-800",
+        "[&_.mapboxgl-ctrl-bottom-left]:hidden! [&_.mapboxgl-ctrl-logo]:hidden! [&_.mapboxgl-ctrl-bottom-right]:hidden!",
+        className
+      )}
     />
   );
 }

--- a/client/src/app/[site]/user/[userId]/components/UserSidebar.tsx
+++ b/client/src/app/[site]/user/[userId]/components/UserSidebar.tsx
@@ -1,18 +1,11 @@
 "use client";
 
 import { useExtracted } from "next-intl";
-import { getTimezone } from "@/lib/store";
-import { Calendar, CalendarCheck, Clock, Files, Globe, Laptop, Monitor, Pencil, Smartphone, Tablet } from "lucide-react";
-import { DateTime } from "luxon";
+import { Pencil } from "lucide-react";
 import { useState } from "react";
-import { Avatar, generateName } from "../../../../../components/Avatar";
-import { Badge } from "../../../../../components/ui/badge";
 import { Button } from "../../../../../components/ui/button";
-import { IdentifiedBadge } from "../../../../../components/IdentifiedBadge";
-import { useDateTimeFormat } from "../../../../../hooks/useDateTimeFormat";
-import { formatDuration } from "../../../../../lib/dateTimeUtils";
+import { Skeleton } from "../../../../../components/ui/skeleton";
 import { VisitCalendar } from "./Calendar";
-import { EventIcon, PageviewIcon } from "../../../../../components/EventIcons";
 import { UserInfo, UserSessionCountResponse } from "../../../../../api/analytics/endpoints";
 import { ChannelIcon, extractDomain, getDisplayName } from "../../../../../components/Channel";
 import { Favicon } from "../../../../../components/Favicon";
@@ -29,21 +22,21 @@ import {
 } from "../../../performance/utils/performanceUtils";
 import { EditTraitsDialog } from "../../../../../components/EditTraitsDialog";
 import { LocationDevices } from "./LocationDevices";
-import { InfoRow, InfoRowSkeleton, SidebarCard, StatCard } from "./SidebarPrimitives";
+import { InfoRow, InfoRowSkeleton, SidebarCard, SidebarHeader } from "./SidebarPrimitives";
 import { UserLocationMap } from "./UserLocationMap";
 
 interface UserSidebarProps {
   data: UserInfo | undefined;
   isLoading: boolean;
   sessionCount: UserSessionCountResponse[];
+  isLoadingCalendar: boolean;
   getRegionName: (region: string) => string;
 }
 
 const VITALS_ORDER: PerformanceMetric[] = ["lcp", "cls", "inp", "fcp", "ttfb"];
 
-export function UserSidebar({ data, isLoading, sessionCount, getRegionName }: UserSidebarProps) {
+export function UserSidebar({ data, isLoading, sessionCount, isLoadingCalendar, getRegionName }: UserSidebarProps) {
   const t = useExtracted();
-  const { formatRelative } = useDateTimeFormat();
   const { configs } = useConfigs();
   const { user } = userStore();
   const [traitsOpen, setTraitsOpen] = useState(false);
@@ -60,64 +53,13 @@ export function UserSidebar({ data, isLoading, sessionCount, getRegionName }: Us
   const vitalsToShow = vitals
     ? VITALS_ORDER.filter(metric => vitals[`${metric}_p75`] != null)
     : [];
+  const showMap = !!configs?.mapboxToken && !!data?.country;
 
   return (
-    <div className="w-full lg:w-[300px] md:shrink-0 space-y-3">
-      {/* Stats Grid */}
-      <SidebarCard>
-        <div className="grid grid-cols-2 gap-4">
-          <StatCard
-            icon={<Files className="w-3 h-3" />}
-            label={t("Sessions")}
-            value={data?.sessions ?? "—"}
-            isLoading={isLoading}
-          />
-          <StatCard
-            icon={<PageviewIcon className="w-3 h-3" />}
-            label={t("Pageviews")}
-            value={data?.pageviews ?? "—"}
-            isLoading={isLoading}
-          />
-          <StatCard
-            icon={<EventIcon className="w-3 h-3" />}
-            label={t("Events")}
-            value={data?.events ?? "—"}
-            isLoading={isLoading}
-          />
-          <StatCard
-            icon={<Clock className="w-3 h-3" />}
-            label={t("Avg Duration")}
-            value={data?.duration ? formatDuration(data.duration) : "—"}
-            isLoading={isLoading}
-          />
-          <StatCard
-            icon={<Calendar className="w-3 h-3" />}
-            label={t("First Seen")}
-            value={
-              data?.first_seen
-                ? DateTime.fromSQL(data.first_seen, { zone: "utc" }).setZone(getTimezone()).toLocaleString(DateTime.DATE_MED)
-                : "—"
-            }
-            isLoading={isLoading}
-          />
-          <StatCard
-            icon={<CalendarCheck className="w-3 h-3" />}
-            label={t("Last Seen")}
-            value={
-              data?.last_seen
-                ? DateTime.fromSQL(data.last_seen, { zone: "utc" }).setZone(getTimezone()).toLocaleString(DateTime.DATE_MED)
-                : "—"
-            }
-            isLoading={isLoading}
-          />
-        </div>
-      </SidebarCard>
-
+    <div className="w-full lg:w-[300px] lg:shrink-0 space-y-3">
       {/* Acquisition (first-touch attribution) */}
       <SidebarCard>
-        <h3 className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wide mb-2">
-          {t("Acquisition")}
-        </h3>
+        <SidebarHeader title={t("Acquisition")} />
         {isLoading ? (
           <div>
             <InfoRowSkeleton labelWidth="w-14" valueWidth="w-24" withIcon />
@@ -179,31 +121,51 @@ export function UserSidebar({ data, isLoading, sessionCount, getRegionName }: Us
 
       {/* Location & Device Info */}
       <SidebarCard>
-        <h3 className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wide mb-2">
-          {t("Location & Device")}
-        </h3>
+        <SidebarHeader title={t("Location & Device")} />
+        {showMap && data && !isLoading && (
+          <UserLocationMap
+            country={data.country}
+            region={data.region}
+            city={data.city}
+            className="mb-3 h-[132px]"
+          />
+        )}
         <LocationDevices data={data} isLoading={isLoading} getRegionName={getRegionName} />
       </SidebarCard>
 
-      {/* Activity Calendar */}
-      <SidebarCard className="h-[180px]">
-        <h3 className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wide mb-2">
-          {t("Activity Calendar")}
-        </h3>
+      {/* Activity Calendar — always the user's full recent history, independent
+          of the selected date range */}
+      <SidebarCard>
+        <SidebarHeader
+          title={t("Activity Calendar")}
+          right={
+            <span className="text-[10px] uppercase tracking-wide text-neutral-400 dark:text-neutral-500">
+              {t("Last 4 months")}
+            </span>
+          }
+        />
         <div className="h-[140px]">
-          <VisitCalendar sessionCount={sessionCount} />
+          {isLoadingCalendar ? (
+            <Skeleton className="h-full w-full rounded-md" />
+          ) : sessionCount.length > 0 ? (
+            <VisitCalendar sessionCount={sessionCount} />
+          ) : (
+            <div className="flex h-full items-center justify-center text-xs text-neutral-500 dark:text-neutral-400">
+              {t("No visits in the last 4 months")}
+            </div>
+          )}
         </div>
       </SidebarCard>
 
       {/* Web Vitals (p75 across this user's performance events) */}
       {vitals && vitalsToShow.length > 0 && (
         <SidebarCard>
-          <div className="flex items-center justify-between mb-2">
-            <h3 className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wide">
-              {t("Web Vitals")}
-            </h3>
-            <span className="text-[10px] text-neutral-400 dark:text-neutral-500 uppercase tracking-wide">p75</span>
-          </div>
+          <SidebarHeader
+            title={t("Web Vitals")}
+            right={
+              <span className="text-[10px] uppercase tracking-wide text-neutral-400 dark:text-neutral-500">p75</span>
+            }
+          />
           <div>
             {vitalsToShow.map(metric => {
               const value = vitals[`${metric}_p75`] as number;
@@ -234,22 +196,22 @@ export function UserSidebar({ data, isLoading, sessionCount, getRegionName }: Us
       {/* User Traits (identified users only) */}
       {isIdentified && data && (customTraits.length > 0 || !!user) && (
         <SidebarCard>
-          <div className="flex items-center justify-between mb-2">
-            <h3 className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wide">
-              {t("User Traits")}
-            </h3>
-            {user && (
-              <Button
-                variant="ghost"
-                size="smIcon"
-                className="-my-1.5 -mr-1.5 h-6 w-6 text-neutral-500"
-                aria-label={t("Edit Traits")}
-                onClick={() => setTraitsOpen(true)}
-              >
-                <Pencil className="w-3 h-3" />
-              </Button>
-            )}
-          </div>
+          <SidebarHeader
+            title={t("User Traits")}
+            right={
+              user ? (
+                <Button
+                  variant="ghost"
+                  size="smIcon"
+                  className="-my-1.5 -mr-1.5 h-6 w-6 text-neutral-500"
+                  aria-label={t("Edit Traits")}
+                  onClick={() => setTraitsOpen(true)}
+                >
+                  <Pencil className="w-3 h-3" />
+                </Button>
+              ) : undefined
+            }
+          />
           {customTraits.length > 0 ? (
             <div className="space-y-1">
               {customTraits.map(([key, value]) => (
@@ -273,42 +235,6 @@ export function UserSidebar({ data, isLoading, sessionCount, getRegionName }: Us
           />
         </SidebarCard>
       )}
-
-      {/* Location Map */}
-      {configs?.mapboxToken && data?.country && (
-        <div className="bg-white dark:bg-neutral-900 rounded-lg border border-neutral-100 dark:border-neutral-850 aspect-square overflow-hidden">
-          <UserLocationMap
-            country={data.country}
-            region={data.region}
-            city={data.city}
-          />
-        </div>
-      )}
-
-      {/* Linked Devices (identified users only) */}
-      {/* {isIdentified && data?.linked_devices && data.linked_devices.length > 0 && (
-        <SidebarCard>
-          <h3 className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wide mb-2 flex items-center gap-1.5">
-            <Laptop className="w-3 h-3" />
-            Linked Devices ({data.linked_devices.length})
-          </h3>
-          <div className="space-y-1 max-h-32 overflow-y-auto">
-            {data.linked_devices.map(device => (
-              <div
-                key={device.anonymous_id}
-                className="flex items-center justify-between py-1 border-b border-neutral-50 dark:border-neutral-850 last:border-0"
-              >
-                <span className="text-neutral-600 dark:text-neutral-300 font-mono text-xs truncate max-w-[140px]">
-                  {device.anonymous_id}
-                </span>
-                <span className="text-neutral-400 dark:text-neutral-500 text-xs">
-                  {formatRelative(DateTime.fromISO(device.created_at))}
-                </span>
-              </div>
-            ))}
-          </div>
-        </SidebarCard>
-      )} */}
     </div>
   );
 }

--- a/client/src/app/[site]/user/[userId]/components/UserStatBand.tsx
+++ b/client/src/app/[site]/user/[userId]/components/UserStatBand.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Calendar, CalendarCheck, Clock, Files } from "lucide-react";
+import { DateTime } from "luxon";
+import { useExtracted } from "next-intl";
+import { ReactNode } from "react";
+import { UserInfo } from "../../../../../api/analytics/endpoints";
+import { EventIcon, PageviewIcon } from "../../../../../components/EventIcons";
+import { Skeleton } from "../../../../../components/ui/skeleton";
+import { useDateTimeFormat } from "../../../../../hooks/useDateTimeFormat";
+import { formatDuration } from "../../../../../lib/dateTimeUtils";
+import { getTimezone } from "../../../../../lib/store";
+import { formatter } from "../../../../../lib/utils";
+
+function StatCell({
+  icon,
+  label,
+  value,
+  title,
+  isLoading,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: ReactNode;
+  title?: string;
+  isLoading: boolean;
+}) {
+  return (
+    <div className="min-w-0 bg-white px-3.5 py-2.5 dark:bg-neutral-900">
+      <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+        {icon}
+        <span className="truncate">{label}</span>
+      </div>
+      {isLoading ? (
+        <Skeleton className="mt-1.5 h-4 w-16 rounded" />
+      ) : (
+        <div
+          className="mt-0.5 truncate text-base font-semibold tabular-nums text-neutral-900 dark:text-neutral-50"
+          title={title}
+        >
+          {value}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Full-width engagement summary: one flat strip of six cells separated by
+// hairline seams (gap-px over the border color), wrapping 6 → 3 → 2 per row.
+export function UserStatBand({ data, isLoading }: { data: UserInfo | undefined; isLoading: boolean }) {
+  const t = useExtracted();
+  const { formatRelative, formatDateTime, hour12 } = useDateTimeFormat();
+
+  const timezone = getTimezone();
+  const toLocal = (sql: string | undefined) => {
+    if (!sql) return null;
+    const dt = DateTime.fromSQL(sql, { zone: "utc" }).setZone(timezone);
+    // Empty ranges come back as epoch-zero timestamps; treat them as absent
+    return dt.isValid && dt.year > 1970 ? dt : null;
+  };
+  const firstSeen = toLocal(data?.first_seen);
+  const lastSeen = toLocal(data?.last_seen);
+  const absolute = (dt: DateTime) =>
+    formatDateTime(dt, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12,
+      timeZone: timezone,
+    });
+
+  const count = (value: number | undefined) => (value != null ? formatter(value) : "—");
+  const countTitle = (value: number | undefined) => (value != null ? value.toLocaleString() : undefined);
+
+  return (
+    <div className="mb-4 overflow-hidden rounded-lg border border-neutral-100 dark:border-neutral-850">
+      <div className="grid grid-cols-2 gap-px bg-neutral-100 dark:bg-neutral-850 sm:grid-cols-3 lg:grid-cols-6">
+        <StatCell
+          icon={<Files className="h-3 w-3" />}
+          label={t("Sessions")}
+          value={count(data?.sessions)}
+          title={countTitle(data?.sessions)}
+          isLoading={isLoading}
+        />
+        <StatCell
+          icon={<PageviewIcon className="h-3 w-3" />}
+          label={t("Pageviews")}
+          value={count(data?.pageviews)}
+          title={countTitle(data?.pageviews)}
+          isLoading={isLoading}
+        />
+        <StatCell
+          icon={<EventIcon className="h-3 w-3" />}
+          label={t("Events")}
+          value={count(data?.events)}
+          title={countTitle(data?.events)}
+          isLoading={isLoading}
+        />
+        <StatCell
+          icon={<Clock className="h-3 w-3" />}
+          label={t("Avg Duration")}
+          value={data?.duration ? formatDuration(data.duration) : "—"}
+          isLoading={isLoading}
+        />
+        <StatCell
+          icon={<Calendar className="h-3 w-3" />}
+          label={t("First Seen")}
+          value={firstSeen ? formatRelative(firstSeen) : "—"}
+          title={firstSeen ? absolute(firstSeen) : undefined}
+          isLoading={isLoading}
+        />
+        <StatCell
+          icon={<CalendarCheck className="h-3 w-3" />}
+          label={t("Last Seen")}
+          value={lastSeen ? formatRelative(lastSeen) : "—"}
+          title={lastSeen ? absolute(lastSeen) : undefined}
+          isLoading={isLoading}
+        />
+      </div>
+    </div>
+  );
+}

--- a/client/src/app/[site]/user/[userId]/components/UserTopPages.tsx
+++ b/client/src/app/[site]/user/[userId]/components/UserTopPages.tsx
@@ -17,7 +17,7 @@ export function UserTopPages({ userId }: { userId: string }) {
 
   return (
     <Card>
-      <CardContent className="mt-2">
+      <CardContent className="pt-3">
         <Tabs defaultValue="pages" value={tab} onValueChange={value => setTab(value as Tab)}>
           <div className="flex flex-row gap-2 items-center">
             <TabsList>

--- a/client/src/app/[site]/user/[userId]/page.tsx
+++ b/client/src/app/[site]/user/[userId]/page.tsx
@@ -32,7 +32,7 @@ import { Badge } from "../../../../components/ui/badge";
 import { Pagination } from "../../../../components/pagination";
 import { Skeleton } from "../../../../components/ui/skeleton";
 import { generateName } from "../../../../components/Avatar";
-import { formatter } from "../../../../lib/utils";
+import { formatter, getUserDisplayName } from "../../../../lib/utils";
 import { UserJourneys } from "./components/UserJourneys";
 import { UserTopPages } from "./components/UserTopPages";
 
@@ -70,10 +70,9 @@ export default function UserPage() {
 
   const { getRegionName } = useGetRegionName();
 
-  const traitsUsername = data?.traits?.username as string | undefined;
-  const traitsName = data?.traits?.name as string | undefined;
-  const isIdentified = !!data?.identified_user_id;
-  const displayName = traitsUsername || traitsName || (isIdentified ? userId : generateName(userId));
+  // Same resolution the session cards use; before user info arrives, fall back
+  // to the deterministic generated name for the route id
+  const displayName = data ? getUserDisplayName(data) : generateName(userId);
 
   useSetPageTitle(isLoading ? "User" : displayName);
 

--- a/client/src/app/[site]/user/[userId]/page.tsx
+++ b/client/src/app/[site]/user/[userId]/page.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useExtracted, useLocale } from "next-intl";
+import { useExtracted } from "next-intl";
 import { SessionsList } from "@/components/Sessions/SessionsList";
-import { ChevronLeft, ChevronRight, Clock } from "lucide-react";
-import { DateTime } from "luxon";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useUserInfo } from "../../../../api/analytics/hooks/userGetInfo";
 import { useGetSessions, useGetUserSessionCount } from "../../../../api/analytics/hooks/useGetUserSessions";
 import { DateSelector } from "../../../../components/DateSelector/DateSelector";
@@ -25,26 +24,24 @@ import {
 } from "../../../../components/ui/breadcrumb";
 import { useSetPageTitle } from "../../../../hooks/useSetPageTitle";
 import { useGetRegionName } from "../../../../lib/geo";
-import { userStore } from "../../../../lib/userStore";
 import { MobileSidebar } from "../../components/Sidebar/MobileSidebar";
-import { UserActions } from "./components/UserActions";
+import { UserHeader } from "./components/UserHeader";
 import { UserSidebar } from "./components/UserSidebar";
-import { Skeleton } from "../../../../components/ui/skeleton";
-import { Avatar, generateName } from "../../../../components/Avatar";
+import { UserStatBand } from "./components/UserStatBand";
 import { Badge } from "../../../../components/ui/badge";
-import { IdentifiedBadge } from "../../../../components/IdentifiedBadge";
+import { Pagination } from "../../../../components/pagination";
+import { Skeleton } from "../../../../components/ui/skeleton";
+import { generateName } from "../../../../components/Avatar";
+import { formatter } from "../../../../lib/utils";
 import { UserJourneys } from "./components/UserJourneys";
 import { UserTopPages } from "./components/UserTopPages";
 
 const LIMIT = 25;
 
 export default function UserPage() {
-  useSetPageTitle("User");
   const t = useExtracted();
 
-  const locale = useLocale();
   const { userId: rawUserId, site } = useParams();
-  const { user } = userStore();
   const { time, setTime } = useStore();
   const userId = (() => {
     const value = Array.isArray(rawUserId) ? rawUserId[0] : rawUserId;
@@ -56,9 +53,10 @@ export default function UserPage() {
     }
   })();
   const [page, setPage] = useState(1);
+  const sessionsRef = useRef<HTMLDivElement>(null);
 
   const { data, isLoading } = useUserInfo(Number(site), userId);
-  const { data: sessionCount } = useGetUserSessionCount(userId);
+  const { data: sessionCount, isLoading: isLoadingCalendar } = useGetUserSessionCount(userId);
   const { data: sessionsData, isLoading: isLoadingSessions } = useGetSessions({
     userId,
     page: page,
@@ -74,14 +72,16 @@ export default function UserPage() {
 
   const traitsUsername = data?.traits?.username as string | undefined;
   const traitsName = data?.traits?.name as string | undefined;
-  const traitsEmail = data?.traits?.email as string | undefined;
   const isIdentified = !!data?.identified_user_id;
   const displayName = traitsUsername || traitsName || (isIdentified ? userId : generateName(userId));
 
-  // The user's clock, from the timezone captured on their latest event
-  const localTime = data?.timezone ? DateTime.now().setZone(data.timezone) : null;
-  const localTimeValid = localTime?.isValid ? localTime : null;
-  const timezoneCity = data?.timezone?.split("/").pop()?.replace(/_/g, " ");
+  useSetPageTitle(isLoading ? "User" : displayName);
+
+  // Bottom pagination: restore context by jumping back to the top of the list
+  const handleBottomPageChange = (nextPage: number) => {
+    setPage(nextPage);
+    sessionsRef.current?.scrollIntoView({ block: "start" });
+  };
 
   return (
     <div className="p-2 md:p-4 max-w-[1200px] mx-auto">
@@ -94,12 +94,15 @@ export default function UserPage() {
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem className="min-w-0">
-            <BreadcrumbPage className="truncate">{isLoading ? t("Loading...") : displayName}</BreadcrumbPage>
+            <BreadcrumbPage className="truncate">
+              {isLoading ? <Skeleton className="h-4 w-28 rounded" /> : displayName}
+            </BreadcrumbPage>
           </BreadcrumbItem>
         </BreadcrumbList>
       </Breadcrumb>
-      {/* Header */}
-      <div className="flex items-center gap-2 mt-2 mb-3">
+
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 mt-2">
         <MobileSidebar />
         <div className="hidden md:block">
           <NewFilterButton availableFilters={USER_DETAIL_PAGE_FILTERS} />
@@ -128,79 +131,59 @@ export default function UserPage() {
           </div>
         </div>
       </div>
-      <div className="md:hidden mb-2">
+      <div className="md:hidden mt-2">
         <NewFilterButton availableFilters={USER_DETAIL_PAGE_FILTERS} />
       </div>
       <Filters availableFilters={USER_DETAIL_PAGE_FILTERS} />
 
-      <div className="flex items-center gap-4 mb-4">
-        <Avatar size={64} id={userId} />
-        <div className="mt-3 w-full flex gap-2">
-          <div>
-            <div className="font-semibold text-lg flex items-center gap-2">
-              {isLoading ? <Skeleton className="h-6 w-32" /> : displayName}
-              {!isLoading && isIdentified && (
-                <IdentifiedBadge traits={data?.traits} userId={data?.identified_user_id} />
-              )}
-            </div>
-            {isLoading ? (
-              <div className="flex flex-col items-center gap-1 mt-1">
-                <Skeleton className="h-4 w-40" />
-                <Skeleton className="h-3 w-24" />
-              </div>
-            ) : (
-              <>
-                {traitsEmail && <p className="text-neutral-500 dark:text-neutral-400 text-sm mt-0.5">{traitsEmail}</p>}
-                <p className="text-neutral-400 dark:text-neutral-500 text-xs font-mono mt-1 truncate">{userId}</p>
-              </>
+      <UserHeader userId={userId} displayName={displayName} data={data} isLoading={isLoading} />
+
+      <UserStatBand data={data} isLoading={isLoading} />
+
+      {/* Main content leads in the DOM so activity comes first on mobile;
+          row-reverse puts the profile rail back on the left on desktop */}
+      <div className="flex flex-col gap-4 lg:flex-row-reverse">
+        <div className="flex-1 min-w-0 space-y-4">
+          <UserTopPages userId={userId} />
+          <UserJourneys userId={userId} />
+          <div ref={sessionsRef} className="scroll-mt-4 space-y-3">
+            <SessionsList
+              sessions={sessions}
+              isLoading={isLoadingSessions}
+              page={page}
+              onPageChange={setPage}
+              hasNextPage={hasNextPage}
+              hasPrevPage={hasPrevPage}
+              userId={userId}
+              headerElement={
+                <div className="flex items-center gap-2">
+                  <h2 className="text-sm font-medium text-neutral-700 dark:text-neutral-200">{t("Sessions")}</h2>
+                  {!isLoading && data?.sessions != null && (
+                    <Badge variant="secondary" className="tabular-nums" title={data.sessions.toLocaleString()}>
+                      {formatter(data.sessions)}
+                    </Badge>
+                  )}
+                </div>
+              }
+            />
+            {!isLoadingSessions && sessions.length >= 10 && (hasNextPage || hasPrevPage) && (
+              <Pagination
+                page={page}
+                onPageChange={handleBottomPageChange}
+                hasPreviousPage={hasPrevPage}
+                hasNextPage={hasNextPage}
+              />
             )}
           </div>
         </div>
-        <div className="ml-auto flex items-center gap-2">
-          {localTimeValid && (
-            <Badge
-              variant="outline"
-              className="text-xs whitespace-nowrap"
-              title={`${t("Local time")} · ${data?.timezone}`}
-            >
-              <Clock className="w-3 h-3 mr-1 text-neutral-400 dark:text-neutral-500" />
-              {localTimeValid.setLocale(locale).toLocaleString(DateTime.TIME_SIMPLE)}
-              {timezoneCity && <span className="text-neutral-400 dark:text-neutral-500 ml-1">{timezoneCity}</span>}
-            </Badge>
-          )}
-          {data?.ip && (
-            <Badge variant="outline" className="text-xs whitespace-nowrap">
-              IP: {data.ip}
-            </Badge>
-          )}
-          {user && data && <UserActions userId={userId} data={data} />}
-        </div>
-      </div>
 
-      {/* Main two-column layout */}
-      <div className="flex flex-col lg:flex-row gap-4">
-        {/* Left Sidebar */}
         <UserSidebar
           data={data}
           isLoading={isLoading}
           sessionCount={sessionCount?.data ?? []}
+          isLoadingCalendar={isLoadingCalendar}
           getRegionName={getRegionName}
         />
-
-        {/* Right Content - Sessions */}
-        <div className="flex-1 min-w-0 space-y-4">
-          <UserTopPages userId={userId} />
-          <UserJourneys userId={userId} />
-          <SessionsList
-            sessions={sessions}
-            isLoading={isLoadingSessions}
-            page={page}
-            onPageChange={setPage}
-            hasNextPage={hasNextPage}
-            hasPrevPage={hasPrevPage}
-            userId={userId}
-          />
-        </div>
       </div>
     </div>
   );

--- a/client/src/components/Sessions/SessionCard.tsx
+++ b/client/src/components/Sessions/SessionCard.tsx
@@ -76,20 +76,24 @@ export function SessionCard({ session, onClick, userId, expandedByDefault, highl
       <div className="p-3 cursor-pointer" onClick={handleCardClick}>
         {/* Mobile layout - two rows */}
         <div className="flex flex-col gap-2 md:hidden">
-          {/* Top row on mobile - User name (left) + Timestamp (right) */}
+          {/* Top row on mobile - User name (left) + Timestamp (right).
+              On a single user's page the name repeats on every card, so it is
+              hidden there, matching the desktop layout. */}
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Avatar
-                size={24}
-                id={session.user_id}
-                lastActiveTime={DateTime.fromSQL(session.session_end, { zone: "utc" })}
-              />
-              <span className="text-xs text-neutral-600 dark:text-neutral-200 truncate max-w-[150px]">
-                {getUserDisplayName(session)}
-              </span>
-              {!!session.identified_user_id && <IdentifiedBadge traits={session.traits} userId={session.identified_user_id} />}
-            </div>
-            <span className="text-xs text-neutral-500 dark:text-neutral-400 ">
+            {!userId && (
+              <div className="flex items-center gap-2">
+                <Avatar
+                  size={24}
+                  id={session.user_id}
+                  lastActiveTime={DateTime.fromSQL(session.session_end, { zone: "utc" })}
+                />
+                <span className="text-xs text-neutral-600 dark:text-neutral-200 truncate max-w-[150px]">
+                  {getUserDisplayName(session)}
+                </span>
+                {!!session.identified_user_id && <IdentifiedBadge traits={session.traits} userId={session.identified_user_id} />}
+              </div>
+            )}
+            <span className="ml-auto text-xs text-neutral-500 dark:text-neutral-400">
               <span className="group-hover/card:hidden">
                 {formatDateTime(DateTime.fromSQL(session.session_start, { zone: "utc" }), {
                   month: "short",
@@ -365,11 +369,13 @@ export const SessionCardSkeleton = memo(({ userId, count }: { userId?: string; c
         <div className="flex flex-col gap-2 md:hidden">
           {/* Top row - Avatar + name (left) + timestamp (right) */}
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Skeleton className="h-6 w-6 rounded-full" />
-              <Skeleton className="h-3 w-24" />
-            </div>
-            <Skeleton className={cn("h-3", getRandomTimeWidth())} />
+            {!userId && (
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-6 w-6 rounded-full" />
+                <Skeleton className="h-3 w-24" />
+              </div>
+            )}
+            <Skeleton className={cn("ml-auto h-3", getRandomTimeWidth())} />
           </div>
 
           {/* Bottom row - Icons, badges, channel */}


### PR DESCRIPTION
- Compose the identity header: presence (Online / Active Nh ago), copyable user ID, email, local time and IP in one meta row
- Move the six engagement stats into a full-width seam-divided band
- Embed the location map in Location & Device; region zoom, no scroll trap
- Activity calendar: loading and empty states, "last 4 months" scope hint
- Sessions: section header with total count, bottom pagination that returns to the top of the list
- Journeys: sankey-shaped skeleton, teaching empty state, error retry, refetch indicator on step changes
- Mobile: activity ordered before profile details; session cards no longer repeat the user's own name on their page
- Fix epoch-zero first/last seen on empty ranges and a malformed /sites//sessions request racing store hydration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refreshed the user detail page with dedicated header, engagement stat band, and sidebar sections (including presence, contact metadata, traits, web vitals, and location/device).
  * Improved journeys UI with skeleton loading, explicit error + retry, and a friendly empty state.
  * Added tooltip-enhanced “Delete User” guidance and improved user-id copy-to-clipboard feedback.
* **Bug Fixes**
  * Prevented analytics session queries from running before site data is ready.
  * Updated location map behavior and rendering for loading/failure states (including new non-interactive thumbnail).
* **Refactor**
  * Streamlined session pagination and mobile layout alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->