### PR TITLE
claude-persona-1

### DIFF
--- a/docs/src/app/[locale]/(home)/enterprise/page.tsx
+++ b/docs/src/app/[locale]/(home)/enterprise/page.tsx
@@ -1,0 +1,268 @@
+import { CTASection } from "@/components/CTASection";
+import { GridCrosses } from "@/components/GridCrosses";
+import { InteriorPageHero } from "@/components/InteriorPageHero";
+import { PersonaCrossLinks } from "@/components/persona/PersonaCrossLinks";
+import { PersonaFaqSection } from "@/components/persona/PersonaFaqSection";
+import { SectionKicker } from "@/components/deco/SectionKicker";
+import { createMetadata, createOGImageUrl } from "@/lib/metadata";
+import { ArrowRight, ExternalLink } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+
+const pageTitle = "Rybbit for Enterprise | Open-Source Analytics Your Security Team Can Read";
+const pageDescription =
+  "SSO, dedicated isolated instances, on-premise installation, infinite retention, whitelabeling, and an uptime SLA — on a 100% open-source codebase your security review can audit line by line.";
+
+export const metadata = createMetadata({
+  title: pageTitle,
+  description: pageDescription,
+  alternates: {
+    canonical: "https://rybbit.com/enterprise",
+  },
+  openGraph: {
+    title: pageTitle,
+    description: pageDescription,
+    url: "https://rybbit.com/enterprise",
+    images: [createOGImageUrl("Rybbit for Enterprise", "Open-source analytics your security team can read.", "Solutions")],
+  },
+  twitter: {
+    images: [createOGImageUrl("Rybbit for Enterprise", "Open-source analytics your security team can read.", "Solutions")],
+  },
+});
+
+const faqItems = [
+  {
+    question: "Can we run Rybbit on our own infrastructure?",
+    answer:
+      "Yes. Enterprise includes on-premise installation and dedicated isolated instances, and the product itself is open source under AGPL v3 — self-hosting is free for personal and business use.",
+  },
+  {
+    question: "Does Rybbit support Single Sign-On?",
+    answer:
+      "Yes, SSO is included on the Enterprise plan. Contact us about your identity provider and setup.",
+  },
+  {
+    question: "How long is data retained?",
+    answer:
+      "Standard keeps 3 years, Pro keeps 5, and Enterprise retention is infinite — your history doesn't expire out from under you.",
+  },
+  {
+    question: "What does enterprise support look like?",
+    answer:
+      "Enterprise includes an uptime SLA, enterprise support with Slack or live chat, and manual invoicing for procurement processes that need it.",
+  },
+  {
+    question: "Is there a Data Processing Agreement?",
+    answer:
+      "Yes — a DPA is available at rybbit.com/dpa, alongside a public security page. The cloud is EU-hosted, and visitor tracking is cookieless with daily-salted IDs.",
+  },
+  {
+    question: "Can we white-label the dashboard?",
+    answer:
+      "Yes. Whitelabeling is an Enterprise feature, along with custom features scoped to your deployment — talk to us about what your rollout needs.",
+  },
+];
+
+// Same white-SVG treatment the homepage logo band uses.
+const whiteSvgLogo = "opacity-40 invert dark:opacity-60 dark:invert-0";
+
+const enterpriseLogos = [
+  { src: "/logos/bosch.svg", alt: "Bosch", width: 120, className: whiteSvgLogo },
+  { src: "/logos/govuk-logo.svg", alt: "GOV.UK", width: 120, className: whiteSvgLogo },
+  { src: "/logos/royalcaribbean.svg", alt: "Royal Caribbean", width: 120, className: whiteSvgLogo },
+  { src: "/logos/op.svg", alt: "OP.GG", width: 120, className: whiteSvgLogo },
+  { src: "/logos/ustwo.svg", alt: "ustwo", width: 100, className: whiteSvgLogo },
+  { src: "/logos/softr.svg", alt: "Softr", width: 100, className: whiteSvgLogo },
+];
+
+const enterpriseFeatures = [
+  {
+    title: "Single Sign-On",
+    description: "Bring analytics under your identity provider instead of another password.",
+  },
+  {
+    title: "Dedicated isolated instance",
+    description: "Your organization's data on its own instance, separated from every other tenant.",
+  },
+  {
+    title: "On-premise installation",
+    description: "Run the full product inside your own network when the data can't leave.",
+  },
+  {
+    title: "Infinite data retention",
+    description: "Year-over-year comparisons that still work a decade from now.",
+  },
+  {
+    title: "Whitelabeling",
+    description: "Your brand on the dashboards your teams and clients see.",
+  },
+  {
+    title: "Uptime SLA",
+    description: "A contractual availability commitment, not a status-page promise.",
+  },
+  {
+    title: "Enterprise support",
+    description: "Slack or live-chat support with the people who build the product.",
+  },
+  {
+    title: "Manual invoicing",
+    description: "Purchase orders and procurement-friendly billing, when card payments don't fit.",
+  },
+];
+
+export default function EnterprisePage() {
+  return (
+    <div className="overflow-x-clip">
+      <InteriorPageHero
+        eyebrow="Rybbit for enterprise"
+        title="Open-source analytics your security team can read."
+        description="SSO, dedicated instances, on-premise installation, infinite retention, and an SLA — on a codebase your security review can audit line by line instead of taking on faith."
+        eventLocation="enterprise_hero"
+        primaryAction={{ href: "/contact", label: "Contact us", eventName: "contact" }}
+        note="Prefer self-serve? Every plan starts with a 7-day free trial."
+      />
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="enterprise-proof">
+        <div className="relative mx-auto grid max-w-[1200px] grid-cols-2 gap-px border-x border-neutral-200 bg-neutral-200 p-px dark:border-neutral-800 dark:bg-neutral-800 sm:grid-cols-3 lg:grid-cols-6">
+          <GridCrosses />
+          <div className="col-span-full flex min-h-14 items-center bg-white px-5 dark:bg-neutral-950 sm:px-8">
+            <p id="enterprise-proof" className="text-sm font-medium text-neutral-600 dark:text-neutral-400">
+              Trusted by 10,000+ organizations worldwide
+            </p>
+          </div>
+          {enterpriseLogos.map(logo => (
+            <div key={logo.alt} className="flex min-h-24 items-center justify-center bg-white dark:bg-neutral-950">
+              <Image
+                src={logo.src}
+                alt={logo.alt}
+                width={logo.width}
+                height={40}
+                className={`max-h-7 w-auto max-w-[112px] ${logo.className}`}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="enterprise-features-title">
+        <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+          <GridCrosses />
+          <div className="border-b border-neutral-200 px-5 py-12 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 lg:py-16">
+            <div className="lg:sticky lg:top-24">
+              <SectionKicker>The Enterprise plan</SectionKicker>
+              <h2
+                id="enterprise-features-title"
+                className="mt-5 max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+              >
+                Everything procurement will ask about.
+              </h2>
+              <p className="mt-6 max-w-sm text-base leading-7 text-neutral-600 dark:text-neutral-400">
+                Enterprise is everything in Pro — funnels, replays, unlimited websites and team members — plus the
+                layer large organizations actually negotiate over.
+              </p>
+              <Link
+                href="/pricing"
+                className="group mt-8 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+              >
+                Compare all plans
+                <ArrowRight
+                  className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                  aria-hidden="true"
+                />
+              </Link>
+            </div>
+          </div>
+          <div className="grid lg:col-span-8 sm:grid-cols-2">
+            {enterpriseFeatures.map((feature, index) => (
+              <article
+                key={feature.title}
+                className={`border-b border-neutral-200 px-5 py-8 dark:border-neutral-800 sm:px-8 lg:px-10 ${
+                  index % 2 === 0 ? "sm:border-r" : ""
+                } ${index >= enterpriseFeatures.length - 2 ? "sm:[&:nth-last-child(-n+2)]:border-b-0" : ""}`}
+              >
+                <h3 className="font-semibold tracking-tight">{feature.title}</h3>
+                <p className="mt-2 max-w-md text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                  {feature.description}
+                </p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="enterprise-audit-title">
+        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+          <GridCrosses />
+          <div className="grid grid-cols-1 lg:grid-cols-12">
+            <div className="relative border-b border-neutral-200 bg-plate-accent px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-7 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 bg-graph-accent [mask-image:linear-gradient(to_bottom,black,transparent_92%)]"
+              />
+              <div className="relative">
+                <SectionKicker>Auditability</SectionKicker>
+                <h2
+                  id="enterprise-audit-title"
+                  className="mt-5 max-w-2xl text-4xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl"
+                >
+                  Vendor reviews go faster when the vendor is source-available.
+                </h2>
+              </div>
+            </div>
+            <div className="flex flex-col justify-center px-5 py-10 sm:px-8 md:py-20 lg:col-span-5 lg:px-10">
+              <p className="max-w-md text-lg leading-8 text-neutral-600 text-pretty dark:text-neutral-400">
+                Every line of Rybbit — including the cloud and enterprise code — is public on GitHub under AGPL v3.
+                Your security team reviews the actual data path, not a marketing diagram of it.
+              </p>
+              <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-3 text-sm">
+                <a
+                  href="https://github.com/rybbit-io/rybbit"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group inline-flex items-center gap-1.5 rounded-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+                >
+                  Read the source
+                  <ExternalLink
+                    className="size-3.5 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                    aria-hidden="true"
+                  />
+                </a>
+                <Link
+                  href="/security"
+                  className="group inline-flex items-center gap-1.5 rounded-sm font-medium text-neutral-600 transition-colors duration-200 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 dark:text-neutral-400 dark:hover:text-white"
+                >
+                  Security overview
+                  <ArrowRight
+                    className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                    aria-hidden="true"
+                  />
+                </Link>
+                <Link
+                  href="/dpa"
+                  className="group inline-flex items-center gap-1.5 rounded-sm font-medium text-neutral-600 transition-colors duration-200 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 dark:text-neutral-400 dark:hover:text-white"
+                >
+                  DPA
+                  <ArrowRight
+                    className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                    aria-hidden="true"
+                  />
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <PersonaFaqSection heading="Enterprise questions, answered plainly." items={faqItems} />
+      <PersonaCrossLinks current="enterprise" />
+
+      <CTASection
+        title="Bring your security team. We like it that way."
+        description="SSO, dedicated instances, on-prem, and an SLA — on a codebase you can audit before you sign."
+        primaryButtonText="Contact us"
+        primaryButtonHref="/contact"
+        eventLocation="enterprise_bottom_cta"
+      />
+    </div>
+  );
+}

--- a/docs/src/app/[locale]/(home)/for-agencies/page.tsx
+++ b/docs/src/app/[locale]/(home)/for-agencies/page.tsx
@@ -1,0 +1,394 @@
+import { CTASection } from "@/components/CTASection";
+import { GridCrosses } from "@/components/GridCrosses";
+import { InteriorPageHero } from "@/components/InteriorPageHero";
+import { SectionKicker } from "@/components/deco/SectionKicker";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { createMetadata, createOGImageUrl } from "@/lib/metadata";
+import { ArrowRight, ExternalLink, Link2, Mail } from "lucide-react";
+import Link from "next/link";
+
+const pageTitle = "Rybbit for Agencies | Client-Friendly Web Analytics";
+const pageDescription =
+  "Run every client site from one workspace. Dashboards clients can read without a training call, automated email reports, share links without accounts, and unlimited websites on Pro.";
+
+export const metadata = createMetadata({
+  title: pageTitle,
+  description: pageDescription,
+  alternates: {
+    canonical: "https://rybbit.com/for-agencies",
+  },
+  openGraph: {
+    title: pageTitle,
+    description: pageDescription,
+    url: "https://rybbit.com/for-agencies",
+    images: [createOGImageUrl("Rybbit for Agencies", "Every client site in one workspace, on dashboards clients can actually read.", "Solutions")],
+  },
+  twitter: {
+    images: [createOGImageUrl("Rybbit for Agencies", "Every client site in one workspace, on dashboards clients can actually read.", "Solutions")],
+  },
+});
+
+// Rendered in the accordion AND emitted as FAQPage JSON-LD from the same
+// array, so the schema can never drift from the visible answers.
+const faqItems = [
+  {
+    question: "Can my clients see their dashboard without a Rybbit account?",
+    answer:
+      "Yes. Share any dashboard with a secret link or make it fully public. People with the link see that site's dashboard and nothing else — no account required.",
+  },
+  {
+    question: "How many websites can I add?",
+    answer:
+      "The Standard plan includes up to 5 websites. Pro includes unlimited websites, so every client site fits under one subscription.",
+  },
+  {
+    question: "Can I give a client or teammate limited access?",
+    answer:
+      "Yes. Organizations support member roles, so you control who can view dashboards and who can manage sites and settings.",
+  },
+  {
+    question: "Do client sites need a cookie consent banner for Rybbit?",
+    answer:
+      "No. Rybbit doesn't use cookies or collect personal data, so it's GDPR and CCPA compliant without a consent banner.",
+  },
+  {
+    question: "Can I white-label Rybbit for my clients?",
+    answer:
+      "White-labeling is available on the Enterprise plan, along with dedicated instances and on-premise installation. Contact us to talk through your setup.",
+  },
+  {
+    question: "What happens if a client wants to take over their analytics?",
+    answer:
+      "Nothing is locked in: Rybbit is open source, with API access and data export on every plan. Worst case, they can self-host the exact same product.",
+  },
+];
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqItems.map(item => ({
+    "@type": "Question",
+    name: item.question,
+    acceptedAnswer: { "@type": "Answer", text: item.answer },
+  })),
+};
+
+// Fake-but-concrete workspace rows, in the landing page's mock-data idiom.
+const workspaceRows = [
+  { domain: "acme-cycles.com", visitors: "12.4k", delta: "+8%" },
+  { domain: "harbor-dental.co", visitors: "3.1k", delta: "+21%" },
+  { domain: "fernwood.studio", visitors: "9.8k", delta: "+4%" },
+];
+
+const tierFacts = [
+  { tier: "Standard", fact: "Up to 5 websites and 3 team members" },
+  { tier: "Pro", fact: "Unlimited websites, unlimited team members" },
+  { tier: "Enterprise", fact: "White-labeling, SSO, dedicated instance" },
+];
+
+export default function ForAgenciesPage() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <div className="overflow-x-clip">
+        <InteriorPageHero
+          eyebrow="Rybbit for agencies"
+          title="Client reporting without the training call."
+          description="Run every client site from one workspace. Hand clients a dashboard they can read in thirty seconds — no GA4 walkthroughs, no cookie-banner liability on their sites, no per-site fees eating your margin."
+          eventLocation="for_agencies_hero"
+        />
+
+        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="agency-problem-title">
+          <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+            <GridCrosses />
+            <div className="grid grid-cols-1 lg:grid-cols-12">
+              <div className="relative border-b border-neutral-200 bg-plate-accent px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-7 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-0 bg-graph-accent [mask-image:linear-gradient(to_bottom,black,transparent_92%)]"
+                />
+                <div className="relative">
+                  <SectionKicker>The client problem</SectionKicker>
+                  <h2
+                    id="agency-problem-title"
+                    className="mt-5 max-w-2xl text-4xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl"
+                  >
+                    Your clients don&apos;t want analytics. They want answers.
+                  </h2>
+                </div>
+              </div>
+              <div className="flex items-end px-5 py-10 sm:px-8 md:py-20 lg:col-span-5 lg:px-10">
+                <p className="max-w-md text-lg leading-8 text-neutral-600 text-pretty dark:text-neutral-400">
+                  Every agency knows the call: a client opens GA4, can&apos;t find their own traffic, and asks you to
+                  explain it. Rybbit puts sessions, sources, and conversions on one screen that stays legible to
+                  someone who looks at it once a month.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-label="Agency workflow">
+          <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+            <GridCrosses />
+            <div className="grid grid-cols-1 gap-px bg-neutral-200 p-px dark:bg-neutral-800 lg:grid-cols-12">
+              <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-7 lg:px-10">
+                <h3 className="text-lg font-semibold tracking-tight">Every client in one workspace</h3>
+                <p className="mt-2 max-w-lg text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                  Organizations group your team and client sites together, with member roles for who can view and who
+                  can manage. Jump between client dashboards without logging in and out.
+                </p>
+                <ul className="mt-6 max-w-md divide-y divide-neutral-200 rounded-md border border-neutral-200 dark:divide-neutral-800 dark:border-neutral-800">
+                  {workspaceRows.map(row => (
+                    <li key={row.domain} className="flex items-center justify-between gap-3 px-3.5 py-2.5 text-sm">
+                      <span className="flex items-center gap-2.5 font-mono text-xs text-neutral-700 dark:text-neutral-300">
+                        <span aria-hidden="true" className="size-1.5 rounded-full bg-emerald-500" />
+                        {row.domain}
+                      </span>
+                      <span className="flex items-baseline gap-2 tabular-nums">
+                        <span className="text-sm font-medium">{row.visitors}</span>
+                        <span className="text-xs text-neutral-500 dark:text-neutral-400">{row.delta}</span>
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </article>
+
+              <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-5 lg:px-10">
+                <h3 className="text-lg font-semibold tracking-tight">Reports that send themselves</h3>
+                <p className="mt-2 max-w-md text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                  Weekly or monthly email reports per site. Clients get their numbers in the inbox without you
+                  exporting a PDF on the last Friday of the month.
+                </p>
+                <div className="mt-6 flex max-w-sm items-center gap-3 rounded-md border border-neutral-200 px-3.5 py-3 dark:border-neutral-800">
+                  <Mail aria-hidden="true" className="size-4 shrink-0 text-neutral-400 dark:text-neutral-500" />
+                  <div className="min-w-0 text-xs leading-5">
+                    <p className="truncate font-medium text-neutral-700 dark:text-neutral-300">
+                      Weekly report — acme-cycles.com
+                    </p>
+                    <p className="text-neutral-500 dark:text-neutral-400">Arrives Monday, 9:00</p>
+                  </div>
+                </div>
+              </article>
+
+              <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-5 lg:px-10">
+                <h3 className="text-lg font-semibold tracking-tight">Share a dashboard, not a login</h3>
+                <p className="mt-2 max-w-md text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                  Any dashboard can be shared with a secret link or made fully public. Clients see their site&apos;s
+                  numbers without creating an account — and never anyone else&apos;s.
+                </p>
+                <div className="mt-6 flex max-w-sm items-center gap-2.5 rounded-md border border-neutral-200 bg-neutral-50 px-3.5 py-2.5 dark:border-neutral-800 dark:bg-neutral-900">
+                  <Link2 aria-hidden="true" className="size-3.5 shrink-0 text-neutral-400 dark:text-neutral-500" />
+                  <span className="truncate font-mono text-xs text-neutral-500 dark:text-neutral-400">
+                    app.rybbit.io/share/acme-cycles…
+                  </span>
+                </div>
+              </article>
+
+              <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-7 lg:px-10">
+                <h3 className="text-lg font-semibold tracking-tight">No cookie banner on any client site</h3>
+                <p className="mt-2 max-w-lg text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                  Rybbit is cookieless and compliant with GDPR and CCPA out of the box, so the sites you build
+                  don&apos;t need a consent banner for analytics. One less awkward conversation per launch — and no
+                  consent-declined gap in the numbers you report.
+                </p>
+                <div className="mt-6 flex flex-wrap items-center gap-x-6 gap-y-3 text-sm">
+                  <Link
+                    href="/privacy"
+                    className="group inline-flex items-center gap-1.5 rounded-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+                  >
+                    How Rybbit handles privacy
+                    <ArrowRight
+                      className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                      aria-hidden="true"
+                    />
+                  </Link>
+                  <Link
+                    href="/dpa"
+                    className="group inline-flex items-center gap-1.5 rounded-sm font-medium text-neutral-600 transition-colors duration-200 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 dark:text-neutral-400 dark:hover:text-white"
+                  >
+                    Data Processing Agreement
+                    <ArrowRight
+                      className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                      aria-hidden="true"
+                    />
+                  </Link>
+                </div>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="agency-pricing-title">
+          <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+            <GridCrosses />
+            <div className="grid grid-cols-1 border-b border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+              <div className="relative border-b border-neutral-200 bg-plate-accent px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-7 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-0 bg-graph-accent [mask-image:linear-gradient(to_bottom,black,transparent_92%)]"
+                />
+                <div className="relative">
+                  <SectionKicker>Pricing for a roster</SectionKicker>
+                  <h2
+                    id="agency-pricing-title"
+                    className="mt-5 max-w-2xl text-4xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl"
+                  >
+                    Unlimited client websites on Pro.
+                  </h2>
+                </div>
+              </div>
+              <div className="flex items-end px-5 py-10 sm:px-8 md:py-20 lg:col-span-5 lg:px-10">
+                <p className="max-w-md text-lg leading-8 text-neutral-600 text-pretty dark:text-neutral-400">
+                  No per-site packs, no per-seat surprises. One subscription covers the whole roster, priced by
+                  traffic — and referrals pay 50% through the affiliate program.
+                </p>
+              </div>
+            </div>
+            <div>
+              {tierFacts.map(item => (
+                <Link
+                  key={item.tier}
+                  href="/pricing"
+                  className="group grid border-b border-neutral-200 px-5 py-6 transition-colors last:border-b-0 hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500 dark:border-neutral-800 dark:hover:bg-neutral-900/60 sm:grid-cols-[160px_1fr_auto] sm:items-center sm:gap-6 sm:px-8 lg:px-10"
+                >
+                  <span className="font-semibold tracking-tight">{item.tier}</span>
+                  <span className="mt-1 text-sm leading-6 text-neutral-500 dark:text-neutral-400 sm:mt-0">
+                    {item.fact}
+                  </span>
+                  <ArrowRight
+                    className="mt-3 size-4 text-neutral-400 transition-transform group-hover:translate-x-1 motion-reduce:transition-none sm:mt-0"
+                    aria-hidden="true"
+                  />
+                </Link>
+              ))}
+              <div className="flex flex-wrap items-center justify-between gap-3 border-t border-neutral-200 px-5 py-5 text-sm text-neutral-500 dark:border-neutral-800 dark:text-neutral-400 sm:px-8 lg:px-10">
+                <span>Referring clients instead of hosting them?</span>
+                <Link
+                  href="/affiliate"
+                  className="group inline-flex items-center gap-1.5 rounded-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+                >
+                  50% affiliate program
+                  <ArrowRight
+                    className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                    aria-hidden="true"
+                  />
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="agency-lockin-title">
+          <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+            <GridCrosses />
+            <div className="border-b border-neutral-200 px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-7 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+              <h2
+                id="agency-lockin-title"
+                className="max-w-xl text-4xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl"
+              >
+                Easy to leave. That&apos;s the point.
+              </h2>
+              <p className="mt-6 max-w-xl text-base leading-7 text-neutral-600 dark:text-neutral-400">
+                Rybbit is 100% open source under AGPL v3. If you or a client ever want out of the cloud, self-host the
+                exact same product and keep the workflow. With full API access and data export, the numbers were never
+                locked in to begin with — which is an easier pitch to put in front of a client than a contract.
+              </p>
+            </div>
+            <div className="flex flex-col justify-center gap-4 px-5 py-10 sm:px-8 md:py-20 lg:col-span-5 lg:px-10">
+              <Link
+                href="/docs/self-hosting"
+                className="group inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+              >
+                Self-hosting guide
+                <ArrowRight
+                  className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                  aria-hidden="true"
+                />
+              </Link>
+              <a
+                href="https://github.com/rybbit-io/rybbit"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-neutral-600 transition-colors duration-200 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 dark:text-neutral-400 dark:hover:text-white"
+              >
+                Open source on GitHub
+                <ExternalLink
+                  className="size-3.5 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                  aria-hidden="true"
+                />
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="agency-faq-title">
+          <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+            <GridCrosses />
+            <div className="border-b border-neutral-200 px-5 py-12 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 lg:py-16">
+              <div className="lg:sticky lg:top-24">
+                <h2
+                  id="agency-faq-title"
+                  className="max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+                >
+                  Agency questions, answered plainly.
+                </h2>
+              </div>
+            </div>
+            <Accordion type="single" collapsible className="lg:col-span-8">
+              {faqItems.map((faq, index) => (
+                <AccordionItem key={faq.question} value={`item-${index}`} className="last:border-b-0">
+                  <AccordionTrigger className="px-5 py-5 text-left sm:px-8 lg:px-10">{faq.question}</AccordionTrigger>
+                  <AccordionContent className="px-5 pb-6 sm:px-8 lg:px-10">{faq.answer}</AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </div>
+        </section>
+
+        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-label="Related pages">
+          <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+            <GridCrosses />
+            <Link
+              href="/for-developers"
+              className="group grid border-b border-neutral-200 px-5 py-7 transition-colors hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500 dark:border-neutral-800 dark:hover:bg-neutral-900/60 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto] sm:items-center sm:gap-6 sm:px-8 lg:px-10"
+            >
+              <span className="font-semibold">Rybbit for developers</span>
+              <span className="mt-1 text-sm leading-6 text-neutral-500 dark:text-neutral-400 sm:mt-0">
+                The script tag, the SDK, the API, the MCP server, and self-hosting.
+              </span>
+              <ArrowRight
+                className="mt-4 size-4 text-neutral-400 transition-transform group-hover:translate-x-1 motion-reduce:transition-none sm:mt-0"
+                aria-hidden="true"
+              />
+            </Link>
+            <Link
+              href="/compare"
+              className="group grid px-5 py-7 transition-colors hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500 dark:hover:bg-neutral-900/60 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto] sm:items-center sm:gap-6 sm:px-8 lg:px-10"
+            >
+              <span className="font-semibold">Compare Rybbit</span>
+              <span className="mt-1 text-sm leading-6 text-neutral-500 dark:text-neutral-400 sm:mt-0">
+                Side-by-side with Google Analytics, Plausible, Matomo, PostHog, and more.
+              </span>
+              <ArrowRight
+                className="mt-4 size-4 text-neutral-400 transition-transform group-hover:translate-x-1 motion-reduce:transition-none sm:mt-0"
+                aria-hidden="true"
+              />
+            </Link>
+          </div>
+        </section>
+
+        <CTASection
+          title="Put every client on analytics they'll actually open."
+          description="One workspace, unlimited client websites on Pro, and dashboards you can hand to anyone."
+          eventLocation="for_agencies_bottom_cta"
+        />
+      </div>
+    </>
+  );
+}

--- a/docs/src/app/[locale]/(home)/for-agencies/page.tsx
+++ b/docs/src/app/[locale]/(home)/for-agencies/page.tsx
@@ -1,13 +1,9 @@
 import { CTASection } from "@/components/CTASection";
 import { GridCrosses } from "@/components/GridCrosses";
 import { InteriorPageHero } from "@/components/InteriorPageHero";
+import { PersonaCrossLinks } from "@/components/persona/PersonaCrossLinks";
+import { PersonaFaqSection } from "@/components/persona/PersonaFaqSection";
 import { SectionKicker } from "@/components/deco/SectionKicker";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 import { createMetadata, createOGImageUrl } from "@/lib/metadata";
 import { ArrowRight, ExternalLink, Link2, Mail } from "lucide-react";
 import Link from "next/link";
@@ -68,16 +64,6 @@ const faqItems = [
   },
 ];
 
-const faqSchema = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: faqItems.map(item => ({
-    "@type": "Question",
-    name: item.question,
-    acceptedAnswer: { "@type": "Answer", text: item.answer },
-  })),
-};
-
 // Fake-but-concrete workspace rows, in the landing page's mock-data idiom.
 const workspaceRows = [
   { domain: "acme-cycles.com", visitors: "12.4k", delta: "+8%" },
@@ -93,9 +79,7 @@ const tierFacts = [
 
 export default function ForAgenciesPage() {
   return (
-    <>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
-      <div className="overflow-x-clip">
+    <div className="overflow-x-clip">
         <InteriorPageHero
           eyebrow="Rybbit for agencies"
           title="Client reporting without the training call."
@@ -327,61 +311,8 @@ export default function ForAgenciesPage() {
           </div>
         </section>
 
-        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="agency-faq-title">
-          <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
-            <GridCrosses />
-            <div className="border-b border-neutral-200 px-5 py-12 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 lg:py-16">
-              <div className="lg:sticky lg:top-24">
-                <h2
-                  id="agency-faq-title"
-                  className="max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
-                >
-                  Agency questions, answered plainly.
-                </h2>
-              </div>
-            </div>
-            <Accordion type="single" collapsible className="lg:col-span-8">
-              {faqItems.map((faq, index) => (
-                <AccordionItem key={faq.question} value={`item-${index}`} className="last:border-b-0">
-                  <AccordionTrigger className="px-5 py-5 text-left sm:px-8 lg:px-10">{faq.question}</AccordionTrigger>
-                  <AccordionContent className="px-5 pb-6 sm:px-8 lg:px-10">{faq.answer}</AccordionContent>
-                </AccordionItem>
-              ))}
-            </Accordion>
-          </div>
-        </section>
-
-        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-label="Related pages">
-          <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
-            <GridCrosses />
-            <Link
-              href="/for-developers"
-              className="group grid border-b border-neutral-200 px-5 py-7 transition-colors hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500 dark:border-neutral-800 dark:hover:bg-neutral-900/60 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto] sm:items-center sm:gap-6 sm:px-8 lg:px-10"
-            >
-              <span className="font-semibold">Rybbit for developers</span>
-              <span className="mt-1 text-sm leading-6 text-neutral-500 dark:text-neutral-400 sm:mt-0">
-                The script tag, the SDK, the API, the MCP server, and self-hosting.
-              </span>
-              <ArrowRight
-                className="mt-4 size-4 text-neutral-400 transition-transform group-hover:translate-x-1 motion-reduce:transition-none sm:mt-0"
-                aria-hidden="true"
-              />
-            </Link>
-            <Link
-              href="/compare"
-              className="group grid px-5 py-7 transition-colors hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500 dark:hover:bg-neutral-900/60 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto] sm:items-center sm:gap-6 sm:px-8 lg:px-10"
-            >
-              <span className="font-semibold">Compare Rybbit</span>
-              <span className="mt-1 text-sm leading-6 text-neutral-500 dark:text-neutral-400 sm:mt-0">
-                Side-by-side with Google Analytics, Plausible, Matomo, PostHog, and more.
-              </span>
-              <ArrowRight
-                className="mt-4 size-4 text-neutral-400 transition-transform group-hover:translate-x-1 motion-reduce:transition-none sm:mt-0"
-                aria-hidden="true"
-              />
-            </Link>
-          </div>
-        </section>
+        <PersonaFaqSection heading="Agency questions, answered plainly." items={faqItems} />
+        <PersonaCrossLinks current="for-agencies" />
 
         <CTASection
           title="Put every client on analytics they'll actually open."
@@ -389,6 +320,5 @@ export default function ForAgenciesPage() {
           eventLocation="for_agencies_bottom_cta"
         />
       </div>
-    </>
   );
 }

--- a/docs/src/app/[locale]/(home)/for-creators/page.tsx
+++ b/docs/src/app/[locale]/(home)/for-creators/page.tsx
@@ -1,0 +1,223 @@
+import { CTASection } from "@/components/CTASection";
+import { GridCrosses } from "@/components/GridCrosses";
+import { InteriorPageHero } from "@/components/InteriorPageHero";
+import { PersonaCrossLinks } from "@/components/persona/PersonaCrossLinks";
+import { PersonaFaqSection } from "@/components/persona/PersonaFaqSection";
+import { SectionKicker } from "@/components/deco/SectionKicker";
+import { createMetadata, createOGImageUrl } from "@/lib/metadata";
+import { ArrowRight, Globe } from "lucide-react";
+import Link from "next/link";
+
+const pageTitle = "Rybbit for Creators & Publishers | Know What Resonates";
+const pageDescription =
+  "See which posts land, where readers come from, and which searches bring them in — without putting cookies or a consent banner on your audience. Share your dashboard publicly if you build in public.";
+
+export const metadata = createMetadata({
+  title: pageTitle,
+  description: pageDescription,
+  alternates: {
+    canonical: "https://rybbit.com/for-creators",
+  },
+  openGraph: {
+    title: pageTitle,
+    description: pageDescription,
+    url: "https://rybbit.com/for-creators",
+    images: [createOGImageUrl("Rybbit for Creators", "Know what resonates. Skip the surveillance.", "Solutions")],
+  },
+  twitter: {
+    images: [createOGImageUrl("Rybbit for Creators", "Know what resonates. Skip the surveillance.", "Solutions")],
+  },
+});
+
+const faqItems = [
+  {
+    question: "Do I need a cookie banner on my blog?",
+    answer:
+      "No. Rybbit doesn't use cookies or collect personal data about your readers, so it's GDPR and CCPA compliant without a consent banner cluttering your site.",
+  },
+  {
+    question: "Will analytics slow my site down?",
+    answer:
+      "The script loads async, so it doesn't block your pages from rendering. Rybbit also measures web vitals from real visits, so you can see your site's actual speed instead of guessing.",
+  },
+  {
+    question: "Can I share my stats publicly?",
+    answer:
+      "Yes. Any dashboard can be made fully public or shared with a secret link — useful if you build in public, or if a sponsor asks for your numbers.",
+  },
+  {
+    question: "Does Rybbit work with my platform?",
+    answer:
+      "Rybbit works anywhere you can add a script tag: WordPress, Ghost, Webflow, Squarespace, Wix, Framer, Hugo, Astro, Jekyll, and every major framework. Most setups take a few minutes.",
+  },
+  {
+    question: "Can I see which search queries bring readers in?",
+    answer:
+      "Yes. Connect Google Search Console and the queries that bring searchers to your site appear alongside your other traffic sources.",
+  },
+  {
+    question: "What does it cost for a personal site?",
+    answer:
+      "Standard starts at $13/month billed annually for 100K pageviews, with a 7-day free trial. Rybbit is also open source — self-hosting on your own server is free.",
+  },
+];
+
+const topPosts = [
+  { title: "The build-vs-buy essay", views: "4,812" },
+  { title: "How I set up my writing pipeline", views: "3,940" },
+  { title: "Notes on a year of self-hosting", views: "2,377" },
+];
+
+const readerSources = [
+  { source: "Newsletter", share: "34%" },
+  { source: "Google", share: "27%" },
+  { source: "X / Twitter", share: "17%" },
+  { source: "Hacker News", share: "11%" },
+];
+
+export default function ForCreatorsPage() {
+  return (
+    <div className="overflow-x-clip">
+      <InteriorPageHero
+        eyebrow="Rybbit for creators & publishers"
+        title="Know what resonates. Skip the surveillance."
+        description="See which posts land, where readers come from, and which searches bring them in — without putting cookies, fingerprinting, or a consent banner on the people who read you."
+        eventLocation="for_creators_hero"
+      />
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="creators-ethics-title">
+        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+          <GridCrosses />
+          <div className="grid grid-cols-1 lg:grid-cols-12">
+            <div className="relative border-b border-neutral-200 bg-plate-accent px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-7 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 bg-graph-accent [mask-image:linear-gradient(to_bottom,black,transparent_92%)]"
+              />
+              <div className="relative">
+                <SectionKicker>Your audience, not your product</SectionKicker>
+                <h2
+                  id="creators-ethics-title"
+                  className="mt-5 max-w-2xl text-4xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl"
+                >
+                  Your readers came for the writing. Don&apos;t make them the product.
+                </h2>
+              </div>
+            </div>
+            <div className="flex items-end px-5 py-10 sm:px-8 md:py-20 lg:col-span-5 lg:px-10">
+              <p className="max-w-md text-lg leading-8 text-neutral-600 text-pretty dark:text-neutral-400">
+                Free analytics is paid for with your audience's data. Rybbit's answer is structural: no cookies, no
+                personal data, daily-salted IDs that can't fingerprint anyone — and a subscription instead of an ad
+                machine behind the numbers.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-label="Creator workflow">
+        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+          <GridCrosses />
+          <div className="grid grid-cols-1 gap-px bg-neutral-200 p-px dark:bg-neutral-800 lg:grid-cols-12">
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-7 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">Which posts actually land</h3>
+              <p className="mt-2 max-w-lg text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                Top pages in realtime, so on publish day you watch a post find its readers — and over months you learn
+                which topics deserve the sequel.
+              </p>
+              <ul className="mt-6 max-w-lg divide-y divide-neutral-200 rounded-md border border-neutral-200 text-sm dark:divide-neutral-800 dark:border-neutral-800">
+                {topPosts.map(post => (
+                  <li key={post.title} className="flex items-center justify-between gap-3 px-3.5 py-2.5">
+                    <span className="truncate text-neutral-700 dark:text-neutral-300">{post.title}</span>
+                    <span className="shrink-0 font-medium tabular-nums">{post.views}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-5 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">Where readers come from</h3>
+              <p className="mt-2 max-w-md text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                Referrers and UTM tags separate the newsletter from the socials from the search traffic — so you know
+                which channel is worth the effort.
+              </p>
+              <ul className="mt-6 max-w-sm space-y-2 text-sm">
+                {readerSources.map(row => (
+                  <li key={row.source} className="flex items-center justify-between gap-3">
+                    <span className="text-neutral-600 dark:text-neutral-400">{row.source}</span>
+                    <span className="font-medium tabular-nums">{row.share}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-5 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">The searches that find you</h3>
+              <p className="mt-2 max-w-md text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                Connect Google Search Console and see the queries that bring searchers in, next to the rest of your
+                traffic — no second tab, no export.
+              </p>
+            </article>
+
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-7 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">Goals for the numbers that pay</h3>
+              <p className="mt-2 max-w-lg text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                Set a goal on newsletter signups or a product page, and see which posts convert readers into
+                subscribers — the difference between traffic and an audience.
+              </p>
+              <Link
+                href="/features/goals"
+                className="group mt-5 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+              >
+                Goals
+                <ArrowRight
+                  className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                  aria-hidden="true"
+                />
+              </Link>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="creators-public-title">
+        <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+          <GridCrosses />
+          <div className="border-b border-neutral-200 px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-7 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+            <h2
+              id="creators-public-title"
+              className="max-w-xl text-4xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl"
+            >
+              Build in public. Literally.
+            </h2>
+            <p className="mt-6 max-w-xl text-base leading-7 text-neutral-600 dark:text-neutral-400">
+              Make your dashboard fully public and put the link in your bio, or share it privately with a secret link
+              when a sponsor asks for real numbers. Your stats become something you can point at instead of a
+              screenshot you have to crop.
+            </p>
+          </div>
+          <div className="flex flex-col justify-center px-5 py-10 sm:px-8 md:py-20 lg:col-span-5 lg:px-10">
+            <div className="flex max-w-sm items-center gap-2.5 rounded-md border border-neutral-200 bg-neutral-50 px-3.5 py-2.5 dark:border-neutral-800 dark:bg-neutral-900">
+              <Globe aria-hidden="true" className="size-3.5 shrink-0 text-neutral-400 dark:text-neutral-500" />
+              <span className="truncate font-mono text-xs text-neutral-500 dark:text-neutral-400">
+                app.rybbit.io/share/your-blog
+              </span>
+            </div>
+            <p className="mt-4 max-w-sm text-sm leading-6 text-neutral-500 dark:text-neutral-400">
+              Public, secret-link, or private — per dashboard, switchable any time.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <PersonaFaqSection heading="Creator questions, answered plainly." items={faqItems} />
+      <PersonaCrossLinks current="for-creators" />
+
+      <CTASection
+        title="Publish. Then watch it land."
+        description="Top pages, reader sources, and search queries — on analytics your audience never has to click 'accept' for."
+        eventLocation="for_creators_bottom_cta"
+      />
+    </div>
+  );
+}

--- a/docs/src/app/[locale]/(home)/for-developers/page.tsx
+++ b/docs/src/app/[locale]/(home)/for-developers/page.tsx
@@ -1,0 +1,408 @@
+import { CodeCard } from "@/components/CodeCard";
+import { CTASection } from "@/components/CTASection";
+import { GitHubStarButton } from "@/components/GitHubStarButton";
+import { GridCrosses } from "@/components/GridCrosses";
+import { InteriorPageHero } from "@/components/InteriorPageHero";
+import { SectionKicker } from "@/components/deco/SectionKicker";
+import { TrackingSnippet } from "@/components/deco/TrackingSnippet";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { createMetadata, createOGImageUrl } from "@/lib/metadata";
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+const pageTitle = "Rybbit for Developers | Open-Source, Self-Hostable Analytics";
+const pageDescription =
+  "One script tag or one npm package. A REST API for everything the dashboard shows, a hosted MCP server your AI agents can operate, and 100% open-source code you can self-host with Docker.";
+
+export const metadata = createMetadata({
+  title: pageTitle,
+  description: pageDescription,
+  alternates: {
+    canonical: "https://rybbit.com/for-developers",
+  },
+  openGraph: {
+    title: pageTitle,
+    description: pageDescription,
+    url: "https://rybbit.com/for-developers",
+    images: [createOGImageUrl("Rybbit for Developers", "Script tag, SDK, REST API, MCP server, and self-hosting — all open source.", "Solutions")],
+  },
+  twitter: {
+    images: [createOGImageUrl("Rybbit for Developers", "Script tag, SDK, REST API, MCP server, and self-hosting — all open source.", "Solutions")],
+  },
+});
+
+const mcpClients = [
+  { name: "Claude Code", path: "/docs/mcp/claude-code" },
+  { name: "Claude Desktop", path: "/docs/mcp/claude-desktop" },
+  { name: "Codex", path: "/docs/mcp/codex" },
+  { name: "Cursor", path: "/docs/mcp/cursor" },
+  { name: "VS Code", path: "/docs/mcp/vscode" },
+  { name: "opencode", path: "/docs/mcp/opencode" },
+];
+
+// Rendered in the accordion AND emitted as FAQPage JSON-LD from the same
+// array, so the schema can never drift from the visible answers.
+const faqItems = [
+  {
+    question: "What do I need to self-host Rybbit?",
+    answer:
+      "A server with Docker. Clone the repository and run the setup script with your domain — it brings up the full stack with Docker Compose. Self-hosting is free for personal and business use.",
+  },
+  {
+    question: "Is the open-source version the full product?",
+    answer:
+      "Rybbit is 100% open source under AGPL v3, including the code for the cloud and enterprise offerings. See the self-hosting vs cloud guide for the practical differences between running it yourself and using the managed cloud.",
+  },
+  {
+    question: "Does Rybbit have an SDK?",
+    answer:
+      "Yes — @rybbit/js on npm for websites and web apps, plus Node and React Native SDKs. The plain script tag works anywhere HTML does.",
+  },
+  {
+    question: "Can I access my data programmatically?",
+    answer:
+      "Yes. The Stats API exposes the metrics the dashboard shows over HTTP with bearer-key auth, and there's an API playground in the dashboard for exploring endpoints and generating code snippets.",
+  },
+  {
+    question: "How does the MCP server work?",
+    answer:
+      "It's a hosted MCP endpoint on top of the REST API. Point Claude Code, Claude Desktop, Codex, Cursor, VS Code, or opencode at it, and your agent can query traffic, debug errors, and manage goals with the same permissions as a teammate.",
+  },
+  {
+    question: "Is Rybbit GDPR compliant without a cookie banner?",
+    answer:
+      "Yes. Rybbit doesn't use cookies or collect personal data that could identify visitors, so sites using it don't need a consent banner for analytics.",
+  },
+];
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqItems.map(item => ({
+    "@type": "Question",
+    name: item.question,
+    acceptedAnswer: { "@type": "Answer", text: item.answer },
+  })),
+};
+
+const tokenPlain = "";
+const tokenName = "text-neutral-700 dark:text-neutral-300";
+const tokenString = "text-emerald-700 dark:text-emerald-400";
+
+const sdkTokens = [
+  { text: "npm install @rybbit/js", className: tokenName },
+  { text: "\n\n", className: tokenPlain },
+  { text: "import", className: tokenName },
+  { text: " rybbit ", className: tokenPlain },
+  { text: "from", className: tokenName },
+  { text: " ", className: tokenPlain },
+  { text: '"@rybbit/js"', className: tokenString },
+  { text: ";\n\n", className: tokenPlain },
+  { text: "await", className: tokenName },
+  { text: " rybbit.init({\n  analyticsHost: ", className: tokenPlain },
+  { text: '"https://app.rybbit.io/api"', className: tokenString },
+  { text: ",\n  siteId: ", className: tokenPlain },
+  { text: '"YOUR_SITE_ID"', className: tokenString },
+  { text: ",\n});", className: tokenPlain },
+];
+
+const apiTokens = [
+  { text: "curl ", className: tokenName },
+  {
+    text: '"https://app.rybbit.io/api/sites/123/metric?parameter=country&start_date=2026-06-01&end_date=2026-06-30"',
+    className: tokenString,
+  },
+  { text: " \\\n  -H ", className: tokenPlain },
+  { text: '"Authorization: Bearer YOUR_API_KEY"', className: tokenString },
+];
+
+const apiResponseTokens = [
+  { text: "{\n  ", className: tokenPlain },
+  { text: '"data"', className: tokenName },
+  { text: ": {\n    ", className: tokenPlain },
+  { text: '"data"', className: tokenName },
+  { text: ": [\n      { ", className: tokenPlain },
+  { text: '"value"', className: tokenName },
+  { text: ": ", className: tokenPlain },
+  { text: '"US"', className: tokenString },
+  { text: ", ", className: tokenPlain },
+  { text: '"count"', className: tokenName },
+  { text: ": 8420, ", className: tokenPlain },
+  { text: '"percentage"', className: tokenName },
+  { text: ": 54.63 },\n      { ", className: tokenPlain },
+  { text: '"value"', className: tokenName },
+  { text: ": ", className: tokenPlain },
+  { text: '"GB"', className: tokenString },
+  { text: ", ", className: tokenPlain },
+  { text: '"count"', className: tokenName },
+  { text: ": 2150, ", className: tokenPlain },
+  { text: '"percentage"', className: tokenName },
+  { text: ": 13.95 }\n    ],\n    ", className: tokenPlain },
+  { text: '"totalCount"', className: tokenName },
+  { text: ": 87\n  }\n}", className: tokenPlain },
+];
+
+const mcpTokens = [
+  { text: "claude mcp add ", className: tokenName },
+  { text: "--transport http rybbit \\\n  ", className: tokenPlain },
+  { text: "https://app.rybbit.io/api/mcp", className: tokenString },
+];
+
+const selfHostTokens = [
+  { text: "git clone ", className: tokenName },
+  { text: "https://github.com/rybbit-io/rybbit.git", className: tokenString },
+  { text: "\n", className: tokenPlain },
+  { text: "cd ", className: tokenName },
+  { text: "rybbit\n", className: tokenPlain },
+  { text: "./setup.sh ", className: tokenName },
+  { text: "your.domain.name", className: tokenString },
+];
+
+export default function ForDevelopersPage() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <div className="overflow-x-clip">
+        <InteriorPageHero
+          eyebrow="Rybbit for developers"
+          title="Analytics that behaves like good software."
+          description="One script tag, or one npm package. A REST API for everything the dashboard shows, an MCP server your agents can operate, and a codebase you can read, audit, and run on your own server."
+          eventLocation="for_developers_hero"
+          note="7-day free trial — or self-host free forever."
+        />
+
+        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="dev-install-title">
+          <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+            <GridCrosses />
+            <div className="border-b border-neutral-200 px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+              <div className="lg:sticky lg:top-24">
+                <SectionKicker>Install</SectionKicker>
+                <h2
+                  id="dev-install-title"
+                  className="mt-5 max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+                >
+                  One tag. Or one package.
+                </h2>
+                <p className="mt-6 max-w-sm text-base leading-7 text-neutral-600 dark:text-neutral-400">
+                  Drop the script on any site, or install @rybbit/js and initialize it in two lines. Autocapture
+                  starts immediately; custom events are there when you want them.
+                </p>
+                <Link
+                  href="/docs/script"
+                  className="group mt-8 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+                >
+                  Script docs
+                  <ArrowRight
+                    className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                    aria-hidden="true"
+                  />
+                </Link>
+              </div>
+            </div>
+            <div className="grid content-center gap-5 px-5 py-10 sm:px-8 md:grid-cols-2 md:py-14 lg:col-span-8 lg:px-10">
+              <TrackingSnippet />
+              <CodeCard label="app.ts" tokens={sdkTokens} />
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="dev-api-title">
+          <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+            <GridCrosses />
+            <div className="border-b border-neutral-200 px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+              <div className="lg:sticky lg:top-24">
+                <SectionKicker>Stats API</SectionKicker>
+                <h2
+                  id="dev-api-title"
+                  className="mt-5 max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+                >
+                  Everything in the dashboard, over HTTP.
+                </h2>
+                <p className="mt-6 max-w-sm text-base leading-7 text-neutral-600 dark:text-neutral-400">
+                  Every metric Rybbit shows is available from the REST API with a bearer key — pull traffic into your
+                  own tools, build a live feed, or export events to a warehouse. An API playground in the dashboard
+                  generates ready-to-use snippets.
+                </p>
+                <Link
+                  href="/docs/api/getting-started"
+                  className="group mt-8 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+                >
+                  API reference
+                  <ArrowRight
+                    className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                    aria-hidden="true"
+                  />
+                </Link>
+              </div>
+            </div>
+            <div className="flex flex-col justify-center gap-5 px-5 py-10 sm:px-8 md:py-14 lg:col-span-8 lg:px-10">
+              <CodeCard label="terminal" tokens={apiTokens} />
+              <CodeCard label="response.json" tokens={apiResponseTokens} />
+              <p className="max-w-2xl text-sm leading-6 text-neutral-500 dark:text-neutral-400">
+                Organization keys or personal keys, rate-limited per plan. Sessions, metrics, funnels, goals, errors,
+                and events are all endpoints — see the reference for the full surface.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="dev-mcp-title">
+          <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+            <GridCrosses />
+            <div className="border-b border-neutral-200 px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+              <div className="lg:sticky lg:top-24">
+                <SectionKicker>MCP</SectionKicker>
+                <h2
+                  id="dev-mcp-title"
+                  className="mt-5 max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+                >
+                  Your agent already knows how to use it.
+                </h2>
+                <p className="mt-6 max-w-sm text-base leading-7 text-neutral-600 dark:text-neutral-400">
+                  A hosted MCP server sits on top of the full REST API. Your agent reads live traffic, debugs errors,
+                  and manages goals — with the same permissions as a teammate.
+                </p>
+                <Link
+                  href="/docs/mcp"
+                  className="group mt-8 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+                >
+                  Set up MCP
+                  <ArrowRight
+                    className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                    aria-hidden="true"
+                  />
+                </Link>
+              </div>
+            </div>
+            <div className="flex flex-col justify-center gap-6 px-5 py-10 sm:px-8 md:py-14 lg:col-span-8 lg:px-10">
+              <CodeCard label="terminal" tokens={mcpTokens} />
+              <div>
+                <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Works with</p>
+                <ul className="mt-3 flex flex-wrap gap-2">
+                  {mcpClients.map(client => (
+                    <li key={client.name}>
+                      <Link
+                        href={client.path}
+                        className="inline-flex rounded-md border border-neutral-200 px-2.5 py-1 text-xs font-medium text-neutral-600 transition-colors duration-200 hover:border-neutral-300 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:border-neutral-800 dark:text-neutral-400 dark:hover:border-neutral-700 dark:hover:text-white"
+                      >
+                        {client.name}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="dev-oss-title">
+          <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+            <GridCrosses />
+            <div className="border-b border-neutral-200 px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+              <div className="lg:sticky lg:top-24">
+                <SectionKicker>Open source</SectionKicker>
+                <h2
+                  id="dev-oss-title"
+                  className="mt-5 max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+                >
+                  Read the code. Run the code.
+                </h2>
+                <p className="mt-6 max-w-sm text-base leading-7 text-neutral-600 dark:text-neutral-400">
+                  Every line of Rybbit is on GitHub under AGPL v3 — including the cloud and enterprise features. Clone
+                  it, audit it, and run the full stack on your own VPS with Docker.
+                </p>
+                <div className="mt-8 flex flex-col items-start gap-4">
+                  <GitHubStarButton />
+                  <Link
+                    href="/docs/self-hosting"
+                    className="group inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+                  >
+                    Self-hosting guide
+                    <ArrowRight
+                      className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                      aria-hidden="true"
+                    />
+                  </Link>
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-col justify-center gap-5 px-5 py-10 sm:px-8 md:py-14 lg:col-span-8 lg:px-10">
+              <CodeCard label="terminal" tokens={selfHostTokens} />
+              <p className="max-w-2xl text-sm leading-6 text-neutral-500 dark:text-neutral-400">
+                The setup script brings up the full stack with Docker Compose. Self-hosting is free for personal and
+                business use.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="dev-faq-title">
+          <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+            <GridCrosses />
+            <div className="border-b border-neutral-200 px-5 py-12 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 lg:py-16">
+              <div className="lg:sticky lg:top-24">
+                <h2
+                  id="dev-faq-title"
+                  className="max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+                >
+                  Developer questions, answered plainly.
+                </h2>
+              </div>
+            </div>
+            <Accordion type="single" collapsible className="lg:col-span-8">
+              {faqItems.map((faq, index) => (
+                <AccordionItem key={faq.question} value={`item-${index}`} className="last:border-b-0">
+                  <AccordionTrigger className="px-5 py-5 text-left sm:px-8 lg:px-10">{faq.question}</AccordionTrigger>
+                  <AccordionContent className="px-5 pb-6 sm:px-8 lg:px-10">{faq.answer}</AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </div>
+        </section>
+
+        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-label="Related pages">
+          <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+            <GridCrosses />
+            <Link
+              href="/for-agencies"
+              className="group grid border-b border-neutral-200 px-5 py-7 transition-colors hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500 dark:border-neutral-800 dark:hover:bg-neutral-900/60 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto] sm:items-center sm:gap-6 sm:px-8 lg:px-10"
+            >
+              <span className="font-semibold">Rybbit for agencies</span>
+              <span className="mt-1 text-sm leading-6 text-neutral-500 dark:text-neutral-400 sm:mt-0">
+                One workspace for every client site, with dashboards clients can read on their own.
+              </span>
+              <ArrowRight
+                className="mt-4 size-4 text-neutral-400 transition-transform group-hover:translate-x-1 motion-reduce:transition-none sm:mt-0"
+                aria-hidden="true"
+              />
+            </Link>
+            <Link
+              href="/compare"
+              className="group grid px-5 py-7 transition-colors hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500 dark:hover:bg-neutral-900/60 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto] sm:items-center sm:gap-6 sm:px-8 lg:px-10"
+            >
+              <span className="font-semibold">Compare Rybbit</span>
+              <span className="mt-1 text-sm leading-6 text-neutral-500 dark:text-neutral-400 sm:mt-0">
+                Side-by-side with Google Analytics, Plausible, Matomo, PostHog, and more.
+              </span>
+              <ArrowRight
+                className="mt-4 size-4 text-neutral-400 transition-transform group-hover:translate-x-1 motion-reduce:transition-none sm:mt-0"
+                aria-hidden="true"
+              />
+            </Link>
+          </div>
+        </section>
+
+        <CTASection
+          title="Ship analytics in the next ten minutes."
+          description="One script tag now — the API, the MCP server, and self-hosting whenever you want them."
+          eventLocation="for_developers_bottom_cta"
+        />
+      </div>
+    </>
+  );
+}

--- a/docs/src/app/[locale]/(home)/for-developers/page.tsx
+++ b/docs/src/app/[locale]/(home)/for-developers/page.tsx
@@ -3,14 +3,10 @@ import { CTASection } from "@/components/CTASection";
 import { GitHubStarButton } from "@/components/GitHubStarButton";
 import { GridCrosses } from "@/components/GridCrosses";
 import { InteriorPageHero } from "@/components/InteriorPageHero";
+import { PersonaCrossLinks } from "@/components/persona/PersonaCrossLinks";
+import { PersonaFaqSection } from "@/components/persona/PersonaFaqSection";
 import { SectionKicker } from "@/components/deco/SectionKicker";
 import { TrackingSnippet } from "@/components/deco/TrackingSnippet";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 import { createMetadata, createOGImageUrl } from "@/lib/metadata";
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
@@ -79,16 +75,6 @@ const faqItems = [
       "Yes. Rybbit doesn't use cookies or collect personal data that could identify visitors, so sites using it don't need a consent banner for analytics.",
   },
 ];
-
-const faqSchema = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: faqItems.map(item => ({
-    "@type": "Question",
-    name: item.question,
-    acceptedAnswer: { "@type": "Answer", text: item.answer },
-  })),
-};
 
 const tokenPlain = "";
 const tokenName = "text-neutral-700 dark:text-neutral-300";
@@ -165,9 +151,7 @@ const selfHostTokens = [
 
 export default function ForDevelopersPage() {
   return (
-    <>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
-      <div className="overflow-x-clip">
+    <div className="overflow-x-clip">
         <InteriorPageHero
           eyebrow="Rybbit for developers"
           title="Analytics that behaves like good software."
@@ -341,61 +325,8 @@ export default function ForDevelopersPage() {
           </div>
         </section>
 
-        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="dev-faq-title">
-          <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
-            <GridCrosses />
-            <div className="border-b border-neutral-200 px-5 py-12 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 lg:py-16">
-              <div className="lg:sticky lg:top-24">
-                <h2
-                  id="dev-faq-title"
-                  className="max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
-                >
-                  Developer questions, answered plainly.
-                </h2>
-              </div>
-            </div>
-            <Accordion type="single" collapsible className="lg:col-span-8">
-              {faqItems.map((faq, index) => (
-                <AccordionItem key={faq.question} value={`item-${index}`} className="last:border-b-0">
-                  <AccordionTrigger className="px-5 py-5 text-left sm:px-8 lg:px-10">{faq.question}</AccordionTrigger>
-                  <AccordionContent className="px-5 pb-6 sm:px-8 lg:px-10">{faq.answer}</AccordionContent>
-                </AccordionItem>
-              ))}
-            </Accordion>
-          </div>
-        </section>
-
-        <section className="border-b border-neutral-200 dark:border-neutral-800" aria-label="Related pages">
-          <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
-            <GridCrosses />
-            <Link
-              href="/for-agencies"
-              className="group grid border-b border-neutral-200 px-5 py-7 transition-colors hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500 dark:border-neutral-800 dark:hover:bg-neutral-900/60 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto] sm:items-center sm:gap-6 sm:px-8 lg:px-10"
-            >
-              <span className="font-semibold">Rybbit for agencies</span>
-              <span className="mt-1 text-sm leading-6 text-neutral-500 dark:text-neutral-400 sm:mt-0">
-                One workspace for every client site, with dashboards clients can read on their own.
-              </span>
-              <ArrowRight
-                className="mt-4 size-4 text-neutral-400 transition-transform group-hover:translate-x-1 motion-reduce:transition-none sm:mt-0"
-                aria-hidden="true"
-              />
-            </Link>
-            <Link
-              href="/compare"
-              className="group grid px-5 py-7 transition-colors hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500 dark:hover:bg-neutral-900/60 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto] sm:items-center sm:gap-6 sm:px-8 lg:px-10"
-            >
-              <span className="font-semibold">Compare Rybbit</span>
-              <span className="mt-1 text-sm leading-6 text-neutral-500 dark:text-neutral-400 sm:mt-0">
-                Side-by-side with Google Analytics, Plausible, Matomo, PostHog, and more.
-              </span>
-              <ArrowRight
-                className="mt-4 size-4 text-neutral-400 transition-transform group-hover:translate-x-1 motion-reduce:transition-none sm:mt-0"
-                aria-hidden="true"
-              />
-            </Link>
-          </div>
-        </section>
+        <PersonaFaqSection heading="Developer questions, answered plainly." items={faqItems} />
+        <PersonaCrossLinks current="for-developers" />
 
         <CTASection
           title="Ship analytics in the next ten minutes."
@@ -403,6 +334,5 @@ export default function ForDevelopersPage() {
           eventLocation="for_developers_bottom_cta"
         />
       </div>
-    </>
   );
 }

--- a/docs/src/app/[locale]/(home)/for-ecommerce/page.tsx
+++ b/docs/src/app/[locale]/(home)/for-ecommerce/page.tsx
@@ -1,0 +1,251 @@
+import { CTASection } from "@/components/CTASection";
+import { GridCrosses } from "@/components/GridCrosses";
+import { InteriorPageHero } from "@/components/InteriorPageHero";
+import { PersonaCrossLinks } from "@/components/persona/PersonaCrossLinks";
+import { PersonaFaqSection } from "@/components/persona/PersonaFaqSection";
+import { SectionKicker } from "@/components/deco/SectionKicker";
+import { createMetadata, createOGImageUrl } from "@/lib/metadata";
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+const pageTitle = "Rybbit for Ecommerce | See Every Step From Ad Click to Checkout";
+const pageDescription =
+  "Checkout funnels, campaign tracking, and custom events with properties — cookieless, so there's no consent banner between a visitor and your store and no consent gap in your numbers.";
+
+export const metadata = createMetadata({
+  title: pageTitle,
+  description: pageDescription,
+  alternates: {
+    canonical: "https://rybbit.com/for-ecommerce",
+  },
+  openGraph: {
+    title: pageTitle,
+    description: pageDescription,
+    url: "https://rybbit.com/for-ecommerce",
+    images: [createOGImageUrl("Rybbit for Ecommerce", "See every step between ad click and checkout.", "Solutions")],
+  },
+  twitter: {
+    images: [createOGImageUrl("Rybbit for Ecommerce", "See every step between ad click and checkout.", "Solutions")],
+  },
+});
+
+const faqItems = [
+  {
+    question: "Does Rybbit work with Shopify and WooCommerce?",
+    answer:
+      "Yes. Rybbit works with Shopify, WooCommerce, BigCommerce, PrestaShop, Squarespace, Wix, and any platform that lets you add a script tag. Most store platforms take a few minutes to set up.",
+  },
+  {
+    question: "Can I track purchases and cart events?",
+    answer:
+      "Yes. Track add-to-cart, checkout steps, and purchases as custom events with properties like SKU or order value, then build funnels and goals on top of them.",
+  },
+  {
+    question: "Does Rybbit have a revenue report?",
+    answer:
+      "Not a dedicated one yet. Purchases and order values live in custom events and funnels today, so you can see which sources and campaigns convert — but there's no revenue-attribution dashboard.",
+  },
+  {
+    question: "Why do my current analytics undercount my traffic?",
+    answer:
+      "Consent banners and ad blockers stop cookie-based analytics from seeing a large share of visitors. Rybbit doesn't use cookies or collect personal data, so it isn't gated behind a consent choice — you see the whole audience.",
+  },
+  {
+    question: "Will the tracking script slow my store down?",
+    answer:
+      "The script loads async, so it doesn't block your pages from rendering. Rybbit also measures web vitals from real visits, so you can watch your store's speed by page and device.",
+  },
+  {
+    question: "Do I need a cookie consent banner for Rybbit?",
+    answer:
+      "No. Rybbit is GDPR and CCPA compliant without a consent banner, because it doesn't use cookies or collect personal data that could identify your shoppers.",
+  },
+];
+
+const checkoutFunnel = [
+  { label: "Product page", value: "8,412", width: "100%" },
+  { label: "Added to cart", value: "2,306", width: "27%" },
+  { label: "Started checkout", value: "1,177", width: "14%" },
+  { label: "Purchased", value: "604", width: "7.2%" },
+];
+
+const campaignRows = [
+  { source: "newsletter / summer-drop", visitors: "1,982", conv: "4.8%" },
+  { source: "instagram / july-reels", visitors: "3,410", conv: "1.9%" },
+  { source: "google / brand", visitors: "2,144", conv: "6.2%" },
+];
+
+export default function ForEcommercePage() {
+  return (
+    <div className="overflow-x-clip">
+      <InteriorPageHero
+        eyebrow="Rybbit for ecommerce"
+        title="See every step between ad click and checkout."
+        description="Campaign tracking, checkout funnels, and custom events with order properties — cookieless, so there's no consent banner between a visitor and your store, and no consent gap in your numbers."
+        eventLocation="for_ecommerce_hero"
+      />
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="ecommerce-problem-title">
+        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+          <GridCrosses />
+          <div className="grid grid-cols-1 lg:grid-cols-12">
+            <div className="relative border-b border-neutral-200 bg-plate-accent px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-7 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 bg-graph-accent [mask-image:linear-gradient(to_bottom,black,transparent_92%)]"
+              />
+              <div className="relative">
+                <SectionKicker>The attribution problem</SectionKicker>
+                <h2
+                  id="ecommerce-problem-title"
+                  className="mt-5 max-w-2xl text-4xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl"
+                >
+                  Attribution breaks when half your visitors decline tracking.
+                </h2>
+              </div>
+            </div>
+            <div className="flex items-end px-5 py-10 sm:px-8 md:py-20 lg:col-span-5 lg:px-10">
+              <p className="max-w-md text-lg leading-8 text-neutral-600 text-pretty dark:text-neutral-400">
+                Cookie-based analytics only measures shoppers who click accept, so campaign numbers drift further from
+                reality as consent rates fall. Rybbit doesn&apos;t sit behind that choice — the campaign you&apos;re
+                judging gets judged on all of its traffic.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="ecommerce-funnel-title">
+        <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+          <GridCrosses />
+          <div className="border-b border-neutral-200 px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+            <div className="lg:sticky lg:top-24">
+              <SectionKicker>Checkout funnels</SectionKicker>
+              <h2
+                id="ecommerce-funnel-title"
+                className="mt-5 max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+              >
+                Find out where carts stall.
+              </h2>
+              <p className="mt-6 max-w-sm text-base leading-7 text-neutral-600 dark:text-neutral-400">
+                Build the product-to-purchase funnel from page paths or cart events, and see which step bleeds. Web
+                vitals sit on the same dashboard, so a slow step and a leaky step get diagnosed together.
+              </p>
+              <Link
+                href="/features/funnels"
+                className="group mt-8 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+              >
+                Funnels
+                <ArrowRight
+                  className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                  aria-hidden="true"
+                />
+              </Link>
+            </div>
+          </div>
+          <div className="flex flex-col justify-center px-5 py-10 sm:px-8 md:py-14 lg:col-span-8 lg:px-10">
+            <div className="max-w-2xl rounded-md border border-neutral-200 p-4 dark:border-neutral-800 sm:p-5">
+              <ul className="space-y-3.5">
+                {checkoutFunnel.map(step => (
+                  <li key={step.label}>
+                    <div className="flex items-baseline justify-between gap-4 text-sm">
+                      <span className="text-neutral-700 dark:text-neutral-300">{step.label}</span>
+                      <span className="font-medium tabular-nums">{step.value}</span>
+                    </div>
+                    <div className="mt-1.5 h-1.5 overflow-hidden rounded-[1px] bg-neutral-100 dark:bg-neutral-900">
+                      <div className="h-full rounded-[1px] bg-(--dataviz)" style={{ width: step.width }} />
+                    </div>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-4 border-t border-neutral-200 pt-3 text-xs text-neutral-500 dark:border-neutral-800 dark:text-neutral-400">
+                Product page to purchase <span className="font-medium tabular-nums">7.2%</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-label="Ecommerce workflow">
+        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+          <GridCrosses />
+          <div className="grid grid-cols-1 gap-px bg-neutral-200 p-px dark:bg-neutral-800 lg:grid-cols-12">
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-7 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">Judge campaigns on conversions, not clicks</h3>
+              <p className="mt-2 max-w-lg text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                UTM parameters work out of the box, so every source, campaign, and creative gets its own line — with
+                conversion rates from your goals, not just visit counts.
+              </p>
+              <ul className="mt-6 max-w-lg divide-y divide-neutral-200 rounded-md border border-neutral-200 text-sm dark:divide-neutral-800 dark:border-neutral-800">
+                {campaignRows.map(row => (
+                  <li key={row.source} className="flex items-center justify-between gap-3 px-3.5 py-2.5">
+                    <span className="truncate font-mono text-xs text-neutral-700 dark:text-neutral-300">
+                      {row.source}
+                    </span>
+                    <span className="flex shrink-0 items-baseline gap-3 tabular-nums">
+                      <span className="text-neutral-500 dark:text-neutral-400">{row.visitors}</span>
+                      <span className="font-medium">{row.conv}</span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-5 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">Events that carry the order</h3>
+              <p className="mt-2 max-w-md text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                Track add-to-cart, checkout steps, and purchases as custom events with properties like SKU and order
+                value — then build goals and funnels on exactly those moments.
+              </p>
+              <Link
+                href="/features/custom-events"
+                className="group mt-5 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+              >
+                Custom events
+                <ArrowRight
+                  className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                  aria-hidden="true"
+                />
+              </Link>
+            </article>
+
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-5 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">Launch-drop realtime</h3>
+              <p className="mt-2 max-w-md text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                When the drop goes live, watch traffic, sources, and purchases move in realtime — and let bot
+                blocking keep the scrapers out of your conversion math.
+              </p>
+            </article>
+
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-7 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">A slow store is a silent discount</h3>
+              <p className="mt-2 max-w-lg text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                Web vitals from real shopper visits show which pages feel slow, by route, country, and device — so
+                you fix the product page that's quietly costing conversions instead of guessing.
+              </p>
+              <Link
+                href="/features/web-vitals"
+                className="group mt-5 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+              >
+                Web vitals
+                <ArrowRight
+                  className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                  aria-hidden="true"
+                />
+              </Link>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <PersonaFaqSection heading="Ecommerce questions, answered plainly." items={faqItems} />
+      <PersonaCrossLinks current="for-ecommerce" />
+
+      <CTASection
+        title="Know which campaigns sell, not just which ones click."
+        description="Checkout funnels, campaign conversion, and full traffic — with no consent banner in the way."
+        eventLocation="for_ecommerce_bottom_cta"
+      />
+    </div>
+  );
+}

--- a/docs/src/app/[locale]/(home)/for-european-companies/page.tsx
+++ b/docs/src/app/[locale]/(home)/for-european-companies/page.tsx
@@ -1,0 +1,236 @@
+import { CTASection } from "@/components/CTASection";
+import { GridCrosses } from "@/components/GridCrosses";
+import { InteriorPageHero } from "@/components/InteriorPageHero";
+import { PersonaCrossLinks } from "@/components/persona/PersonaCrossLinks";
+import { PersonaFaqSection } from "@/components/persona/PersonaFaqSection";
+import { SectionKicker } from "@/components/deco/SectionKicker";
+import { createMetadata, createOGImageUrl } from "@/lib/metadata";
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+const pageTitle = "Rybbit for European Companies | EU-Hosted, Cookieless Analytics";
+const pageDescription =
+  "EU-hosted cloud, no cookies, no consent banner, a DPA ready to sign — and a self-host option when residency has to go all the way down to the server. GDPR compliant by design.";
+
+export const metadata = createMetadata({
+  title: pageTitle,
+  description: pageDescription,
+  alternates: {
+    canonical: "https://rybbit.com/for-european-companies",
+  },
+  openGraph: {
+    title: pageTitle,
+    description: pageDescription,
+    url: "https://rybbit.com/for-european-companies",
+    images: [createOGImageUrl("Rybbit for European Companies", "EU-hosted, cookieless, compliant by design.", "Solutions")],
+  },
+  twitter: {
+    images: [createOGImageUrl("Rybbit for European Companies", "EU-hosted, cookieless, compliant by design.", "Solutions")],
+  },
+});
+
+const faqItems = [
+  {
+    question: "Is Rybbit GDPR and CCPA compliant?",
+    answer:
+      "Yes. Rybbit doesn't use cookies or collect personal data that could identify visitors, and user IDs are salted daily so nobody can be fingerprinted. You won't need to show a cookie consent banner for analytics.",
+  },
+  {
+    question: "Where is the cloud hosted?",
+    answer:
+      "Rybbit's cloud is EU-hosted. If your requirements go further than that, you can self-host the entire product on infrastructure you control, in any region you choose.",
+  },
+  {
+    question: "Do you offer a Data Processing Agreement?",
+    answer:
+      "Yes. Rybbit provides a DPA — see rybbit.com/dpa. Dedicated isolated instances and on-premise installation are available on the Enterprise plan for stricter setups.",
+  },
+  {
+    question: "Do visitors need to consent before Rybbit runs?",
+    answer:
+      "Analytics that doesn't collect personal data doesn't sit behind a consent choice. That's also an accuracy point: you measure all of your visitors, not the subset who click accept.",
+  },
+  {
+    question: "Can we keep the data entirely on our own infrastructure?",
+    answer:
+      "Yes. Rybbit is open source under AGPL v3 — the full product self-hosts with Docker on your own servers, which is the strongest data-residency answer there is.",
+  },
+];
+
+const complianceRows = [
+  {
+    title: "EU-hosted cloud",
+    description: "Rybbit's managed cloud is EU-hosted — the default option is already the compliant one.",
+  },
+  {
+    title: "No cookies, no banner",
+    description:
+      "Rybbit collects no personal data and sets no cookies, so analytics doesn't trigger a consent requirement on your sites.",
+  },
+  {
+    title: "No fingerprinting, by construction",
+    description:
+      "Visitor IDs are salted daily, so they can't be used to fingerprint or follow a person over time — a design property, not a policy promise.",
+  },
+  {
+    title: "DPA ready to sign",
+    description: "A Data Processing Agreement is available for your records, along with a public security page.",
+  },
+];
+
+export default function ForEuropeanCompaniesPage() {
+  return (
+    <div className="overflow-x-clip">
+      <InteriorPageHero
+        eyebrow="Rybbit for European companies"
+        title="Analytics that doesn't need a legal review."
+        description="EU-hosted cloud, no cookies, no consent banner, and a DPA ready to sign — with a self-host option when residency has to go all the way down to the server."
+        eventLocation="for_european_companies_hero"
+      />
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="eu-accuracy-title">
+        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+          <GridCrosses />
+          <div className="grid grid-cols-1 lg:grid-cols-12">
+            <div className="relative border-b border-neutral-200 bg-plate-accent px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-7 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 bg-graph-accent [mask-image:linear-gradient(to_bottom,black,transparent_92%)]"
+              />
+              <div className="relative">
+                <SectionKicker>Compliance is an accuracy feature</SectionKicker>
+                <h2
+                  id="eu-accuracy-title"
+                  className="mt-5 max-w-2xl text-4xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl"
+                >
+                  No cookies means no banner. No banner means all of your traffic.
+                </h2>
+              </div>
+            </div>
+            <div className="flex items-end px-5 py-10 sm:px-8 md:py-20 lg:col-span-5 lg:px-10">
+              <p className="max-w-md text-lg leading-8 text-neutral-600 text-pretty dark:text-neutral-400">
+                Consent-gated analytics only measures the visitors who click accept, so every report starts from a
+                partial number. Analytics that never touches personal data doesn&apos;t have that gap — compliance
+                and accurate data stop being a trade-off.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="eu-compliance-title">
+        <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+          <GridCrosses />
+          <div className="border-b border-neutral-200 px-5 py-12 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 lg:py-16">
+            <div className="lg:sticky lg:top-24">
+              <h2
+                id="eu-compliance-title"
+                className="max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+              >
+                What your DPO will ask. In order.
+              </h2>
+              <p className="mt-6 max-w-sm text-base leading-7 text-neutral-600 dark:text-neutral-400">
+                The short version of the review, in one place — with the documents linked below it.
+              </p>
+              <div className="mt-8 flex flex-col gap-4">
+                <Link
+                  href="/dpa"
+                  className="group inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+                >
+                  Data Processing Agreement
+                  <ArrowRight
+                    className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                    aria-hidden="true"
+                  />
+                </Link>
+                <Link
+                  href="/security"
+                  className="group inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-neutral-600 transition-colors duration-200 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 dark:text-neutral-400 dark:hover:text-white"
+                >
+                  Security overview
+                  <ArrowRight
+                    className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                    aria-hidden="true"
+                  />
+                </Link>
+                <Link
+                  href="/privacy"
+                  className="group inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-neutral-600 transition-colors duration-200 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 dark:text-neutral-400 dark:hover:text-white"
+                >
+                  Privacy policy
+                  <ArrowRight
+                    className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                    aria-hidden="true"
+                  />
+                </Link>
+              </div>
+            </div>
+          </div>
+          <div className="lg:col-span-8">
+            {complianceRows.map(row => (
+              <div
+                key={row.title}
+                className="grid border-b border-neutral-200 px-5 py-8 last:border-b-0 dark:border-neutral-800 sm:grid-cols-[220px_1fr] sm:gap-6 sm:px-8 lg:px-10"
+              >
+                <h3 className="font-semibold tracking-tight">{row.title}</h3>
+                <p className="mt-2 max-w-xl text-sm leading-6 text-neutral-600 dark:text-neutral-400 sm:mt-0">
+                  {row.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="eu-selfhost-title">
+        <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+          <GridCrosses />
+          <div className="border-b border-neutral-200 px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-7 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+            <h2
+              id="eu-selfhost-title"
+              className="max-w-xl text-4xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl"
+            >
+              When "EU-hosted" isn&apos;t strict enough, host it yourself.
+            </h2>
+            <p className="mt-6 max-w-xl text-base leading-7 text-neutral-600 dark:text-neutral-400">
+              Rybbit is 100% open source under AGPL v3 and self-hosts with Docker. For regulated setups, Enterprise
+              adds dedicated isolated instances and on-premise installation — the residency conversation ends at
+              your own rack.
+            </p>
+          </div>
+          <div className="flex flex-col justify-center gap-4 px-5 py-10 sm:px-8 md:py-20 lg:col-span-5 lg:px-10">
+            <Link
+              href="/docs/self-hosting"
+              className="group inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+            >
+              Self-hosting guide
+              <ArrowRight
+                className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                aria-hidden="true"
+              />
+            </Link>
+            <Link
+              href="/enterprise"
+              className="group inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-neutral-600 transition-colors duration-200 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 dark:text-neutral-400 dark:hover:text-white"
+            >
+              Rybbit for enterprise
+              <ArrowRight
+                className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                aria-hidden="true"
+              />
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <PersonaFaqSection heading="European-company questions, answered plainly." items={faqItems} />
+      <PersonaCrossLinks current="for-european-companies" />
+
+      <CTASection
+        title="Compliant by default. Accurate because of it."
+        description="EU-hosted, cookieless, and banner-free — with self-hosting when the answer has to be your own servers."
+        eventLocation="for_european_companies_bottom_cta"
+      />
+    </div>
+  );
+}

--- a/docs/src/app/[locale]/(home)/for-saas/page.tsx
+++ b/docs/src/app/[locale]/(home)/for-saas/page.tsx
@@ -1,0 +1,299 @@
+import { CTASection } from "@/components/CTASection";
+import { GridCrosses } from "@/components/GridCrosses";
+import { InteriorPageHero } from "@/components/InteriorPageHero";
+import { PersonaCrossLinks } from "@/components/persona/PersonaCrossLinks";
+import { PersonaFaqSection } from "@/components/persona/PersonaFaqSection";
+import { SectionKicker } from "@/components/deco/SectionKicker";
+import { createMetadata, createOGImageUrl } from "@/lib/metadata";
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+const pageTitle = "Rybbit for SaaS | Funnels, Retention, and Sessions in One Tool";
+const pageDescription =
+  "Signup funnels, retention cohorts, user profiles, session replay, and error tracking — the product-analytics surface without the enterprise setup project. Cookieless and GDPR compliant.";
+
+export const metadata = createMetadata({
+  title: pageTitle,
+  description: pageDescription,
+  alternates: {
+    canonical: "https://rybbit.com/for-saas",
+  },
+  openGraph: {
+    title: pageTitle,
+    description: pageDescription,
+    url: "https://rybbit.com/for-saas",
+    images: [createOGImageUrl("Rybbit for SaaS", "See the funnel. Then watch the sessions inside it.", "Solutions")],
+  },
+  twitter: {
+    images: [createOGImageUrl("Rybbit for SaaS", "See the funnel. Then watch the sessions inside it.", "Solutions")],
+  },
+});
+
+const faqItems = [
+  {
+    question: "Is Rybbit web analytics or product analytics?",
+    answer:
+      "Both, from one script. Traffic, sources, and campaigns sit next to funnels, retention, user profiles, session replay, and error tracking — you don't glue a marketing tool to a product tool.",
+  },
+  {
+    question: "Do I need an instrumentation plan before I see anything?",
+    answer:
+      "No. Autocapture records pageviews, clicks, form submits, and errors from the moment the script loads. Custom events are there when you want to name specific product moments, and the Node SDK covers server-side events.",
+  },
+  {
+    question: "Can I see what an individual user experienced?",
+    answer:
+      "Yes. User profiles show a visitor's sessions and events over time, and on Pro you can watch session replays — useful when a support ticket says 'it just doesn't work.'",
+  },
+  {
+    question: "Which plan do SaaS teams usually need?",
+    answer:
+      "Standard includes funnels, goals, journeys, retention, user profiles, and error tracking. Pro adds session replays, unlimited websites, and unlimited team members — most product teams end up on Pro for the replays.",
+  },
+  {
+    question: "Does the tracking script need a cookie banner in our app?",
+    answer:
+      "No. Rybbit is cookieless and doesn't collect personal data that could identify visitors, so it's GDPR and CCPA compliant without a consent banner — in the app and on the marketing site.",
+  },
+  {
+    question: "Can we pull the data into our own systems?",
+    answer:
+      "Yes. The Stats API exposes metrics, sessions, funnels, goals, errors, and events over HTTP with bearer-key auth, and there's an API playground in the dashboard that generates ready-to-use snippets.",
+  },
+];
+
+const funnelSteps = [
+  { label: "Visited /pricing", value: "6,720", width: "100%" },
+  { label: "Started trial", value: "1,804", width: "27%" },
+  { label: "Invited a teammate", value: "1,102", width: "16%" },
+  { label: "Upgraded to paid", value: "918", width: "13.7%" },
+];
+
+// Fake-but-plausible weekly retention cohort, rendered in the periwinkle
+// data hue per DESIGN.md (data is the only surface periwinkle may paint).
+const cohortRows = [
+  { cohort: "Jun 1", cells: [100, 62, 48, 41, 37, 34] },
+  { cohort: "Jun 8", cells: [100, 58, 45, 39, 35] },
+  { cohort: "Jun 15", cells: [100, 64, 51, 44] },
+  { cohort: "Jun 22", cells: [100, 61, 47] },
+];
+
+export default function ForSaasPage() {
+  return (
+    <div className="overflow-x-clip">
+      <InteriorPageHero
+        eyebrow="Rybbit for SaaS"
+        title="See the funnel. Then watch the sessions inside it."
+        description="Signup funnels, retention cohorts, user profiles, and error tracking on the same dashboard as your traffic — the product-analytics surface without the enterprise setup project."
+        eventLocation="for_saas_hero"
+      />
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="saas-problem-title">
+        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+          <GridCrosses />
+          <div className="grid grid-cols-1 lg:grid-cols-12">
+            <div className="relative border-b border-neutral-200 bg-plate-accent px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-7 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 bg-graph-accent [mask-image:linear-gradient(to_bottom,black,transparent_92%)]"
+              />
+              <div className="relative">
+                <SectionKicker>One connected surface</SectionKicker>
+                <h2
+                  id="saas-problem-title"
+                  className="mt-5 max-w-2xl text-4xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl"
+                >
+                  Web analytics and product analytics were never two products.
+                </h2>
+              </div>
+            </div>
+            <div className="flex items-end px-5 py-10 sm:px-8 md:py-20 lg:col-span-5 lg:px-10">
+              <p className="max-w-md text-lg leading-8 text-neutral-600 text-pretty dark:text-neutral-400">
+                The question is always the same shape: this campaign brought these visitors, who became these trials,
+                who did or didn&apos;t stick. Splitting that across two tools is where the answer gets lost.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="saas-funnel-title">
+        <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+          <GridCrosses />
+          <div className="border-b border-neutral-200 px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+            <div className="lg:sticky lg:top-24">
+              <SectionKicker>Funnels</SectionKicker>
+              <h2
+                id="saas-funnel-title"
+                className="mt-5 max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+              >
+                Find the step that loses trials.
+              </h2>
+              <p className="mt-6 max-w-sm text-base leading-7 text-neutral-600 dark:text-neutral-400">
+                Build a funnel from page paths or custom events in a few clicks — pricing page to trial to activation
+                to paid — and see exactly where the numbers fall off. Then open the sessions that dropped.
+              </p>
+              <Link
+                href="/features/funnels"
+                className="group mt-8 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+              >
+                Funnels
+                <ArrowRight
+                  className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                  aria-hidden="true"
+                />
+              </Link>
+            </div>
+          </div>
+          <div className="flex flex-col justify-center px-5 py-10 sm:px-8 md:py-14 lg:col-span-8 lg:px-10">
+            <div className="max-w-2xl rounded-md border border-neutral-200 p-4 dark:border-neutral-800 sm:p-5">
+              <ul className="space-y-3.5">
+                {funnelSteps.map(step => (
+                  <li key={step.label}>
+                    <div className="flex items-baseline justify-between gap-4 text-sm">
+                      <span className="text-neutral-700 dark:text-neutral-300">{step.label}</span>
+                      <span className="font-medium tabular-nums">{step.value}</span>
+                    </div>
+                    <div className="mt-1.5 h-1.5 overflow-hidden rounded-[1px] bg-neutral-100 dark:bg-neutral-900">
+                      <div className="h-full rounded-[1px] bg-(--dataviz)" style={{ width: step.width }} />
+                    </div>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-4 border-t border-neutral-200 pt-3 text-xs text-neutral-500 dark:border-neutral-800 dark:text-neutral-400">
+                End-to-end conversion <span className="font-medium tabular-nums">13.7%</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="saas-retention-title">
+        <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+          <GridCrosses />
+          <div className="order-last min-w-0 lg:order-first lg:col-span-8">
+            <div className="flex h-full flex-col justify-center px-5 py-10 sm:px-8 md:py-14 lg:px-10">
+              <div className="max-w-2xl overflow-x-auto rounded-md border border-neutral-200 p-4 dark:border-neutral-800 sm:p-5">
+                <table className="w-full min-w-[420px] border-separate border-spacing-1 text-xs">
+                  <thead>
+                    <tr className="text-left text-neutral-500 dark:text-neutral-400">
+                      <th scope="col" className="pr-2 font-medium">
+                        Cohort
+                      </th>
+                      {["W0", "W1", "W2", "W3", "W4", "W5"].map(week => (
+                        <th scope="col" key={week} className="text-center font-medium">
+                          {week}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {cohortRows.map(row => (
+                      <tr key={row.cohort}>
+                        <th scope="row" className="pr-2 text-left font-medium text-neutral-700 dark:text-neutral-300">
+                          {row.cohort}
+                        </th>
+                        {row.cells.map((value, index) => (
+                          <td
+                            key={index}
+                            className={`rounded-[1px] text-center tabular-nums ${
+                              value >= 55 ? "text-neutral-950" : "text-neutral-700 dark:text-neutral-300"
+                            }`}
+                            style={{
+                              backgroundColor: `color-mix(in oklab, var(--dataviz) ${Math.max(18, value * 0.85)}%, transparent)`,
+                            }}
+                          >
+                            {value}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+          <div className="border-b border-neutral-200 px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-l lg:px-10 md:py-20">
+            <div className="lg:sticky lg:top-24">
+              <SectionKicker>Retention</SectionKicker>
+              <h2
+                id="saas-retention-title"
+                className="mt-5 max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+              >
+                Know if this month&apos;s users stick better than last month&apos;s.
+              </h2>
+              <p className="mt-6 max-w-sm text-base leading-7 text-neutral-600 dark:text-neutral-400">
+                Retention cohorts show how each week&apos;s new users keep coming back — the first number a SaaS
+                should watch, and usually the last one a web-analytics tool offers.
+              </p>
+              <Link
+                href="/features/retention"
+                className="group mt-8 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+              >
+                Retention
+                <ArrowRight
+                  className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                  aria-hidden="true"
+                />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-label="SaaS workflow">
+        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+          <GridCrosses />
+          <div className="grid grid-cols-1 gap-px bg-neutral-200 p-px dark:bg-neutral-800 lg:grid-cols-12">
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-7 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">The ticket says &quot;it doesn&apos;t work&quot;</h3>
+              <p className="mt-2 max-w-lg text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                Pull up the user&apos;s profile, see their sessions and the error that fired, and watch the replay on
+                Pro. Support conversations get shorter when you can see what the customer saw.
+              </p>
+              <div className="mt-5 flex flex-wrap gap-x-6 gap-y-3 text-sm">
+                <Link
+                  href="/features/user-profiles"
+                  className="group inline-flex items-center gap-1.5 rounded-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+                >
+                  User profiles
+                  <ArrowRight
+                    className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                    aria-hidden="true"
+                  />
+                </Link>
+                <Link
+                  href="/features/session-replay"
+                  className="group inline-flex items-center gap-1.5 rounded-sm font-medium text-neutral-600 transition-colors duration-200 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 dark:text-neutral-400 dark:hover:text-white"
+                >
+                  Session replay
+                  <ArrowRight
+                    className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                    aria-hidden="true"
+                  />
+                </Link>
+              </div>
+            </article>
+
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-5 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">Events from the backend too</h3>
+              <p className="mt-2 max-w-md text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                Name the product moments that matter with custom events from the browser, or send them server-side
+                with the Node SDK when the moment doesn&apos;t happen in a click.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <PersonaFaqSection heading="SaaS questions, answered plainly." items={faqItems} />
+      <PersonaCrossLinks current="for-saas" />
+
+      <CTASection
+        title="Product analytics without the onboarding project."
+        description="Funnels, retention, profiles, and replays — running the afternoon you install the script."
+        eventLocation="for_saas_bottom_cta"
+      />
+    </div>
+  );
+}

--- a/docs/src/app/[locale]/(home)/for-startups/page.tsx
+++ b/docs/src/app/[locale]/(home)/for-startups/page.tsx
@@ -1,0 +1,274 @@
+import { CTASection } from "@/components/CTASection";
+import { GridCrosses } from "@/components/GridCrosses";
+import { InteriorPageHero } from "@/components/InteriorPageHero";
+import { PersonaCrossLinks } from "@/components/persona/PersonaCrossLinks";
+import { PersonaFaqSection } from "@/components/persona/PersonaFaqSection";
+import { SectionKicker } from "@/components/deco/SectionKicker";
+import { createMetadata, createOGImageUrl } from "@/lib/metadata";
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+const pageTitle = "Rybbit for Startups | Growth Answers Without a Data Team";
+const pageDescription =
+  "See where signups come from, watch where trials stall, and catch errors early — on one cookieless dashboard your whole team reads without training. Set up in minutes.";
+
+export const metadata = createMetadata({
+  title: pageTitle,
+  description: pageDescription,
+  alternates: {
+    canonical: "https://rybbit.com/for-startups",
+  },
+  openGraph: {
+    title: pageTitle,
+    description: pageDescription,
+    url: "https://rybbit.com/for-startups",
+    images: [createOGImageUrl("Rybbit for Startups", "Growth answers without a data team.", "Solutions")],
+  },
+  twitter: {
+    images: [createOGImageUrl("Rybbit for Startups", "Growth answers without a data team.", "Solutions")],
+  },
+});
+
+const faqItems = [
+  {
+    question: "How long does setup actually take?",
+    answer:
+      "Most teams are live in under five minutes: add one script tag or install @rybbit/js from npm, and pageviews, clicks, and sessions start flowing immediately. Funnels and goals are configured in the dashboard, not in code.",
+  },
+  {
+    question: "What happens to the price as our traffic grows?",
+    answer:
+      "Pricing is a slider over monthly pageviews, so you always see the number before you hit it. Plans start at 100K pageviews and scale in steps — no surprise invoices, and you can change plans at any time.",
+  },
+  {
+    question: "Can I import my Google Analytics history?",
+    answer:
+      "Not yet. Most teams run Rybbit alongside their old analytics for a few weeks, then switch once they trust the numbers. Your Rybbit history builds from the day you install.",
+  },
+  {
+    question: "When do I need Pro instead of Standard?",
+    answer:
+      "Standard covers up to 5 websites and 3 team members with funnels, goals, journeys, error tracking, and web vitals. Pro adds session replays, unlimited websites, and unlimited team members.",
+  },
+  {
+    question: "Do we need a cookie consent banner?",
+    answer:
+      "No. Rybbit doesn't use cookies or collect personal data, so it's GDPR and CCPA compliant without a consent banner — and you see all of your traffic, not just the visitors who click accept.",
+  },
+  {
+    question: "Is our data locked in?",
+    answer:
+      "No. Every plan includes API access and data export, and the whole product is open source under AGPL v3 — you can self-host the same stack whenever you want.",
+  },
+];
+
+const firstWeek = [
+  {
+    step: 1,
+    title: "Install in minutes",
+    description:
+      "One script tag on your marketing site and app, or @rybbit/js from npm. Pageviews, clicks, outbound links, and errors are captured automatically — no instrumentation plan required.",
+  },
+  {
+    step: 2,
+    title: "Wire the moments that matter",
+    description:
+      "Define goals for signups and upgrades, and build a funnel from landing page to activated trial. Both are configured in the dashboard in a few clicks, on data you're already collecting.",
+  },
+  {
+    step: 3,
+    title: "Watch the sessions behind the numbers",
+    description:
+      "When the funnel shows a drop-off, open the sessions that hit it. Session replay on Pro shows exactly what a stuck trial saw — including the error they never reported.",
+  },
+];
+
+export default function ForStartupsPage() {
+  return (
+    <div className="overflow-x-clip">
+      <InteriorPageHero
+        eyebrow="Rybbit for startups"
+        title="Growth answers without a data team."
+        description="See where signups come from, watch where trials stall, and catch errors before your users tweet about them — on one dashboard your whole team reads without training."
+        eventLocation="for_startups_hero"
+      />
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="startup-problem-title">
+        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+          <GridCrosses />
+          <div className="grid grid-cols-1 lg:grid-cols-12">
+            <div className="relative border-b border-neutral-200 bg-plate-accent px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-7 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 bg-graph-accent [mask-image:linear-gradient(to_bottom,black,transparent_92%)]"
+              />
+              <div className="relative">
+                <SectionKicker>Small team, every hat</SectionKicker>
+                <h2
+                  id="startup-problem-title"
+                  className="mt-5 max-w-2xl text-4xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl"
+                >
+                  You have ten minutes, not a GA4 certification.
+                </h2>
+              </div>
+            </div>
+            <div className="flex items-end px-5 py-10 sm:px-8 md:py-20 lg:col-span-5 lg:px-10">
+              <p className="max-w-md text-lg leading-8 text-neutral-600 text-pretty dark:text-neutral-400">
+                Analytics at a startup is a Tuesday-morning question — did the launch work, where did those signups
+                come from — not a discipline someone owns. Rybbit is built for the person answering that question
+                between two other jobs.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="startup-week-title">
+        <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+          <GridCrosses />
+          <div className="border-b border-neutral-200 px-5 py-12 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 lg:py-16">
+            <div className="lg:sticky lg:top-24">
+              <h2
+                id="startup-week-title"
+                className="max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+              >
+                Your first week with Rybbit.
+              </h2>
+              <p className="mt-6 max-w-sm text-base leading-7 text-neutral-600 dark:text-neutral-400">
+                An honest sequence, not a setup project. Each step works on the data the previous one already
+                collected.
+              </p>
+            </div>
+          </div>
+          <ol className="lg:col-span-8">
+            {firstWeek.map(item => (
+              <li
+                key={item.step}
+                className="grid border-b border-neutral-200 px-5 py-9 last:border-b-0 dark:border-neutral-800 sm:grid-cols-[64px_1fr] sm:px-8 lg:px-10"
+              >
+                <span className="mb-4 font-mono text-sm text-emerald-600 dark:text-emerald-400 sm:mb-0">
+                  {String(item.step).padStart(2, "0")}
+                </span>
+                <div>
+                  <h3 className="text-lg font-semibold tracking-tight">{item.title}</h3>
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                    {item.description}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-label="Startup workflow">
+        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+          <GridCrosses />
+          <div className="grid grid-cols-1 gap-px bg-neutral-200 p-px dark:bg-neutral-800 lg:grid-cols-12">
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-7 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">Launch-day realtime</h3>
+              <p className="mt-2 max-w-lg text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                On the morning you hit the front page, watch visitors, referrers, and signups move in realtime —
+                and because Rybbit is cookieless, the Hacker News crowd running ad blockers still shows up in your
+                numbers.
+              </p>
+              <div className="mt-6 flex max-w-md items-center justify-between rounded-md border border-neutral-200 px-3.5 py-3 text-sm dark:border-neutral-800">
+                <span className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400">
+                  <span className="relative flex size-2" aria-hidden="true">
+                    <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-500 opacity-60 motion-reduce:hidden" />
+                    <span className="relative inline-flex size-2 rounded-full bg-emerald-500" />
+                  </span>
+                  Visitors on site now
+                </span>
+                <span className="text-lg font-semibold tabular-nums">318</span>
+              </div>
+            </article>
+
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-5 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">Errors before bug reports</h3>
+              <p className="mt-2 max-w-md text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                Error tracking is on the same dashboard as traffic, so a broken signup page shows up as both a
+                falling funnel and a rising error — usually before the first support email lands.
+              </p>
+            </article>
+
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-5 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">One workspace for the team</h3>
+              <p className="mt-2 max-w-md text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                Invite your cofounder and first hires into an organization with member roles. Standard includes 3
+                team members; Pro removes the limit.
+              </p>
+            </article>
+
+            <article className="bg-white px-5 py-10 dark:bg-neutral-950 sm:px-8 lg:col-span-7 lg:px-10">
+              <h3 className="text-lg font-semibold tracking-tight">Speed you can defend</h3>
+              <p className="mt-2 max-w-lg text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                Web vitals from real visits show where your pages feel slow, by route and device — so performance
+                arguments in standup end with a number instead of a feeling.
+              </p>
+              <Link
+                href="/features/web-vitals"
+                className="group mt-5 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+              >
+                Web vitals
+                <ArrowRight
+                  className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                  aria-hidden="true"
+                />
+              </Link>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="startup-pricing-title">
+        <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+          <GridCrosses />
+          <div className="border-b border-neutral-200 px-5 py-14 dark:border-neutral-800 sm:px-8 lg:col-span-7 lg:border-b-0 lg:border-r lg:px-10 md:py-20">
+            <h2
+              id="startup-pricing-title"
+              className="max-w-xl text-4xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl"
+            >
+              Starts small. Priced by traffic, not by seat.
+            </h2>
+            <p className="mt-6 max-w-xl text-base leading-7 text-neutral-600 dark:text-neutral-400">
+              Standard starts at $13/month billed annually for 100K pageviews, and the pricing slider shows exactly
+              what the next stage of growth costs before you get there. Every plan starts with a 7-day free trial.
+            </p>
+          </div>
+          <div className="flex flex-col justify-center gap-4 px-5 py-10 sm:px-8 md:py-20 lg:col-span-5 lg:px-10">
+            <Link
+              href="/pricing"
+              className="group inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-emerald-700 transition-colors duration-200 hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-400 dark:hover:text-emerald-300"
+            >
+              See the pricing slider
+              <ArrowRight
+                className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                aria-hidden="true"
+              />
+            </Link>
+            <Link
+              href="/docs/self-hosting"
+              className="group inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-neutral-600 transition-colors duration-200 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 dark:text-neutral-400 dark:hover:text-white"
+            >
+              Or self-host free
+              <ArrowRight
+                className="size-3.5 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+                aria-hidden="true"
+              />
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <PersonaFaqSection heading="Startup questions, answered plainly." items={faqItems} />
+      <PersonaCrossLinks current="for-startups" />
+
+      <CTASection
+        title="Spend the week shipping, not configuring analytics."
+        description="Install in minutes, wire your funnel in clicks, and read the answers on one screen."
+        eventLocation="for_startups_bottom_cta"
+      />
+    </div>
+  );
+}

--- a/docs/src/app/sitemap.ts
+++ b/docs/src/app/sitemap.ts
@@ -94,6 +94,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly" as const,
       priority: 0.6,
     },
+    {
+      url: `${baseUrl}/for-agencies`,
+      lastModified: new Date(),
+      changeFrequency: "monthly" as const,
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/for-developers`,
+      lastModified: new Date(),
+      changeFrequency: "monthly" as const,
+      priority: 0.8,
+    },
   ];
 
   return [...staticPages, ...comparisonPages, ...toolPages, ...docPages, ...blogPosts];

--- a/docs/src/app/sitemap.ts
+++ b/docs/src/app/sitemap.ts
@@ -94,19 +94,25 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly" as const,
       priority: 0.6,
     },
-    {
-      url: `${baseUrl}/for-agencies`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/for-developers`,
-      lastModified: new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.8,
-    },
   ];
 
-  return [...staticPages, ...comparisonPages, ...toolPages, ...docPages, ...blogPosts];
+  // Persona / solutions pages
+  const personaSlugs = [
+    "for-agencies",
+    "for-developers",
+    "for-startups",
+    "for-saas",
+    "for-ecommerce",
+    "for-creators",
+    "for-european-companies",
+    "enterprise",
+  ];
+  const personaPages = personaSlugs.map(slug => ({
+    url: `${baseUrl}/${slug}`,
+    lastModified: new Date(),
+    changeFrequency: "monthly" as const,
+    priority: 0.8,
+  }));
+
+  return [...staticPages, ...personaPages, ...comparisonPages, ...toolPages, ...docPages, ...blogPosts];
 }

--- a/docs/src/components/CodeCard.tsx
+++ b/docs/src/components/CodeCard.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+
+export interface CodeCardToken {
+  text: string;
+  className?: string;
+}
+
+interface CodeCardProps {
+  label: string;
+  tokens: CodeCardToken[];
+  className?: string;
+}
+
+/**
+ * A static editor-chrome code block matching TrackingSnippet's visual
+ * language, for pages that show more than the install tag. Code content is
+ * intentionally untranslated; surrounding section copy carries the i18n.
+ */
+export function CodeCard({ label, tokens, className }: CodeCardProps) {
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-md border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900",
+        className
+      )}
+    >
+      <div className="flex items-center gap-1.5 border-b border-neutral-200 px-3 py-2 dark:border-neutral-800">
+        <span aria-hidden="true" className="size-2 rounded-full bg-[#ff5f57]" />
+        <span aria-hidden="true" className="size-2 rounded-full bg-[#febc2e]" />
+        <span aria-hidden="true" className="size-2 rounded-full bg-[#28c840]" />
+        <span className="ml-2 font-mono text-xs text-neutral-500 dark:text-neutral-400">{label}</span>
+      </div>
+      <pre className="overflow-x-auto p-3 text-xs leading-6">
+        <code className="text-neutral-500 dark:text-neutral-400">
+          {tokens.map((token, index) => (
+            <span key={index} className={token.className || undefined}>
+              {token.text}
+            </span>
+          ))}
+        </code>
+      </pre>
+    </div>
+  );
+}

--- a/docs/src/components/persona/PersonaCrossLinks.tsx
+++ b/docs/src/components/persona/PersonaCrossLinks.tsx
@@ -1,0 +1,112 @@
+import { GridCrosses } from "@/components/GridCrosses";
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+export type PersonaSlug =
+  | "for-developers"
+  | "for-agencies"
+  | "for-startups"
+  | "for-saas"
+  | "for-ecommerce"
+  | "for-creators"
+  | "for-european-companies"
+  | "enterprise";
+
+const personas: { slug: PersonaSlug; title: string; description: string }[] = [
+  {
+    slug: "for-developers",
+    title: "For developers",
+    description: "The script tag, the SDK, the API, the MCP server, and self-hosting.",
+  },
+  {
+    slug: "for-agencies",
+    title: "For agencies",
+    description: "One workspace for every client site, with dashboards clients can read on their own.",
+  },
+  {
+    slug: "for-startups",
+    title: "For startups",
+    description: "Answers about your traffic and product without hiring a data team.",
+  },
+  {
+    slug: "for-saas",
+    title: "For SaaS",
+    description: "Signup funnels, retention cohorts, and the sessions behind every drop-off.",
+  },
+  {
+    slug: "for-ecommerce",
+    title: "For ecommerce",
+    description: "Checkout funnels, campaign tracking, and full traffic with no consent banner.",
+  },
+  {
+    slug: "for-creators",
+    title: "For creators & publishers",
+    description: "What resonates, where readers come from, and a dashboard you can share.",
+  },
+  {
+    slug: "for-european-companies",
+    title: "For European companies",
+    description: "EU-hosted cloud, cookieless compliance, and a self-host option for full control.",
+  },
+  {
+    slug: "enterprise",
+    title: "Enterprise",
+    description: "SSO, dedicated instances, on-premise installation, and infinite retention.",
+  },
+];
+
+/**
+ * The persona cluster's closing nav: every sibling page plus the compare
+ * hub, so a mis-landed visitor can self-select instead of bouncing.
+ */
+export function PersonaCrossLinks({ current }: { current: PersonaSlug }) {
+  const siblings = personas.filter(persona => persona.slug !== current);
+
+  return (
+    <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="persona-crosslinks-title">
+      <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+        <GridCrosses />
+        <div className="border-b border-neutral-200 px-5 py-8 dark:border-neutral-800 sm:px-8 lg:px-10">
+          <h2 id="persona-crosslinks-title" className="text-2xl font-semibold tracking-tight md:text-3xl">
+            More ways teams use Rybbit.
+          </h2>
+        </div>
+        <div className="grid grid-cols-1 gap-px bg-neutral-200 p-px dark:bg-neutral-800 sm:grid-cols-2">
+          {siblings.map(persona => (
+            <Link
+              key={persona.slug}
+              href={`/${persona.slug}`}
+              className="group flex items-start justify-between gap-4 bg-white px-5 py-6 transition-colors hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500 dark:bg-neutral-950 dark:hover:bg-neutral-900/60 sm:px-8 lg:px-10"
+            >
+              <span className="min-w-0">
+                <span className="block font-semibold tracking-tight">{persona.title}</span>
+                <span className="mt-1 block text-sm leading-6 text-neutral-500 dark:text-neutral-400">
+                  {persona.description}
+                </span>
+              </span>
+              <ArrowRight
+                className="mt-1 size-4 shrink-0 text-neutral-400 transition-transform group-hover:translate-x-1 motion-reduce:transition-none"
+                aria-hidden="true"
+              />
+            </Link>
+          ))}
+          <Link
+            href="/compare"
+            className="group flex items-start justify-between gap-4 bg-white px-5 py-6 transition-colors hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500 dark:bg-neutral-950 dark:hover:bg-neutral-900/60 sm:px-8 lg:px-10"
+          >
+            <span className="min-w-0">
+              <span className="block font-semibold tracking-tight">Compare Rybbit</span>
+              <span className="mt-1 block text-sm leading-6 text-neutral-500 dark:text-neutral-400">
+                Side-by-side with Google Analytics, Plausible, Matomo, PostHog, and more.
+              </span>
+            </span>
+            <ArrowRight
+              className="mt-1 size-4 shrink-0 text-neutral-400 transition-transform group-hover:translate-x-1 motion-reduce:transition-none"
+              aria-hidden="true"
+            />
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs/src/components/persona/PersonaFaqSection.tsx
+++ b/docs/src/components/persona/PersonaFaqSection.tsx
@@ -1,0 +1,63 @@
+import { GridCrosses } from "@/components/GridCrosses";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+
+export interface PersonaFaqItem {
+  question: string;
+  answer: string;
+}
+
+interface PersonaFaqSectionProps {
+  heading: string;
+  items: PersonaFaqItem[];
+}
+
+/**
+ * FAQ section for persona pages. The accordion and the FAQPage JSON-LD are
+ * rendered from the same array so the schema can never drift from the
+ * visible answers — every question is covered, with identical text.
+ */
+export function PersonaFaqSection({ heading, items }: PersonaFaqSectionProps) {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: items.map(item => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: { "@type": "Answer", text: item.answer },
+    })),
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="persona-faq-title">
+        <div className="relative mx-auto grid max-w-[1200px] grid-cols-1 border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+          <GridCrosses />
+          <div className="border-b border-neutral-200 px-5 py-12 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 lg:py-16">
+            <div className="lg:sticky lg:top-24">
+              <h2
+                id="persona-faq-title"
+                className="max-w-sm text-4xl font-semibold leading-[1.04] tracking-[-0.035em] md:text-5xl"
+              >
+                {heading}
+              </h2>
+            </div>
+          </div>
+          <Accordion type="single" collapsible className="lg:col-span-8">
+            {items.map((faq, index) => (
+              <AccordionItem key={faq.question} value={`item-${index}`} className="last:border-b-0">
+                <AccordionTrigger className="px-5 py-5 text-left sm:px-8 lg:px-10">{faq.question}</AccordionTrigger>
+                <AccordionContent className="px-5 pb-6 sm:px-8 lg:px-10">{faq.answer}</AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </div>
+      </section>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

A full "Who it's for" persona cluster — **eight pages**, grounded in the July 2026 competitor research (Plausible's persona nav, Swetrix/Pirsch agency pages, Fathom's jurisdictional persona, and the developer-page whitespace both big rivals leave open):

| Page | Lead angle |
|---|---|
| `/for-agencies` | Client reporting without the training call; unlimited websites on Pro |
| `/for-developers` | Script/SDK/API/MCP/self-host, with real code samples throughout |
| `/for-startups` | Growth answers without a data team; "first week" sequence; launch-day realtime |
| `/for-saas` | Signup funnels + retention cohorts + the sessions behind every drop-off |
| `/for-ecommerce` | Checkout funnels and campaign conversion; consent-gap accuracy framing |
| `/for-creators` | What resonates, reader sources, Search Console, public "build in public" dashboards |
| `/for-european-companies` | Compliance as an accuracy feature; DPO checklist; self-host for full residency |
| `/enterprise` | Contact-led CTA, customer logo strip, procurement feature grid, open-source auditability |

Each page has a distinct lead pain, its own section shapes and mocks (funnel bars and a retention cohort grid in the periwinkle data hue, campaign rows, workspace roster, realtime chip), and persona-tuned CTAs — enterprise is contact-led, everything else self-serve, per the CTA-laddering pattern from the research.

## Shared architecture

- **`PersonaFaqSection`** — accordion + FAQPage JSON-LD rendered from one array, so schema can never drift from visible answers (all questions covered).
- **`PersonaCrossLinks`** — every page ends with the full sibling cluster + `/compare`, Plausible's closed-cluster pattern.
- **`CodeCard`** — static editor-chrome code blocks matching `TrackingSnippet`.
- **No new i18n keys** — all copy is plain English strings while the translate workflow is down.
- Every claim verified against the repo (tier limits, sharing, roles, GSC integration, self-host commands, API request/response shapes) — including two deliberately honest FAQ answers (no GA importer yet, no dedicated revenue report yet).
- All eight routes in `sitemap.ts`.

## Verification

- `tsc --noEmit` clean; all eight routes render 200 with no dev-server errors.
- Screenshot-reviewed: six pages at 1440px dark, mobile passes (390px) for the riskiest layouts (cohort table, enterprise logo/feature grids), plus a light-mode pass — no horizontal blowout anywhere.

## Follow-ups (deliberately out of scope)

- Header/footer "Solutions" nav group needs translated labels in all 10 locales — the cluster self-links, but nav placement is what makes it IA rather than SEO surface.
- Persona-matched testimonials per page (the research's clearest differentiator between good persona pages and clones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new persona marketing pages, including Enterprise, For Creators, For Ecommerce, For European Companies, For SaaS, and For Startups, alongside dedicated For Agencies and For Developers experiences.
  * Introduced shared FAQ and cross-linking components for consistent accordions, structured FAQ data, and persona navigation.
  * Added a reusable CodeCard component for consistent, styled code example blocks.

* **Documentation**
  * Expanded the sitemap to include all persona/solutions pages.
  * Updated page SEO/social metadata and improved FAQ rendering consistency across personas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->