### PR TITLE
Harmonize free-tools forms with the app design system

### DIFF
--- a/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/AICommentForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/AICommentForm.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { CheckCircle, Copy, Loader2 } from "lucide-react";
 import { useState } from "react";
+import {
+  CopyButton,
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolSelect,
+  ToolTextarea,
+} from "../../components/tool-ui";
 import type { CommentPlatformConfig } from "./comment-platform-configs";
 
 interface AICommentFormProps {
@@ -50,7 +57,6 @@ export default function AICommentForm({ platform }: AICommentFormProps) {
   const [comments, setComments] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
   const [remainingRequests, setRemainingRequests] = useState<number | null>(
     null
   );
@@ -98,52 +104,34 @@ export default function AICommentForm({ platform }: AICommentFormProps) {
     }
   };
 
-  const copyToClipboard = async (text: string, index: number) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopiedIndex(index);
-      setTimeout(() => setCopiedIndex(null), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
-
   return (
     <div className="space-y-6">
-      <div>
-        <label
-          htmlFor="original-content"
-          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-        >
-          Original Content
-        </label>
-        <textarea
-          id="original-content"
+      <ToolField
+        label="Original Content"
+        htmlFor="comment-original-content"
+        hint={
+          <>
+            {originalContent.length}
+            {platform.characterLimit && ` / ${platform.characterLimit}`}{" "}
+            characters
+          </>
+        }
+      >
+        <ToolTextarea
+          id="comment-original-content"
           rows={6}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 resize-y"
+          className="resize-y"
           placeholder={`Paste the ${platform.name} post or content you want to comment on...`}
           value={originalContent}
           onChange={(e) => setOriginalContent(e.target.value)}
           maxLength={platform.characterLimit || 10000}
         />
-        <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-          {originalContent.length}
-          {platform.characterLimit && ` / ${platform.characterLimit}`}{" "}
-          characters
-        </p>
-      </div>
+      </ToolField>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <label
-            htmlFor="tone"
-            className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-          >
-            Tone
-          </label>
-          <select
-            id="tone"
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <ToolField label="Tone" htmlFor="comment-tone">
+          <ToolSelect
+            id="comment-tone"
             value={tone}
             onChange={(e) => setTone(e.target.value)}
           >
@@ -152,19 +140,12 @@ export default function AICommentForm({ platform }: AICommentFormProps) {
                 {option.label} - {option.description}
               </option>
             ))}
-          </select>
-        </div>
+          </ToolSelect>
+        </ToolField>
 
-        <div>
-          <label
-            htmlFor="length"
-            className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-          >
-            Length
-          </label>
-          <select
-            id="length"
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        <ToolField label="Length" htmlFor="comment-length">
+          <ToolSelect
+            id="comment-length"
             value={length}
             onChange={(e) => setLength(e.target.value)}
           >
@@ -173,64 +154,44 @@ export default function AICommentForm({ platform }: AICommentFormProps) {
                 {option.label} - {option.description}
               </option>
             ))}
-          </select>
-        </div>
+          </ToolSelect>
+        </ToolField>
       </div>
 
-      <button
+      <ToolButton
         onClick={generateComments}
-        disabled={isLoading || !originalContent.trim()}
-        className="w-full px-6 py-3 bg-emerald-600 hover:bg-emerald-500 disabled:bg-neutral-400 dark:disabled:bg-neutral-700 text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
+        loading={isLoading}
+        disabled={!originalContent.trim()}
+        className="w-full"
       >
-        {isLoading ? (
-          <>
-            <Loader2 className="w-5 h-5 animate-spin" />
-            Generating Comments...
-          </>
-        ) : (
-          "Generate Comments"
-        )}
-      </button>
+        {isLoading ? "Generating Comments..." : "Generate Comments"}
+      </ToolButton>
 
       {remainingRequests !== null && (
-        <p className="text-sm text-center text-neutral-600 dark:text-neutral-400">
+        <p className="text-center text-sm text-neutral-500 dark:text-neutral-400">
           {remainingRequests} requests remaining this minute
         </p>
       )}
 
-      {error && (
-        <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-          <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
-        </div>
-      )}
+      {error && <ToolCallout variant="error">{error}</ToolCallout>}
 
       {comments.length > 0 && (
-        <div className="space-y-4">
-          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">
+        <div className="space-y-3 border-t border-neutral-200 pt-6 dark:border-neutral-800">
+          <h3 className="text-base font-semibold text-neutral-900 dark:text-white">
             Generated Comments
           </h3>
           {comments.map((comment, index) => (
             <div
               key={index}
-              className="p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-lg"
+              className="rounded-md border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900/50"
             >
-              <div className="flex items-start justify-between gap-3 mb-2">
-                <p className="flex-1 text-neutral-900 dark:text-white whitespace-pre-wrap">
+              <div className="flex items-start justify-between gap-4">
+                <p className="flex-1 whitespace-pre-wrap text-neutral-900 dark:text-white">
                   {comment}
                 </p>
-                <button
-                  onClick={() => copyToClipboard(comment, index)}
-                  className="flex-shrink-0 p-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
-                  title="Copy to clipboard"
-                >
-                  {copiedIndex === index ? (
-                    <CheckCircle className="w-5 h-5 text-emerald-600" />
-                  ) : (
-                    <Copy className="w-5 h-5 text-neutral-600 dark:text-neutral-400" />
-                  )}
-                </button>
+                <CopyButton value={comment} className="shrink-0" />
               </div>
-              <p className="text-xs text-neutral-500 dark:text-neutral-400">
+              <p className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
                 {comment.length} characters
               </p>
             </div>
@@ -238,11 +199,9 @@ export default function AICommentForm({ platform }: AICommentFormProps) {
         </div>
       )}
 
-      <div className="p-4 bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 rounded-lg">
-        <p className="text-sm text-neutral-700 dark:text-neutral-300">
-          <strong>Platform Context:</strong> {platform.contextGuidelines}
-        </p>
-      </div>
+      <ToolCallout variant="info" title="Platform Context">
+        {platform.contextGuidelines}
+      </ToolCallout>
     </div>
   );
 }

--- a/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/BioGenerator.tsx
+++ b/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/BioGenerator.tsx
@@ -1,8 +1,16 @@
 "use client";
 
+import { AlertCircle, Check, Copy, User } from "lucide-react";
 import { useState } from "react";
-import { User, Copy, Check, AlertCircle, Loader2 } from "lucide-react";
 import type { BioGeneratorPlatformConfig } from "./bio-generator-platform-configs";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResultDivider,
+  ToolSelect,
+} from "../../components/tool-ui";
 
 interface BioGeneratorProps {
   platform: BioGeneratorPlatformConfig;
@@ -85,123 +93,72 @@ export function BioGenerator({ platform }: BioGeneratorProps) {
   };
 
   return (
-    <div className="w-full max-w-4xl mx-auto">
-      {/* Context Guidelines */}
-      <div className="mb-8 p-4 bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 rounded-lg">
-        <div className="flex gap-3">
-          <div className="p-2 bg-emerald-100 dark:bg-emerald-900/30 rounded-lg h-fit">
-            <User className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
-          </div>
-          <div>
-            <h3 className="text-sm font-medium text-neutral-900 dark:text-white mb-1">
-              {platform.name} {platform.bioType} Guidelines
-            </h3>
-            <p className="text-sm text-neutral-600 dark:text-neutral-400">{platform.contextGuidelines}</p>
-          </div>
-        </div>
-      </div>
+    <div className="space-y-6">
+      <ToolCallout variant="info" icon={User} title={`${platform.name} ${platform.bioType} Guidelines`}>
+        {platform.contextGuidelines}
+      </ToolCallout>
 
-      {/* Generator Form */}
-      <div className="space-y-6 mb-8">
-        {/* Name Input */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-200 mb-2">
-            Name or Brand *
-          </label>
-          <input
-            type="text"
-            value={name}
-            onChange={e => setName(e.target.value)}
-            placeholder="Your name or brand name"
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:border-transparent text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500"
-          />
-        </div>
+      <ToolField label="Name or Brand" htmlFor="bio-name" required>
+        <ToolInput
+          id="bio-name"
+          type="text"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="Your name or brand name"
+        />
+      </ToolField>
 
-        {/* Profession Input */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-200 mb-2">
-            Profession or Role
-          </label>
-          <input
-            type="text"
-            value={profession}
-            onChange={e => setProfession(e.target.value)}
-            placeholder="e.g., Software Engineer, Content Creator, Artist"
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:border-transparent text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500"
-          />
-        </div>
+      <ToolField label="Profession or Role" htmlFor="bio-profession">
+        <ToolInput
+          id="bio-profession"
+          type="text"
+          value={profession}
+          onChange={e => setProfession(e.target.value)}
+          placeholder="e.g., Software Engineer, Content Creator, Artist"
+        />
+      </ToolField>
 
-        {/* Interests Input */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-200 mb-2">
-            Interests or Focus Areas (Optional)
-          </label>
-          <input
-            type="text"
-            value={interests}
-            onChange={e => setInterests(e.target.value)}
-            placeholder="e.g., AI, fitness, travel, photography"
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:border-transparent text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500"
-          />
-        </div>
+      <ToolField label="Interests or Focus Areas (Optional)" htmlFor="bio-interests">
+        <ToolInput
+          id="bio-interests"
+          type="text"
+          value={interests}
+          onChange={e => setInterests(e.target.value)}
+          placeholder="e.g., AI, fitness, travel, photography"
+        />
+      </ToolField>
 
-        {/* Tone Selector */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-200 mb-2">Tone</label>
-          <select
-            value={tone}
-            onChange={e => setTone(e.target.value)}
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:border-transparent text-neutral-900 dark:text-white"
-          >
-            {platform.tones.map(t => (
-              <option key={t} value={t}>
-                {t}
-              </option>
-            ))}
-          </select>
-        </div>
+      <ToolField label="Tone" htmlFor="bio-tone">
+        <ToolSelect id="bio-tone" value={tone} onChange={e => setTone(e.target.value)}>
+          {platform.tones.map(t => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </ToolSelect>
+      </ToolField>
 
-        {/* Generate Button */}
-        <button
-          onClick={handleGenerate}
-          disabled={loading || (!name.trim() && !profession.trim())}
-          className="w-full px-6 py-3 bg-emerald-600 hover:bg-emerald-700 disabled:bg-neutral-300 dark:disabled:bg-neutral-700 text-white font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2"
-        >
-          {loading ? (
-            <>
-              <Loader2 className="w-5 h-5 animate-spin" />
-              Generating...
-            </>
-          ) : (
-            <>
-              <User className="w-5 h-5" />
-              Generate {platform.bioType}
-            </>
-          )}
-        </button>
-      </div>
+      <ToolButton
+        onClick={handleGenerate}
+        loading={loading}
+        disabled={!name.trim() && !profession.trim()}
+        icon={User}
+        className="w-full"
+      >
+        {loading ? "Generating..." : `Generate ${platform.bioType}`}
+      </ToolButton>
 
-      {/* Rate Limit Info */}
       {rateLimit && (
-        <div className="mb-6 p-4 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-          <p className="text-sm text-neutral-600 dark:text-neutral-400">
-            Rate limit: {rateLimit.remaining} of {rateLimit.limit} requests remaining
-          </p>
-        </div>
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
+          Rate limit: {rateLimit.remaining} of {rateLimit.limit} requests remaining
+        </p>
       )}
 
-      {/* Error Message */}
-      {error && (
-        <div className="mb-6 p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 rounded-lg flex items-start gap-3">
-          <AlertCircle className="w-5 h-5 text-red-600 dark:text-red-400 mt-0.5 flex-shrink-0" />
-          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
-        </div>
-      )}
+      {error && <ToolCallout variant="error">{error}</ToolCallout>}
 
-      {/* Generated Bios */}
       {bios.length > 0 && (
-        <div className="space-y-4">
-          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Generated {platform.bioType}s</h3>
+        <ToolResultDivider>
+          <h3 className="text-base font-semibold text-neutral-900 dark:text-white">Generated {platform.bioType}s</h3>
 
           {bios.map((bio, index) => {
             const isOverLimit = bio.length > platform.characterLimit;
@@ -210,30 +167,22 @@ export function BioGenerator({ platform }: BioGeneratorProps) {
             return (
               <div
                 key={index}
-                className="p-4 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-lg"
+                className="rounded-md border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900/50"
               >
-                <div className="flex items-start justify-between gap-4 mb-3">
+                <div className="mb-3 flex items-start justify-between gap-4">
                   <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Option {index + 1}</p>
-                  <button
+                  <ToolButton
+                    variant="secondary"
                     onClick={() => copyBio(bio, index)}
                     disabled={isOverLimit}
-                    className="px-3 py-1.5 text-xs bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 rounded-md transition-colors duration-200 flex items-center gap-2 flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                    icon={copiedIndex === index ? Check : Copy}
+                    className="shrink-0"
                   >
-                    {copiedIndex === index ? (
-                      <>
-                        <Check className="w-3.5 h-3.5 text-emerald-600 dark:text-emerald-400" />
-                        Copied!
-                      </>
-                    ) : (
-                      <>
-                        <Copy className="w-3.5 h-3.5" />
-                        Copy
-                      </>
-                    )}
-                  </button>
+                    {copiedIndex === index ? "Copied!" : "Copy"}
+                  </ToolButton>
                 </div>
 
-                <p className="text-neutral-900 dark:text-white mb-3 leading-relaxed">{bio}</p>
+                <p className="mb-3 leading-relaxed text-neutral-900 dark:text-white">{bio}</p>
 
                 <div className="flex items-center justify-between text-xs">
                   <span
@@ -241,26 +190,26 @@ export function BioGenerator({ platform }: BioGeneratorProps) {
                       isOverLimit
                         ? "text-red-600 dark:text-red-400"
                         : charsRemaining < 20
-                        ? "text-orange-600 dark:text-orange-400"
+                        ? "text-amber-600 dark:text-amber-500"
                         : "text-neutral-500 dark:text-neutral-400"
                     }`}
                   >
                     {bio.length} / {platform.characterLimit} characters
                   </span>
                   {isOverLimit && (
-                    <span className="text-red-600 dark:text-red-400 flex items-center gap-1">
-                      <AlertCircle className="w-3.5 h-3.5" />
+                    <span className="flex items-center gap-1 text-red-600 dark:text-red-400">
+                      <AlertCircle className="size-3.5" />
                       {Math.abs(charsRemaining)} over limit
                     </span>
                   )}
                   {!isOverLimit && charsRemaining < 20 && (
-                    <span className="text-orange-600 dark:text-orange-400">{charsRemaining} remaining</span>
+                    <span className="text-amber-600 dark:text-amber-500">{charsRemaining} remaining</span>
                   )}
                 </div>
               </div>
             );
           })}
-        </div>
+        </ToolResultDivider>
       )}
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/CharacterCounter.tsx
+++ b/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/CharacterCounter.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { AlertCircle, CheckCircle, Copy, Check } from "lucide-react";
+import { CopyButton, ToolCallout, ToolStat, ToolTextarea } from "../../components/tool-ui";
 import type { CharacterCounterPlatformConfig } from "./character-counter-platform-configs";
 
 interface CharacterCounterProps {
@@ -10,7 +10,6 @@ interface CharacterCounterProps {
 
 export function CharacterCounter({ platform }: CharacterCounterProps) {
   const [text, setText] = useState("");
-  const [copied, setCopied] = useState(false);
 
   const characterCount = text.length;
   const characterCountNoSpaces = text.replace(/\s/g, "").length;
@@ -25,120 +24,78 @@ export function CharacterCounter({ platform }: CharacterCounterProps) {
 
   const getStatusColor = () => {
     if (isOverLimit) return "text-red-600 dark:text-red-400";
-    if (isNearLimit) return "text-orange-600 dark:text-orange-400";
+    if (isNearLimit) return "text-amber-600 dark:text-amber-500";
     return "text-emerald-600 dark:text-emerald-400";
   };
 
   const getProgressBarColor = () => {
     if (isOverLimit) return "bg-red-500";
-    if (isNearLimit) return "bg-orange-500";
+    if (isNearLimit) return "bg-amber-500";
     return "bg-emerald-500";
-  };
-
-  const copyText = async () => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
   };
 
   return (
     <div className="w-full max-w-4xl mx-auto">
       {/* Platform Info */}
-      <div className="mb-8 p-6 bg-emerald-50/50 dark:bg-emerald-950/20 border border-emerald-200 dark:border-emerald-800 rounded-xl">
-        <div className="flex items-start gap-3">
-          <div className="w-5 h-5 mt-0.5 flex-shrink-0">
-            {isOverLimit ? (
-              <AlertCircle className="w-5 h-5 text-red-600 dark:text-red-400" />
-            ) : (
-              <CheckCircle className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
-            )}
-          </div>
-          <div className="flex-1">
-            <h3 className="font-semibold text-neutral-900 dark:text-white mb-2">
-              {platform.name} {platform.contentType} Limit
-            </h3>
-            <p className="text-sm text-neutral-600 dark:text-neutral-300 mb-2">
-              <strong>Character limit:</strong> {platform.characterLimit.toLocaleString()} characters
-              {platform.recommendedLimit && (
-                <span className="ml-2 text-neutral-500">
-                  (recommended: {platform.recommendedLimit} characters)
-                </span>
-              )}
-            </p>
-            <p className="text-sm text-neutral-600 dark:text-neutral-300">
-              {platform.countingRules}
-            </p>
-          </div>
-        </div>
-      </div>
+      <ToolCallout
+        variant={isOverLimit ? "error" : "success"}
+        title={`${platform.name} ${platform.contentType} Limit`}
+        className="mb-8"
+      >
+        <p className="mb-2">
+          <strong>Character limit:</strong> {platform.characterLimit.toLocaleString()} characters
+          {platform.recommendedLimit && (
+            <span className="ml-2 text-neutral-500 dark:text-neutral-400">
+              (recommended: {platform.recommendedLimit} characters)
+            </span>
+          )}
+        </p>
+        <p>{platform.countingRules}</p>
+      </ToolCallout>
 
       {/* Text Area */}
-      <div className="mb-6">
-        <div className="relative">
-          <textarea
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            placeholder={`Type or paste your ${platform.contentType} here...`}
-            rows={10}
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:border-transparent resize-none text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500"
-          />
-          {text && (
-            <button
-              onClick={copyText}
-              className="absolute top-3 right-3 px-3 py-1.5 text-xs bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 rounded-md transition-colors duration-200 flex items-center gap-2"
-            >
-              {copied ? (
-                <>
-                  <Check className="w-3.5 h-3.5 text-emerald-600 dark:text-emerald-400" />
-                  Copied!
-                </>
-              ) : (
-                <>
-                  <Copy className="w-3.5 h-3.5" />
-                  Copy
-                </>
-              )}
-            </button>
-          )}
-        </div>
+      <div className="mb-6 space-y-2">
+        <ToolTextarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={`Type or paste your ${platform.contentType} here...`}
+          rows={10}
+          className="resize-none"
+        />
+        {text && (
+          <div className="flex justify-end">
+            <CopyButton value={text} label="Copy" copiedLabel="Copied!" />
+          </div>
+        )}
       </div>
 
       {/* Character Count Stats */}
       <div className="space-y-4 mb-6">
         {/* Main Counter */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div>
-              <p className={`text-3xl font-bold ${getStatusColor()}`}>
-                {characterCount.toLocaleString()}
-              </p>
-              <p className="text-sm text-neutral-500 dark:text-neutral-400">
-                characters
-              </p>
-            </div>
-            <div className="h-12 w-px bg-neutral-200 dark:bg-neutral-800" />
-            <div>
-              <p className={`text-3xl font-bold ${getStatusColor()}`}>
-                {remaining >= 0 ? remaining.toLocaleString() : `+${Math.abs(remaining).toLocaleString()}`}
-              </p>
-              <p className="text-sm text-neutral-500 dark:text-neutral-400">
-                {remaining >= 0 ? "remaining" : "over limit"}
-              </p>
-            </div>
+        <div className="flex flex-wrap items-center gap-6">
+          <div>
+            <p className={`text-3xl font-semibold ${getStatusColor()}`}>
+              {characterCount.toLocaleString()}
+            </p>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              characters
+            </p>
           </div>
+          <div className="h-12 w-px bg-neutral-200 dark:bg-neutral-800" />
+          <div>
+            <p className={`text-3xl font-semibold ${getStatusColor()}`}>
+              {remaining >= 0 ? remaining.toLocaleString() : `+${Math.abs(remaining).toLocaleString()}`}
+            </p>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              {remaining >= 0 ? "remaining" : "over limit"}
+            </p>
+          </div>
+        </div>
 
-          <div className="text-right">
-            <p className="text-sm text-neutral-600 dark:text-neutral-300 mb-1">
-              <strong>Without spaces:</strong> {characterCountNoSpaces.toLocaleString()}
-            </p>
-            <p className="text-sm text-neutral-600 dark:text-neutral-300">
-              <strong>Progress:</strong> {percentage.toFixed(1)}%
-            </p>
-          </div>
+        {/* Secondary Stats */}
+        <div className="grid grid-cols-2 gap-3">
+          <ToolStat label="Without spaces" value={characterCountNoSpaces.toLocaleString()} />
+          <ToolStat label="Progress" value={`${percentage.toFixed(1)}%`} />
         </div>
 
         {/* Progress Bar */}
@@ -151,51 +108,27 @@ export function CharacterCounter({ platform }: CharacterCounterProps) {
 
         {/* Status Messages */}
         {isOverLimit && (
-          <div className="p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 rounded-lg flex items-start gap-3">
-            <AlertCircle className="w-5 h-5 text-red-600 dark:text-red-400 mt-0.5 flex-shrink-0" />
-            <div>
-              <p className="text-sm font-semibold text-red-600 dark:text-red-400 mb-1">
-                Over Character Limit
-              </p>
-              <p className="text-sm text-red-600 dark:text-red-400">
-                Your {platform.contentType} exceeds {platform.name}'s {platform.characterLimit.toLocaleString()}-character
-                limit by {Math.abs(remaining).toLocaleString()} characters. Please shorten your text.
-              </p>
-            </div>
-          </div>
+          <ToolCallout variant="error" title="Over Character Limit">
+            Your {platform.contentType} exceeds {platform.name}'s {platform.characterLimit.toLocaleString()}-character
+            limit by {Math.abs(remaining).toLocaleString()} characters. Please shorten your text.
+          </ToolCallout>
         )}
 
         {!isOverLimit && isNearLimit && (
-          <div className="p-4 bg-orange-50 dark:bg-orange-950/20 border border-orange-200 dark:border-orange-800 rounded-lg flex items-start gap-3">
-            <AlertCircle className="w-5 h-5 text-orange-600 dark:text-orange-400 mt-0.5 flex-shrink-0" />
-            <div>
-              <p className="text-sm font-semibold text-orange-600 dark:text-orange-400 mb-1">
-                Approaching Character Limit
-              </p>
-              <p className="text-sm text-orange-600 dark:text-orange-400">
-                You're using {percentage.toFixed(1)}% of {platform.name}'s character limit. Only{" "}
-                {remaining.toLocaleString()} characters remaining.
-              </p>
-            </div>
-          </div>
+          <ToolCallout variant="warning" title="Approaching Character Limit">
+            You're using {percentage.toFixed(1)}% of {platform.name}'s character limit. Only{" "}
+            {remaining.toLocaleString()} characters remaining.
+          </ToolCallout>
         )}
 
         {!isOverLimit &&
           !isNearLimit &&
           platform.recommendedLimit &&
           isAtRecommended && (
-            <div className="p-4 bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800 rounded-lg flex items-start gap-3">
-              <AlertCircle className="w-5 h-5 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0" />
-              <div>
-                <p className="text-sm font-semibold text-blue-600 dark:text-blue-400 mb-1">
-                  Above Recommended Length
-                </p>
-                <p className="text-sm text-blue-600 dark:text-blue-400">
-                  While you're within the limit, posts under {platform.recommendedLimit} characters
-                  typically perform better on {platform.name}.
-                </p>
-              </div>
-            </div>
+            <ToolCallout variant="info" title="Above Recommended Length">
+              While you're within the limit, posts under {platform.recommendedLimit} characters
+              typically perform better on {platform.name}.
+            </ToolCallout>
           )}
       </div>
 

--- a/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/FontGeneratorTool.tsx
+++ b/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/FontGeneratorTool.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { CheckCircle, Copy } from "lucide-react";
 import { useState } from "react";
+import { CopyButton, ToolCallout, ToolField, ToolTextarea } from "../../components/tool-ui";
 
 interface FontStyle {
   name: string;
@@ -1648,17 +1648,6 @@ interface FontGeneratorToolProps {
 
 export function FontGeneratorTool({ platformName, characterLimit }: FontGeneratorToolProps) {
   const [inputText, setInputText] = useState("");
-  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
-
-  const copyToClipboard = async (text: string, index: number) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopiedIndex(index);
-      setTimeout(() => setCopiedIndex(null), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
 
   const transformedTexts = fontStyles.map(style => ({
     ...style,
@@ -1666,74 +1655,56 @@ export function FontGeneratorTool({ platformName, characterLimit }: FontGenerato
     length: inputText ? style.transform(inputText).length : 0,
   }));
 
+  const overLimit = Boolean(characterLimit && inputText && inputText.length > characterLimit);
+
   return (
     <div className="space-y-6">
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Enter your text {platformName && `for ${platformName}`}
-        </label>
-        <textarea
+      <ToolField
+        label={`Enter your text${platformName ? ` for ${platformName}` : ""}`}
+        htmlFor="font-input"
+        hint={
+          characterLimit && inputText ? (
+            <span className={overLimit ? "text-red-600 dark:text-red-400" : undefined}>
+              {inputText.length} / {characterLimit} characters
+              {overLimit && ` (${inputText.length - characterLimit} over limit)`}
+            </span>
+          ) : undefined
+        }
+      >
+        <ToolTextarea
+          id="font-input"
           value={inputText}
           onChange={e => setInputText(e.target.value)}
-          placeholder="Type your text here..."
+          placeholder="Type your text here…"
           rows={3}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 resize-none"
+          className="resize-none"
         />
-        {characterLimit && inputText && (
-          <p
-            className={`text-xs mt-1 ${
-              inputText.length > characterLimit
-                ? "text-red-600 dark:text-red-400"
-                : "text-neutral-500 dark:text-neutral-400"
-            }`}
-          >
-            {inputText.length} / {characterLimit} characters
-            {inputText.length > characterLimit && ` (${inputText.length - characterLimit} over limit)`}
-          </p>
-        )}
-      </div>
+      </ToolField>
 
-      {inputText && (
-        <div className="space-y-3">
-          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">Font Styles</h3>
+      {inputText ? (
+        <div className="space-y-3 border-t border-neutral-200 pt-6 dark:border-neutral-800">
+          <h3 className="text-base font-semibold text-neutral-900 dark:text-white">Font styles</h3>
           <div className="grid gap-3">
             {transformedTexts.map((style, index) => (
               <div
                 key={index}
-                className="p-4 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:border-emerald-500/40 dark:hover:border-emerald-500/30 transition-colors"
+                className="rounded-md border border-neutral-200 bg-neutral-50 p-4 transition-colors hover:border-neutral-300 dark:border-neutral-800 dark:bg-neutral-900/50 dark:hover:border-neutral-700"
               >
                 <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1 min-w-0">
-                    <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1">{style.name}</p>
-                    <p className="text-neutral-900 dark:text-white break-words font-medium text-lg">{style.result}</p>
+                  <div className="min-w-0 flex-1">
+                    <p className="mb-1 text-xs font-medium text-neutral-500 dark:text-neutral-400">{style.name}</p>
+                    <p className="break-words text-lg font-medium text-neutral-900 dark:text-white">{style.result}</p>
                   </div>
-                  <button
-                    onClick={() => copyToClipboard(style.result, index)}
-                    className="flex-shrink-0 px-3 py-1.5 bg-neutral-200 dark:bg-neutral-700 hover:bg-neutral-300 dark:hover:bg-neutral-600 text-neutral-900 dark:text-white text-sm rounded-lg transition-colors flex items-center gap-2"
-                  >
-                    {copiedIndex === index ? (
-                      <>
-                        <CheckCircle className="w-4 h-4" />
-                        Copied
-                      </>
-                    ) : (
-                      <>
-                        <Copy className="w-4 h-4" />
-                        Copy
-                      </>
-                    )}
-                  </button>
+                  <CopyButton value={style.result} className="shrink-0" />
                 </div>
               </div>
             ))}
           </div>
         </div>
-      )}
-
-      {!inputText && (
-        <div className="text-center py-12 text-neutral-500 dark:text-neutral-400">
-          Enter text above to see it transformed into different font styles
-        </div>
+      ) : (
+        <ToolCallout variant="info" icon={null} className="justify-center text-center">
+          Enter text above to see it transformed into different font styles.
+        </ToolCallout>
       )}
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/HashtagGenerator.tsx
+++ b/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/HashtagGenerator.tsx
@@ -1,8 +1,18 @@
 "use client";
 
+import { Hash } from "lucide-react";
 import { useState } from "react";
-import { Hash, Copy, Check, AlertCircle, Loader2 } from "lucide-react";
 import type { HashtagGeneratorPlatformConfig } from "./hashtag-generator-platform-configs";
+import {
+  CopyButton,
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResultDivider,
+  ToolSelect,
+  ToolTextarea,
+} from "../../components/tool-ui";
 
 interface HashtagGeneratorProps {
   platform: HashtagGeneratorPlatformConfig;
@@ -15,7 +25,6 @@ export function HashtagGenerator({ platform }: HashtagGeneratorProps) {
   const [hashtags, setHashtags] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
-  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
   const [rateLimit, setRateLimit] = useState<{
     limit: number;
     remaining: number;
@@ -73,188 +82,84 @@ export function HashtagGenerator({ platform }: HashtagGeneratorProps) {
     }
   };
 
-  const copyHashtags = async (hashtagSet: string, index: number) => {
-    try {
-      await navigator.clipboard.writeText(hashtagSet);
-      setCopiedIndex(index);
-      setTimeout(() => setCopiedIndex(null), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
-
-  const copyAllHashtags = async () => {
-    try {
-      await navigator.clipboard.writeText(hashtags.join(" "));
-      setCopiedIndex(-1);
-      setTimeout(() => setCopiedIndex(null), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
-
   return (
-    <div className="w-full max-w-4xl mx-auto">
-      {/* Context Guidelines */}
-      <div className="mb-8 p-6 bg-emerald-50/50 dark:bg-emerald-950/20 border border-emerald-200 dark:border-emerald-800 rounded-xl">
-        <div className="flex items-start gap-3">
-          <Hash className="w-5 h-5 text-emerald-600 dark:text-emerald-400 mt-0.5 flex-shrink-0" />
-          <div>
-            <h3 className="font-semibold text-neutral-900 dark:text-white mb-2">
-              {platform.name} Hashtag Guidelines
-            </h3>
-            <p className="text-sm text-neutral-600 dark:text-neutral-300">
-              {platform.contextGuidelines}
-            </p>
-          </div>
-        </div>
-      </div>
+    <div className="space-y-6">
+      <ToolCallout variant="info" icon={Hash} title={`${platform.name} Hashtag Guidelines`}>
+        {platform.contextGuidelines}
+      </ToolCallout>
 
-      {/* Generator Form */}
-      <div className="space-y-6 mb-8">
-        {/* Topic Input */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-200 mb-2">
-            Topic or Content Description *
-          </label>
-          <textarea
-            value={topic}
-            onChange={(e) => setTopic(e.target.value)}
-            placeholder={`Describe your ${platform.name} content...`}
-            rows={4}
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:border-transparent resize-none text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500"
-          />
-        </div>
+      <ToolField label="Topic or Content Description" htmlFor="hashtag-topic" required>
+        <ToolTextarea
+          id="hashtag-topic"
+          value={topic}
+          onChange={e => setTopic(e.target.value)}
+          placeholder={`Describe your ${platform.name} content...`}
+          rows={4}
+          className="resize-none"
+        />
+      </ToolField>
 
-        {/* Strategy Selector */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-200 mb-2">
-            Hashtag Strategy
-          </label>
-          <select
-            value={strategy}
-            onChange={(e) => setStrategy(e.target.value)}
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:border-transparent text-neutral-900 dark:text-white"
-          >
-            {platform.hashtagStrategies.map((strat) => (
-              <option key={strat} value={strat}>
-                {strat}
-              </option>
-            ))}
-          </select>
-        </div>
+      <ToolField label="Hashtag Strategy" htmlFor="hashtag-strategy">
+        <ToolSelect id="hashtag-strategy" value={strategy} onChange={e => setStrategy(e.target.value)}>
+          {platform.hashtagStrategies.map(strat => (
+            <option key={strat} value={strat}>
+              {strat}
+            </option>
+          ))}
+        </ToolSelect>
+      </ToolField>
 
-        {/* Keywords (Optional) */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-200 mb-2">
-            Niche/Keywords (Optional)
-          </label>
-          <input
-            type="text"
-            value={keywords}
-            onChange={(e) => setKeywords(e.target.value)}
-            placeholder="e.g., fitness, vegan, startup, travel"
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:border-transparent text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500"
-          />
-        </div>
+      <ToolField label="Niche/Keywords (Optional)" htmlFor="hashtag-keywords">
+        <ToolInput
+          id="hashtag-keywords"
+          type="text"
+          value={keywords}
+          onChange={e => setKeywords(e.target.value)}
+          placeholder="e.g., fitness, vegan, startup, travel"
+        />
+      </ToolField>
 
-        {/* Generate Button */}
-        <button
-          onClick={handleGenerate}
-          disabled={loading || !topic.trim()}
-          className="w-full px-6 py-3 bg-emerald-600 hover:bg-emerald-700 disabled:bg-neutral-300 dark:disabled:bg-neutral-700 text-white font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2"
-        >
-          {loading ? (
-            <>
-              <Loader2 className="w-5 h-5 animate-spin" />
-              Generating...
-            </>
-          ) : (
-            <>
-              <Hash className="w-5 h-5" />
-              Generate Hashtags
-            </>
-          )}
-        </button>
-      </div>
+      <ToolButton
+        onClick={handleGenerate}
+        loading={loading}
+        disabled={!topic.trim()}
+        icon={Hash}
+        className="w-full"
+      >
+        {loading ? "Generating..." : "Generate Hashtags"}
+      </ToolButton>
 
-      {/* Rate Limit Info */}
       {rateLimit && (
-        <div className="mb-6 p-4 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-          <p className="text-sm text-neutral-600 dark:text-neutral-400">
-            Rate limit: {rateLimit.remaining} of {rateLimit.limit} requests remaining
-          </p>
-        </div>
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
+          Rate limit: {rateLimit.remaining} of {rateLimit.limit} requests remaining
+        </p>
       )}
 
-      {/* Error Message */}
-      {error && (
-        <div className="mb-6 p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 rounded-lg flex items-start gap-3">
-          <AlertCircle className="w-5 h-5 text-red-600 dark:text-red-400 mt-0.5 flex-shrink-0" />
-          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
-        </div>
-      )}
+      {error && <ToolCallout variant="error">{error}</ToolCallout>}
 
-      {/* Generated Hashtags */}
       {hashtags.length > 0 && (
-        <div className="space-y-4">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">
-              Generated Hashtag Sets
-            </h3>
-            <button
-              onClick={copyAllHashtags}
-              className="px-4 py-2 text-sm bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 rounded-lg transition-colors duration-200 flex items-center gap-2"
-            >
-              {copiedIndex === -1 ? (
-                <>
-                  <Check className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />
-                  Copied!
-                </>
-              ) : (
-                <>
-                  <Copy className="w-4 h-4" />
-                  Copy All
-                </>
-              )}
-            </button>
+        <ToolResultDivider>
+          <div className="flex items-center justify-between gap-4">
+            <h3 className="text-base font-semibold text-neutral-900 dark:text-white">Generated Hashtag Sets</h3>
+            <CopyButton value={hashtags.join(" ")} label="Copy All" copiedLabel="Copied!" className="shrink-0" />
           </div>
 
           {hashtags.map((hashtagSet, index) => (
             <div
               key={index}
-              className="p-4 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-lg"
+              className="rounded-md border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900/50"
             >
-              <div className="flex items-start justify-between gap-4 mb-3">
-                <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">
-                  Set {index + 1}
-                </p>
-                <button
-                  onClick={() => copyHashtags(hashtagSet, index)}
-                  className="px-3 py-1.5 text-xs bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 rounded-md transition-colors duration-200 flex items-center gap-2 flex-shrink-0"
-                >
-                  {copiedIndex === index ? (
-                    <>
-                      <Check className="w-3.5 h-3.5 text-emerald-600 dark:text-emerald-400" />
-                      Copied!
-                    </>
-                  ) : (
-                    <>
-                      <Copy className="w-3.5 h-3.5" />
-                      Copy
-                    </>
-                  )}
-                </button>
+              <div className="mb-3 flex items-start justify-between gap-4">
+                <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Set {index + 1}</p>
+                <CopyButton value={hashtagSet} copiedLabel="Copied!" className="shrink-0" />
               </div>
-              <p className="text-neutral-900 dark:text-white break-words">
-                {hashtagSet}
-              </p>
-              <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-2">
+              <p className="break-words text-neutral-900 dark:text-white">{hashtagSet}</p>
+              <p className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
                 {hashtagSet.split(/\s+/).filter(Boolean).length} hashtags • {hashtagSet.length} characters
               </p>
             </div>
           ))}
-        </div>
+        </ToolResultDivider>
       )}
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/ImageResizer.tsx
+++ b/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/ImageResizer.tsx
@@ -5,6 +5,7 @@ import Cropper, { Area } from "react-easy-crop";
 import { Upload, Download, RotateCw, ZoomIn, Image as ImageIcon, X } from "lucide-react";
 import { ImageResizerPlatformConfig } from "./image-resizer-platform-configs";
 import getCroppedImg from "./image-resizer-utils";
+import { ToolButton, ToolCallout, ToolField } from "../../components/tool-ui";
 
 interface ImageResizerProps {
   platform: ImageResizerPlatformConfig;
@@ -84,19 +85,16 @@ export default function ImageResizer({ platform }: ImageResizerProps) {
   return (
     <div className="space-y-8">
       {/* Controls Section */}
-      <div className="space-y-4">
-        <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300">
-          Select Image Type
-        </label>
+      <ToolField label="Select Image Type">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {platform.dimensions.map((dim, index) => (
             <button
               key={index}
               onClick={() => setSelectedDimensionIndex(index)}
-              className={`p-3 rounded-lg border text-left transition-all ${
+              className={`p-3 rounded-md border text-left transition-colors ${
                 selectedDimensionIndex === index
-                  ? "border-emerald-500 bg-emerald-50 dark:bg-emerald-900/20 ring-1 ring-emerald-500"
-                  : "border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 hover:border-emerald-300 dark:hover:border-emerald-700"
+                  ? "border-emerald-500 bg-emerald-50 dark:bg-emerald-950/25 ring-1 ring-emerald-500"
+                  : "border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900/50 hover:border-emerald-300 dark:hover:border-emerald-700"
               }`}
             >
               <div className="font-medium text-neutral-900 dark:text-white">
@@ -113,10 +111,10 @@ export default function ImageResizer({ platform }: ImageResizerProps) {
             </button>
           ))}
         </div>
-      </div>
+      </ToolField>
 
       {/* Editor Section */}
-      <div className="bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-xl overflow-hidden">
+      <div className="bg-white dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg overflow-hidden">
         {!imageSrc ? (
           <div 
             className="h-80 flex flex-col items-center justify-center bg-neutral-50 dark:bg-neutral-900/50 cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-900 transition-colors border-2 border-dashed border-neutral-300 dark:border-neutral-700 m-4 rounded-lg"
@@ -163,7 +161,7 @@ export default function ImageResizer({ platform }: ImageResizerProps) {
             </div>
 
             {/* Editing Controls */}
-            <div className="p-6 space-y-6 border-t border-neutral-200 dark:border-neutral-700">
+            <div className="p-6 space-y-6 border-t border-neutral-200 dark:border-neutral-800">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-2">
                   <div className="flex justify-between text-sm text-neutral-600 dark:text-neutral-400">
@@ -180,7 +178,7 @@ export default function ImageResizer({ platform }: ImageResizerProps) {
                     step={0.1}
                     aria-labelledby="Zoom"
                     onChange={(e) => setZoom(Number(e.target.value))}
-                    className="w-full h-2 bg-neutral-200 dark:bg-neutral-700 rounded-lg appearance-none cursor-pointer accent-emerald-600"
+                    className="w-full h-2 bg-neutral-200 dark:bg-neutral-800 rounded-md appearance-none cursor-pointer accent-emerald-600"
                   />
                 </div>
 
@@ -199,49 +197,27 @@ export default function ImageResizer({ platform }: ImageResizerProps) {
                     step={1}
                     aria-labelledby="Rotation"
                     onChange={(e) => setRotation(Number(e.target.value))}
-                    className="w-full h-2 bg-neutral-200 dark:bg-neutral-700 rounded-lg appearance-none cursor-pointer accent-emerald-600"
+                    className="w-full h-2 bg-neutral-200 dark:bg-neutral-800 rounded-md appearance-none cursor-pointer accent-emerald-600"
                   />
                 </div>
               </div>
 
-              <div className="flex items-center justify-between pt-4 border-t border-neutral-200 dark:border-neutral-700">
+              <div className="flex items-center justify-between pt-4 border-t border-neutral-200 dark:border-neutral-800">
                 <div className="text-sm text-neutral-500 dark:text-neutral-400">
                   Output: <span className="font-mono text-neutral-900 dark:text-white">{selectedDimension.width} x {selectedDimension.height}px</span>
                 </div>
-                <button
-                  onClick={onDownload}
-                  disabled={isGenerating}
-                  className="px-6 py-2.5 bg-emerald-600 hover:bg-emerald-500 text-white font-medium rounded-lg transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {isGenerating ? (
-                    "Processing..."
-                  ) : (
-                    <>
-                      <Download className="w-4 h-4" /> Download Image
-                    </>
-                  )}
-                </button>
+                <ToolButton onClick={onDownload} loading={isGenerating} icon={Download}>
+                  {isGenerating ? "Processing..." : "Download Image"}
+                </ToolButton>
               </div>
             </div>
           </div>
         )}
       </div>
       
-      <div className="p-4 bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 rounded-lg">
-        <div className="flex gap-3">
-          <div className="p-2 bg-emerald-100 dark:bg-emerald-900/30 rounded-lg h-fit">
-            <ImageIcon className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
-          </div>
-          <div>
-            <h3 className="text-sm font-medium text-neutral-900 dark:text-white mb-1">
-              Why use this tool?
-            </h3>
-            <p className="text-sm text-neutral-600 dark:text-neutral-400">
-              {platform.educationalContent} This tool ensures your images are perfectly sized to avoid automatic cropping or quality loss.
-            </p>
-          </div>
-        </div>
-      </div>
+      <ToolCallout variant="tip" icon={ImageIcon} title="Why use this tool?">
+        {platform.educationalContent} This tool ensures your images are perfectly sized to avoid automatic cropping or quality loss.
+      </ToolCallout>
     </div>
   );
 }

--- a/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/LogoGenerator.tsx
+++ b/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/LogoGenerator.tsx
@@ -1,7 +1,14 @@
 "use client";
 
+import { Download, Palette, RefreshCw } from "lucide-react";
 import { useState } from "react";
-import { Palette, Download, AlertCircle, Loader2, RefreshCw } from "lucide-react";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolSelect,
+} from "../../components/tool-ui";
 import type { LogoGeneratorPlatformConfig } from "./logo-generator-platform-configs";
 
 interface LogoGeneratorProps {
@@ -116,164 +123,114 @@ export function LogoGenerator({ platform }: LogoGeneratorProps) {
   };
 
   return (
-    <div className="w-full max-w-4xl mx-auto">
+    <div className="mx-auto w-full max-w-4xl space-y-6">
       {/* Context Guidelines */}
-      <div className="mb-8 p-4 bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 rounded-lg">
-        <div className="flex gap-3">
-          <div className="p-2 bg-emerald-100 dark:bg-emerald-900/30 rounded-lg h-fit">
-            <Palette className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
-          </div>
-          <div>
-            <h3 className="text-sm font-medium text-neutral-900 dark:text-white mb-1">
-              {platform.name} Logo Guidelines
-            </h3>
-            <p className="text-sm text-neutral-600 dark:text-neutral-400">{platform.contextGuidelines}</p>
-          </div>
-        </div>
-      </div>
+      <ToolCallout variant="info" icon={Palette} title={`${platform.name} Logo Guidelines`}>
+        {platform.contextGuidelines}
+      </ToolCallout>
 
       {/* Generator Form */}
-      <div className="space-y-6 mb-8">
-        {/* Brand Name Input */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-200 mb-2">
-            Brand or Company Name *
-          </label>
-          <input
+      <div className="space-y-6">
+        <ToolField label="Brand or Company Name" htmlFor="logo-brand-name" required>
+          <ToolInput
+            id="logo-brand-name"
             type="text"
             value={brandName}
             onChange={e => setBrandName(e.target.value)}
             placeholder="Enter your brand or company name"
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:border-transparent text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500"
           />
-        </div>
+        </ToolField>
 
-        {/* Industry Input */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-200 mb-2">
-            Industry or Niche (Optional)
-          </label>
-          <input
+        <ToolField label="Industry or Niche (Optional)" htmlFor="logo-industry">
+          <ToolInput
+            id="logo-industry"
             type="text"
             value={industry}
             onChange={e => setIndustry(e.target.value)}
             placeholder="e.g., Technology, Food & Beverage, Fashion, Fitness"
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:border-transparent text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500"
           />
-        </div>
+        </ToolField>
 
-        {/* Style Selector */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-200 mb-2">Design Style</label>
-          <select
-            value={style}
-            onChange={e => setStyle(e.target.value)}
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:border-transparent text-neutral-900 dark:text-white"
-          >
+        <ToolField label="Design Style" htmlFor="logo-style">
+          <ToolSelect id="logo-style" value={style} onChange={e => setStyle(e.target.value)}>
             {DESIGN_STYLES.map(s => (
               <option key={s.id} value={s.id}>
                 {s.name} - {s.description}
               </option>
             ))}
-          </select>
-        </div>
+          </ToolSelect>
+        </ToolField>
 
-        {/* Colors Input */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-200 mb-2">
-            Color Preferences (Optional)
-          </label>
-          <input
+        <ToolField label="Color Preferences (Optional)" htmlFor="logo-colors">
+          <ToolInput
+            id="logo-colors"
             type="text"
             value={colors}
             onChange={e => setColors(e.target.value)}
             placeholder="e.g., Blue and white, Earth tones, Vibrant colors"
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:border-transparent text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500"
           />
-        </div>
+        </ToolField>
 
-        {/* Generate Button */}
-        <button
+        <ToolButton
           onClick={handleGenerate}
-          disabled={loading || !brandName.trim()}
-          className="w-full px-6 py-3 bg-emerald-600 hover:bg-emerald-700 disabled:bg-neutral-300 dark:disabled:bg-neutral-700 text-white font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2"
+          loading={loading}
+          disabled={!brandName.trim()}
+          icon={Palette}
+          className="w-full"
         >
-          {loading ? (
-            <>
-              <Loader2 className="w-5 h-5 animate-spin" />
-              Generating Logo...
-            </>
-          ) : (
-            <>
-              <Palette className="w-5 h-5" />
-              Generate Logo
-            </>
-          )}
-        </button>
+          {loading ? "Generating Logo..." : "Generate Logo"}
+        </ToolButton>
       </div>
 
       {/* Rate Limit Info */}
       {rateLimit && (
-        <div className="mb-6 p-4 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-          <p className="text-sm text-neutral-600 dark:text-neutral-400">
-            Rate limit: {rateLimit.remaining} of {rateLimit.limit} requests remaining
-          </p>
-        </div>
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
+          Rate limit: {rateLimit.remaining} of {rateLimit.limit} requests remaining
+        </p>
       )}
 
       {/* Error Message */}
-      {error && (
-        <div className="mb-6 p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 rounded-lg flex items-start gap-3">
-          <AlertCircle className="w-5 h-5 text-red-600 dark:text-red-400 mt-0.5 flex-shrink-0" />
-          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
-        </div>
-      )}
+      {error && <ToolCallout variant="error">{error}</ToolCallout>}
 
       {/* Generated Logo */}
       {imageUrl && (
         <div className="space-y-4">
-          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4">Your Generated Logo</h3>
+          <h3 className="text-base font-semibold text-neutral-900 dark:text-white">Your Generated Logo</h3>
 
-          <div className="p-6 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-lg">
+          <div className="rounded-md border border-neutral-200 bg-neutral-50 p-6 dark:border-neutral-800 dark:bg-neutral-900/50">
             {/* Logo Display */}
-            <div className="flex justify-center mb-6">
-              <div className="relative bg-neutral-100 dark:bg-neutral-800 rounded-lg p-4">
+            <div className="mb-6 flex justify-center">
+              <div className="relative rounded-md bg-neutral-100 p-4 dark:bg-neutral-800">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   src={imageUrl}
                   alt={`Generated logo for ${brandName}`}
-                  className="max-w-full max-h-[400px] object-contain rounded-lg"
+                  className="max-h-[400px] max-w-full rounded-md object-contain"
                 />
               </div>
             </div>
 
             {/* Actions */}
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              <button
-                onClick={handleDownload}
-                className="px-6 py-2.5 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2"
-              >
-                <Download className="w-4 h-4" />
+            <div className="flex flex-col justify-center gap-3 sm:flex-row">
+              <ToolButton onClick={handleDownload} icon={Download}>
                 Download PNG
-              </button>
-              <button
+              </ToolButton>
+              <ToolButton
+                variant="secondary"
                 onClick={handleGenerate}
                 disabled={loading}
-                className="px-6 py-2.5 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2"
+                icon={RefreshCw}
               >
-                <RefreshCw className="w-4 h-4" />
                 Regenerate
-              </button>
+              </ToolButton>
             </div>
           </div>
 
           {/* Tips */}
-          <div className="p-4 bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 rounded-lg">
-            <p className="text-sm text-neutral-600 dark:text-neutral-400">
-              <strong>Tip:</strong> Not quite right? Try adjusting your style or color preferences and regenerate. Each
-              generation creates a unique design.
-            </p>
-          </div>
+          <ToolCallout variant="tip" title="Tip">
+            Not quite right? Try adjusting your style or color preferences and regenerate. Each
+            generation creates a unique design.
+          </ToolCallout>
         </div>
       )}
     </div>

--- a/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/PageNameGenerator.tsx
+++ b/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/PageNameGenerator.tsx
@@ -1,8 +1,17 @@
 "use client";
 
-import { CheckCircle, Copy, Loader2 } from "lucide-react";
 import { useState } from "react";
 import type { PageNamePlatformConfig } from "./page-name-platform-configs";
+import {
+  CopyButton,
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResultDivider,
+  ToolSelect,
+  ToolTextarea,
+} from "../../components/tool-ui";
 
 interface PageNameGeneratorProps {
   platform: PageNamePlatformConfig;
@@ -23,7 +32,6 @@ export default function PageNameGenerator({
   const [names, setNames] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
   const [remainingRequests, setRemainingRequests] = useState<number | null>(
     null
   );
@@ -73,146 +81,83 @@ export default function PageNameGenerator({
     }
   };
 
-  const copyToClipboard = async (text: string, index: number) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopiedIndex(index);
-      setTimeout(() => setCopiedIndex(null), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
-
   return (
     <div className="space-y-6">
-      <div>
-        <label
-          htmlFor="topic"
-          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-        >
-          {platform.pageType} Topic/Purpose
-        </label>
-        <textarea
-          id="topic"
+      <ToolField
+        label={`${platform.pageType} Topic/Purpose`}
+        htmlFor="pagename-topic"
+        hint={`${topic.length} / 500 characters`}
+      >
+        <ToolTextarea
+          id="pagename-topic"
           rows={3}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 resize-y"
+          className="resize-y"
           placeholder={`Describe what your ${platform.pageType.toLowerCase()} is about (e.g., "A gaming community for strategy game players" or "Tech startup focused on AI tools")`}
           value={topic}
-          onChange={(e) => setTopic(e.target.value)}
+          onChange={e => setTopic(e.target.value)}
           maxLength={500}
         />
-        <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-          {topic.length} / 500 characters
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label
-          htmlFor="keywords"
-          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-        >
-          Keywords (Optional)
-        </label>
-        <input
-          id="keywords"
+      <ToolField label="Keywords (Optional)" htmlFor="pagename-keywords">
+        <ToolInput
+          id="pagename-keywords"
           type="text"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
           placeholder="Keywords to include (e.g., gaming, tech, creative)"
           value={keywords}
-          onChange={(e) => setKeywords(e.target.value)}
+          onChange={e => setKeywords(e.target.value)}
           maxLength={100}
         />
-      </div>
+      </ToolField>
 
-      <div>
-        <label
-          htmlFor="length"
-          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-        >
-          Name Length
-        </label>
-        <select
-          id="length"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
-          value={length}
-          onChange={(e) => setLength(e.target.value)}
-        >
-          {lengthOptions.map((option) => (
+      <ToolField label="Name Length" htmlFor="pagename-length">
+        <ToolSelect id="pagename-length" value={length} onChange={e => setLength(e.target.value)}>
+          {lengthOptions.map(option => (
             <option key={option.value} value={option.value}>
               {option.label} - {option.description}
             </option>
           ))}
-        </select>
-      </div>
+        </ToolSelect>
+      </ToolField>
 
-      <button
-        onClick={generateNames}
-        disabled={isLoading || !topic.trim()}
-        className="w-full px-6 py-3 bg-emerald-600 hover:bg-emerald-500 disabled:bg-neutral-400 dark:disabled:bg-neutral-700 text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
-      >
-        {isLoading ? (
-          <>
-            <Loader2 className="w-5 h-5 animate-spin" />
-            Generating Names...
-          </>
-        ) : (
-          "Generate Names"
-        )}
-      </button>
+      <ToolButton onClick={generateNames} loading={isLoading} disabled={!topic.trim()} className="w-full">
+        {isLoading ? "Generating Names..." : "Generate Names"}
+      </ToolButton>
 
       {remainingRequests !== null && (
-        <p className="text-sm text-center text-neutral-600 dark:text-neutral-400">
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
           {remainingRequests} requests remaining this minute
         </p>
       )}
 
-      {error && (
-        <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-          <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
-        </div>
-      )}
+      {error && <ToolCallout variant="error">{error}</ToolCallout>}
 
       {names.length > 0 && (
-        <div className="space-y-4">
-          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">
+        <ToolResultDivider>
+          <h3 className="text-base font-semibold text-neutral-900 dark:text-white">
             Generated {platform.pageType} Names
           </h3>
           {names.map((name, index) => (
             <div
               key={index}
-              className="p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-lg"
+              className="rounded-md border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900/50"
             >
               <div className="flex items-center justify-between gap-3">
-                <p className="flex-1 text-lg font-medium text-neutral-900 dark:text-white">
-                  {name}
-                </p>
-                <button
-                  onClick={() => copyToClipboard(name, index)}
-                  className="flex-shrink-0 p-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
-                  title="Copy to clipboard"
-                >
-                  {copiedIndex === index ? (
-                    <CheckCircle className="w-5 h-5 text-emerald-600" />
-                  ) : (
-                    <Copy className="w-5 h-5 text-neutral-600 dark:text-neutral-400" />
-                  )}
-                </button>
+                <p className="flex-1 text-lg font-medium text-neutral-900 dark:text-white">{name}</p>
+                <CopyButton value={name} className="shrink-0" />
               </div>
-              <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
+              <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
                 {name.length} characters
-                {platform.characterLimit &&
-                  ` / ${platform.characterLimit} limit`}
+                {platform.characterLimit && ` / ${platform.characterLimit} limit`}
               </p>
             </div>
           ))}
-        </div>
+        </ToolResultDivider>
       )}
 
-      <div className="p-4 bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 rounded-lg">
-        <p className="text-sm text-neutral-700 dark:text-neutral-300">
-          <strong>Platform Guidelines:</strong> {platform.contextGuidelines}
-        </p>
-      </div>
+      <ToolCallout variant="info" title="Platform Guidelines">
+        {platform.contextGuidelines}
+      </ToolCallout>
     </div>
   );
 }

--- a/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/PostGenerator.tsx
+++ b/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/PostGenerator.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { CheckCircle, Copy, Loader2 } from "lucide-react";
 import { useState } from "react";
+import {
+  CopyButton,
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolSelect,
+  ToolTextarea,
+} from "../../components/tool-ui";
 import type { PostGeneratorPlatformConfig } from "./post-generator-platform-configs";
 
 interface PostGeneratorProps {
@@ -15,7 +22,6 @@ export default function PostGenerator({ platform }: PostGeneratorProps) {
   const [posts, setPosts] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
   const [remainingRequests, setRemainingRequests] = useState<number | null>(
     null
   );
@@ -64,49 +70,31 @@ export default function PostGenerator({ platform }: PostGeneratorProps) {
     }
   };
 
-  const copyToClipboard = async (text: string, index: number) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopiedIndex(index);
-      setTimeout(() => setCopiedIndex(null), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
-
   return (
     <div className="space-y-6">
-      <div>
-        <label
-          htmlFor="topic"
-          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-        >
-          What do you want to post about?
-        </label>
-        <textarea
-          id="topic"
+      <ToolField
+        label="What do you want to post about?"
+        htmlFor="post-topic"
+        hint={`${topic.length} / 1000 characters`}
+      >
+        <ToolTextarea
+          id="post-topic"
           rows={4}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 resize-y"
+          className="resize-y"
           placeholder={`Describe your post topic or key message (e.g., "Sharing lessons learned from building a startup" or "Tips for productivity")`}
           value={topic}
           onChange={(e) => setTopic(e.target.value)}
           maxLength={1000}
         />
-        <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-          {topic.length} / 1000 characters
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label
-          htmlFor="style"
-          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-        >
-          Post Style
-        </label>
-        <select
-          id="style"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+      <ToolField
+        label="Post Style"
+        htmlFor="post-style"
+        hint="Choose a style that fits your content and audience"
+      >
+        <ToolSelect
+          id="post-style"
           value={style}
           onChange={(e) => setStyle(e.target.value)}
         >
@@ -115,84 +103,58 @@ export default function PostGenerator({ platform }: PostGeneratorProps) {
               {styleOption}
             </option>
           ))}
-        </select>
-        <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-          Choose a style that fits your content and audience
-        </p>
-      </div>
+        </ToolSelect>
+      </ToolField>
 
-      <div>
-        <label
-          htmlFor="additionalContext"
-          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-        >
-          Additional Context (Optional)
-        </label>
-        <textarea
-          id="additionalContext"
+      <ToolField
+        label="Additional Context (Optional)"
+        htmlFor="post-additional-context"
+      >
+        <ToolTextarea
+          id="post-additional-context"
           rows={2}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 resize-y"
+          className="resize-y"
           placeholder="Any specific details, CTAs, or hashtags you want to include"
           value={additionalContext}
           onChange={(e) => setAdditionalContext(e.target.value)}
           maxLength={500}
         />
-      </div>
+      </ToolField>
 
-      <button
+      <ToolButton
         onClick={generatePosts}
-        disabled={isLoading || !topic.trim()}
-        className="w-full px-6 py-3 bg-emerald-600 hover:bg-emerald-500 disabled:bg-neutral-400 dark:disabled:bg-neutral-700 text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
+        loading={isLoading}
+        disabled={!topic.trim()}
+        className="w-full"
       >
-        {isLoading ? (
-          <>
-            <Loader2 className="w-5 h-5 animate-spin" />
-            Generating Posts...
-          </>
-        ) : (
-          "Generate Posts"
-        )}
-      </button>
+        {isLoading ? "Generating Posts..." : "Generate Posts"}
+      </ToolButton>
 
       {remainingRequests !== null && (
-        <p className="text-sm text-center text-neutral-600 dark:text-neutral-400">
+        <p className="text-center text-sm text-neutral-500 dark:text-neutral-400">
           {remainingRequests} requests remaining this minute
         </p>
       )}
 
-      {error && (
-        <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-          <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
-        </div>
-      )}
+      {error && <ToolCallout variant="error">{error}</ToolCallout>}
 
       {posts.length > 0 && (
-        <div className="space-y-4">
-          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">
+        <div className="space-y-3 border-t border-neutral-200 pt-6 dark:border-neutral-800">
+          <h3 className="text-base font-semibold text-neutral-900 dark:text-white">
             Generated Posts
           </h3>
           {posts.map((post, index) => (
             <div
               key={index}
-              className="p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-lg"
+              className="rounded-md border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900/50"
             >
-              <div className="flex items-start justify-between gap-3 mb-3">
-                <p className="flex-1 text-neutral-900 dark:text-white whitespace-pre-wrap leading-relaxed">
+              <div className="flex items-start justify-between gap-4">
+                <p className="flex-1 whitespace-pre-wrap leading-relaxed text-neutral-900 dark:text-white">
                   {post}
                 </p>
-                <button
-                  onClick={() => copyToClipboard(post, index)}
-                  className="flex-shrink-0 p-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
-                  title="Copy to clipboard"
-                >
-                  {copiedIndex === index ? (
-                    <CheckCircle className="w-5 h-5 text-emerald-600" />
-                  ) : (
-                    <Copy className="w-5 h-5 text-neutral-600 dark:text-neutral-400" />
-                  )}
-                </button>
+                <CopyButton value={post} className="shrink-0" />
               </div>
-              <p className="text-xs text-neutral-500 dark:text-neutral-400">
+              <p className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
                 {post.length} characters
                 {platform.characterLimit &&
                   ` / ${platform.characterLimit} limit`}
@@ -202,11 +164,9 @@ export default function PostGenerator({ platform }: PostGeneratorProps) {
         </div>
       )}
 
-      <div className="p-4 bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 rounded-lg">
-        <p className="text-sm text-neutral-700 dark:text-neutral-300">
-          <strong>Platform Guidelines:</strong> {platform.contextGuidelines}
-        </p>
-      </div>
+      <ToolCallout variant="info" title="Platform Guidelines">
+        {platform.contextGuidelines}
+      </ToolCallout>
     </div>
   );
 }

--- a/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/UsernameGenerator.tsx
+++ b/docs/src/app/[locale]/(home)/tools/(social-media-tools)/components/UsernameGenerator.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { CheckCircle, Copy, Loader2 } from "lucide-react";
 import { useState } from "react";
 import type { UsernameGeneratorPlatformConfig } from "./username-generator-platform-configs";
+import {
+  CopyButton,
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResultDivider,
+} from "../../components/tool-ui";
 
 interface UsernameGeneratorProps {
   platform: UsernameGeneratorPlatformConfig;
@@ -17,7 +24,6 @@ export default function UsernameGenerator({
   const [usernames, setUsernames] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
   const [remainingRequests, setRemainingRequests] = useState<number | null>(
     null
   );
@@ -67,148 +73,100 @@ export default function UsernameGenerator({
     }
   };
 
-  const copyToClipboard = async (text: string, index: number) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopiedIndex(index);
-      setTimeout(() => setCopiedIndex(null), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
-
   return (
     <div className="space-y-6">
-      <div>
-        <label
-          htmlFor="name"
-          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-        >
-          Your Name or Brand
-        </label>
-        <input
-          id="name"
+      <ToolField label="Your Name or Brand" htmlFor="username-name">
+        <ToolInput
+          id="username-name"
           type="text"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
           placeholder="Enter your name, brand, or nickname"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={e => setName(e.target.value)}
           maxLength={100}
         />
-      </div>
+      </ToolField>
 
-      <div>
-        <label
-          htmlFor="interests"
-          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-        >
-          Interests or Keywords (Optional)
-        </label>
-        <input
-          id="interests"
+      <ToolField label="Interests or Keywords (Optional)" htmlFor="username-interests">
+        <ToolInput
+          id="username-interests"
           type="text"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
           placeholder="e.g., gaming, tech, art, music"
           value={interests}
-          onChange={(e) => setInterests(e.target.value)}
+          onChange={e => setInterests(e.target.value)}
           maxLength={100}
         />
-      </div>
+      </ToolField>
 
       <div className="flex items-center gap-3">
         <input
-          id="includeNumbers"
+          id="username-include-numbers"
           type="checkbox"
-          className="w-4 h-4 text-emerald-600 bg-white dark:bg-neutral-800 border-neutral-300 dark:border-neutral-700 rounded focus:ring-2 focus:ring-emerald-500"
+          className="size-4 rounded border-neutral-300 text-emerald-600 focus-visible:ring-2 focus-visible:ring-emerald-500 dark:border-neutral-700 dark:bg-neutral-900"
           checked={includeNumbers}
-          onChange={(e) => setIncludeNumbers(e.target.checked)}
+          onChange={e => setIncludeNumbers(e.target.checked)}
         />
         <label
-          htmlFor="includeNumbers"
+          htmlFor="username-include-numbers"
           className="text-sm font-medium text-neutral-700 dark:text-neutral-300"
         >
           Include numbers in usernames
         </label>
       </div>
 
-      <button
+      <ToolButton
         onClick={generateUsernames}
-        disabled={isLoading || (!name.trim() && !interests.trim())}
-        className="w-full px-6 py-3 bg-emerald-600 hover:bg-emerald-500 disabled:bg-neutral-400 dark:disabled:bg-neutral-700 text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
+        loading={isLoading}
+        disabled={!name.trim() && !interests.trim()}
+        className="w-full"
       >
-        {isLoading ? (
-          <>
-            <Loader2 className="w-5 h-5 animate-spin" />
-            Generating Usernames...
-          </>
-        ) : (
-          "Generate Usernames"
-        )}
-      </button>
+        {isLoading ? "Generating Usernames..." : "Generate Usernames"}
+      </ToolButton>
 
       {remainingRequests !== null && (
-        <p className="text-sm text-center text-neutral-600 dark:text-neutral-400">
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
           {remainingRequests} requests remaining this minute
         </p>
       )}
 
-      {error && (
-        <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
-          <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
-        </div>
-      )}
+      {error && <ToolCallout variant="error">{error}</ToolCallout>}
 
       {usernames.length > 0 && (
-        <div className="space-y-4">
-          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">
-            Generated Usernames
-          </h3>
+        <ToolResultDivider>
+          <h3 className="text-base font-semibold text-neutral-900 dark:text-white">Generated Usernames</h3>
           {usernames.map((username, index) => (
             <div
               key={index}
-              className="p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-lg"
+              className="rounded-md border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900/50"
             >
               <div className="flex items-center justify-between gap-3">
-                <p className="flex-1 text-lg font-medium text-neutral-900 dark:text-white font-mono">
+                <p className="flex-1 font-mono text-lg font-medium text-neutral-900 dark:text-white">
                   {platform.usernamePrefix}
                   {username}
                 </p>
-                <button
-                  onClick={() => copyToClipboard(username, index)}
-                  className="flex-shrink-0 p-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
-                  title="Copy to clipboard"
-                >
-                  {copiedIndex === index ? (
-                    <CheckCircle className="w-5 h-5 text-emerald-600" />
-                  ) : (
-                    <Copy className="w-5 h-5 text-neutral-600 dark:text-neutral-400" />
-                  )}
-                </button>
+                <CopyButton value={username} className="shrink-0" />
               </div>
-              <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
+              <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
                 {username.length} characters
-                {platform.characterLimit &&
-                  ` / ${platform.characterLimit} limit`}
+                {platform.characterLimit && ` / ${platform.characterLimit} limit`}
               </p>
             </div>
           ))}
-        </div>
+        </ToolResultDivider>
       )}
 
-      <div className="p-4 bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 rounded-lg space-y-2">
-        <p className="text-sm text-neutral-700 dark:text-neutral-300">
-          <strong>Platform Guidelines:</strong> {platform.contextGuidelines}
-        </p>
-        <p className="text-xs text-neutral-600 dark:text-neutral-400">
-          <strong>Allowed characters:</strong> {platform.allowedCharacters}
-        </p>
-        {platform.characterLimit && (
-          <p className="text-xs text-neutral-600 dark:text-neutral-400">
-            <strong>Character limit:</strong> {platform.characterLimit}{" "}
-            characters
+      <ToolCallout variant="info" title="Platform Guidelines">
+        <div className="space-y-2">
+          <p>{platform.contextGuidelines}</p>
+          <p className="text-xs">
+            <strong className="font-semibold">Allowed characters:</strong> {platform.allowedCharacters}
           </p>
-        )}
-      </div>
+          {platform.characterLimit && (
+            <p className="text-xs">
+              <strong className="font-semibold">Character limit:</strong> {platform.characterLimit} characters
+            </p>
+          )}
+        </div>
+      </ToolCallout>
     </div>
   );
 }

--- a/docs/src/app/[locale]/(home)/tools/CLAUDE.md
+++ b/docs/src/app/[locale]/(home)/tools/CLAUDE.md
@@ -29,14 +29,32 @@ All tools use `ToolPageLayout` with 6 sections: Header, Tool, Educational Conten
 - `ctaButtonText`: Default `"Start tracking for free"`
 - `structuredData`: JSON-LD object
 
-## Styling
+## Styling — use the shared primitives
 
-- Primary: `bg-emerald-600 hover:bg-emerald-500`
-- Success: `bg-emerald-50 dark:bg-emerald-900/20 border-emerald-200 dark:border-emerald-800`
-- Error: `bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800`
-- Backgrounds: `bg-white dark:bg-neutral-900`
-- Borders: `border-neutral-200 dark:border-neutral-800`
-- Text: `text-neutral-900 dark:text-white` (headings), `text-neutral-700 dark:text-neutral-300` (body)
+**Build the interactive tool out of the primitives in `components/tool-ui.tsx`.** They encode
+Rybbit's "instrument panel" vocabulary (tight `rounded-md` geometry, hairline borders, flat
+surfaces, `font-semibold`/`font-medium` weights, a single emerald accent) so every tool matches
+the rest of the app. Do NOT hand-roll `rounded-lg` inputs, `bg-emerald-600` buttons, `font-bold`
+headings, or tinted `bg-blue-50`/`bg-orange-50` boxes — that is the exact divergence these
+primitives replace.
+
+Import from `../components/tool-ui` (calculators/AI/utility tools) or `../../components/tool-ui`
+(social-media tools under `(social-media-tools)/components/`):
+
+- `ToolField({ label, htmlFor, required, hint })` — wraps a control with its label + hint.
+- `ToolInput` / `ToolTextarea` / `ToolSelect` — styled form controls (`h-10`, `rounded-md`).
+- `ToolButton({ variant: "primary" | "secondary" | "ghost", loading, icon })` — actions.
+- `CopyButton({ value })` — self-contained copy-to-clipboard (don't re-implement copied state).
+- `ToolResult({ label, value })` — the one headline metric a tool outputs.
+- `ToolStat({ label, value })` — compact secondary stat, for a grid under the result.
+- `ToolCallout({ variant: "info" | "tip" | "success" | "warning" | "error", title })` — notes/tips.
+- `ToolResultDivider` — opens the results region below the inputs.
+
+Reference implementations: `conversion-rate-calculator/ConversionRateForm.tsx` (calculator),
+`seo-title-generator/SEOTitleForm.tsx` (AI generator), `utm-builder/UTMBuilderForm.tsx` (copy result).
+
+**Do NOT add an FAQ or CTA inside the form** — `ToolPageLayout` already renders both (the FAQ from
+the `faqs` prop and a `ToolCTA` at the bottom). Embedding them duplicates the sections on the page.
 
 ## CRITICAL Rules
 
@@ -49,18 +67,22 @@ All tools use `ToolPageLayout` with 6 sections: Header, Tool, Educational Conten
 ## Common Patterns
 
 ```tsx
-// Loading
+import { ToolButton, ToolCallout, ToolField, ToolInput, CopyButton } from "../components/tool-ui";
+
+// Field + input
+<ToolField label="Total Visitors" htmlFor="tv" required hint="Sessions in the period">
+  <ToolInput id="tv" type="number" value={visitors} onChange={e => setVisitors(e.target.value)} />
+</ToolField>
+
+// Loading action
 const [isLoading, setIsLoading] = useState(false);
-<button disabled={isLoading}>{isLoading ? "Processing..." : "Calculate"}</button>;
+<ToolButton onClick={run} loading={isLoading}>{isLoading ? "Generating…" : "Generate"}</ToolButton>;
 
-// Error
-const [error, setError] = useState<string | null>(null);
-{
-  error && <div className="p-4 bg-red-50...">{error}</div>;
-}
+// Error / tip
+{error && <ToolCallout variant="error">{error}</ToolCallout>}
 
-// Copy
-await navigator.clipboard.writeText(result);
+// Copy (no local state needed)
+<CopyButton value={result} />
 ```
 
 ## API Routes (if needed)

--- a/docs/src/app/[locale]/(home)/tools/analytics-detector/AnalyticsDetectorForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/analytics-detector/AnalyticsDetectorForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { AlertCircle, Loader2, Shield } from "lucide-react";
+import { Shield } from "lucide-react";
 import { useState } from "react";
+import { ToolButton, ToolCallout, ToolField, ToolInput } from "../components/tool-ui";
 
 interface Platform {
   name: string;
@@ -62,7 +63,7 @@ export function AnalyticsDetectorForm() {
       case "low":
         return "text-emerald-600 dark:text-emerald-400";
       case "medium":
-        return "text-orange-600 dark:text-orange-400";
+        return "text-amber-600 dark:text-amber-500";
       case "high":
         return "text-red-600 dark:text-red-400";
       default:
@@ -72,110 +73,68 @@ export function AnalyticsDetectorForm() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Website URL <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField label="Website URL" htmlFor="detector-url" required hint="Enter the full URL including https://">
+        <ToolInput
+          id="detector-url"
           type="url"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
           placeholder="https://example.com"
           disabled={isLoading}
           onKeyDown={(e) => e.key === "Enter" && detectAnalytics()}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Enter the full URL including https://
-        </p>
-      </div>
+      </ToolField>
 
-      {error && (
-        <div className="p-4 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded-lg flex items-start gap-2">
-          <AlertCircle className="w-5 h-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
-          <p className="text-sm text-red-900 dark:text-red-200">{error}</p>
-        </div>
-      )}
+      {error && <ToolCallout variant="error">{error}</ToolCallout>}
 
-      <button
-        onClick={detectAnalytics}
-        disabled={isLoading}
-        className="w-full px-6 py-3 bg-emerald-600 hover:bg-emerald-500 disabled:bg-neutral-400 dark:disabled:bg-neutral-700 text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
-      >
-        {isLoading ? (
-          <>
-            <Loader2 className="w-5 h-5 animate-spin" />
-            Analyzing Website...
-          </>
-        ) : (
-          "Detect Analytics"
-        )}
-      </button>
+      <ToolButton onClick={detectAnalytics} loading={isLoading} className="w-full">
+        {isLoading ? "Analyzing Website..." : "Detect Analytics"}
+      </ToolButton>
 
       {result && (
-        <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-6">
+        <div className="space-y-6 border-t border-neutral-200 pt-6 dark:border-neutral-800">
           {/* Summary */}
-          <div className="p-6 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded-lg">
-            <div className="flex items-start gap-3 mb-3">
-              <Shield className="w-5 h-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
-              <div className="flex-1">
-                <h3 className="font-semibold text-blue-900 dark:text-blue-200 mb-1">
-                  Privacy Score
-                </h3>
-                <p className={`text-2xl font-bold ${getPrivacyScoreColor(result.privacyScore)}`}>
-                  {result.privacyScore}
-                </p>
-              </div>
-            </div>
-            <p className="text-sm text-blue-900 dark:text-blue-200">{result.summary}</p>
-          </div>
+          <ToolCallout variant="info" icon={Shield} title="Privacy Score">
+            <p className={`text-2xl font-semibold ${getPrivacyScoreColor(result.privacyScore)}`}>{result.privacyScore}</p>
+            <p className="mt-2">{result.summary}</p>
+          </ToolCallout>
 
           {/* Detected Platforms */}
           {result.platforms.length > 0 ? (
             <div>
-              <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-4">
+              <h3 className="mb-4 text-base font-semibold text-neutral-900 dark:text-white">
                 Detected Platforms ({result.platforms.length})
               </h3>
               <div className="space-y-3">
                 {result.platforms.map((platform, index) => (
                   <div
                     key={index}
-                    className="p-4 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg"
+                    className="rounded-md border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900/50"
                   >
-                    <div className="flex items-start justify-between mb-2">
-                      <h4 className="font-semibold text-neutral-900 dark:text-white">
-                        {platform.name}
-                      </h4>
-                      <span className="px-2 py-1 text-xs font-medium bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-full">
+                    <div className="mb-2 flex items-start justify-between gap-4">
+                      <h4 className="font-semibold text-neutral-900 dark:text-white">{platform.name}</h4>
+                      <span className="rounded-full bg-neutral-100 px-2 py-1 text-xs font-medium text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300">
                         {platform.category}
                       </span>
                     </div>
-                    <p className="text-sm text-neutral-600 dark:text-neutral-300 mb-2">
-                      {platform.privacy}
-                    </p>
+                    <p className="mb-2 text-sm text-neutral-600 dark:text-neutral-300">{platform.privacy}</p>
                     {platform.identifier && (
-                      <p className="text-xs text-neutral-500 dark:text-neutral-400 font-mono">
-                        ID: {platform.identifier}
-                      </p>
+                      <p className="font-mono text-xs text-neutral-500 dark:text-neutral-400">ID: {platform.identifier}</p>
                     )}
                   </div>
                 ))}
               </div>
             </div>
           ) : (
-            <div className="p-6 text-center bg-neutral-100 dark:bg-neutral-800 rounded-lg">
-              <p className="text-neutral-600 dark:text-neutral-400">
-                No analytics platforms detected on this website.
-              </p>
+            <div className="rounded-md border border-neutral-200 bg-neutral-50 p-6 text-center dark:border-neutral-800 dark:bg-neutral-900/50">
+              <p className="text-neutral-600 dark:text-neutral-400">No analytics platforms detected on this website.</p>
             </div>
           )}
         </div>
       )}
 
       {remainingRequests !== null && (
-        <p className="text-sm text-neutral-500 dark:text-neutral-400">
-          {remainingRequests} requests remaining this minute
-        </p>
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">{remainingRequests} requests remaining this minute</p>
       )}
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/bounce-rate-calculator/BounceRateForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/bounce-rate-calculator/BounceRateForm.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import Link from "next/link";
 import { useState } from "react";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResult,
+  ToolResultDivider,
+  ToolSelect,
+  ToolStat,
+} from "../components/tool-ui";
 
 const industryBenchmarks: Record<string, { low: number; average: number; high: number }> = {
   "E-commerce": { low: 20, average: 45, high: 70 },
@@ -30,10 +38,10 @@ export function BounceRateForm() {
   const benchmark = industryBenchmarks[industry];
 
   const getPerformanceLevel = (rate: number) => {
-    if (rate <= benchmark.low) return { label: "Excellent", color: "emerald" };
-    if (rate <= benchmark.average) return { label: "Good", color: "blue" };
-    if (rate <= benchmark.high) return { label: "Needs Improvement", color: "orange" };
-    return { label: "Poor", color: "red" };
+    if (rate <= benchmark.low) return { label: "Excellent", variant: "success" as const };
+    if (rate <= benchmark.average) return { label: "Good", variant: "info" as const };
+    if (rate <= benchmark.high) return { label: "Needs Improvement", variant: "warning" as const };
+    return { label: "Poor", variant: "error" as const };
   };
 
   const clearForm = () => {
@@ -43,181 +51,79 @@ export function BounceRateForm() {
   };
 
   return (
-    <>
-      {/* Tool Section */}
-      <div className="mb-16">
-        <div className="space-y-6">
-          {/* Total Sessions */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Total Sessions <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="number"
-              value={totalSessions}
-              onChange={e => setTotalSessions(e.target.value)}
-              placeholder="10000"
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Total number of sessions in the time period</p>
+    <div className="space-y-6">
+      <ToolField
+        label="Total Sessions"
+        htmlFor="brc-total-sessions"
+        required
+        hint="Total number of sessions in the time period"
+      >
+        <ToolInput
+          id="brc-total-sessions"
+          type="number"
+          value={totalSessions}
+          onChange={e => setTotalSessions(e.target.value)}
+          placeholder="10000"
+        />
+      </ToolField>
+
+      <ToolField
+        label="Bounced Sessions"
+        htmlFor="brc-bounced-sessions"
+        required
+        hint="Sessions with only one pageview (single-page visits)"
+      >
+        <ToolInput
+          id="brc-bounced-sessions"
+          type="number"
+          value={bouncedSessions}
+          onChange={e => setBouncedSessions(e.target.value)}
+          placeholder="4500"
+        />
+      </ToolField>
+
+      <ToolField label="Industry Type" htmlFor="brc-industry" hint="Select your industry to compare with benchmarks">
+        <ToolSelect id="brc-industry" value={industry} onChange={e => setIndustry(e.target.value)}>
+          {Object.keys(industryBenchmarks).map(ind => (
+            <option key={ind} value={ind}>
+              {ind}
+            </option>
+          ))}
+        </ToolSelect>
+      </ToolField>
+
+      {bounceRate !== null && (
+        <ToolResultDivider>
+          <ToolResult label="Your Bounce Rate" value={`${bounceRate.toFixed(2)}%`} />
+
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <ToolStat label="Excellent" value={`≤${benchmark.low}%`} />
+            <ToolStat label="Average" value={`~${benchmark.average}%`} />
+            <ToolStat label="Needs Work" value={`≥${benchmark.high}%`} />
           </div>
 
-          {/* Bounced Sessions */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Bounced Sessions <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="number"
-              value={bouncedSessions}
-              onChange={e => setBouncedSessions(e.target.value)}
-              placeholder="4500"
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Sessions with only one pageview (single-page visits)</p>
-          </div>
+          {(() => {
+            const perf = getPerformanceLevel(bounceRate);
+            return (
+              <ToolCallout variant={perf.variant} title={`${perf.label}!`}>
+                {perf.label === "Excellent"
+                  ? `Your bounce rate is well below the ${industry.toLowerCase()} average of ${benchmark.average}%. You're doing great at keeping visitors engaged!`
+                  : perf.label === "Good"
+                    ? `Your bounce rate is close to the ${industry.toLowerCase()} average of ${benchmark.average}%. There's room for improvement.`
+                    : perf.label === "Needs Improvement"
+                      ? `Your bounce rate is above the ${industry.toLowerCase()} average of ${benchmark.average}%. Consider improving page load speed, content quality, or user experience.`
+                      : `Your bounce rate is significantly higher than the ${industry.toLowerCase()} average of ${benchmark.average}%. Focus on improving content relevance, page speed, and user experience.`}
+              </ToolCallout>
+            );
+          })()}
+        </ToolResultDivider>
+      )}
 
-          {/* Industry */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">Industry Type</label>
-            <select
-              value={industry}
-              onChange={e => setIndustry(e.target.value)}
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            >
-              {Object.keys(industryBenchmarks).map(ind => (
-                <option key={ind} value={ind}>
-                  {ind}
-                </option>
-              ))}
-            </select>
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-              Select your industry to compare with benchmarks
-            </p>
-          </div>
-
-          {/* Results */}
-          {bounceRate !== null && (
-            <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">Your Bounce Rate</label>
-                <div className="px-4 py-6 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-center">
-                  <div className="text-4xl font-bold text-emerald-600 dark:text-emerald-400">{bounceRate.toFixed(2)}%</div>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-3 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    Excellent
-                  </label>
-                  <div className="px-4 py-4 bg-neutral-100 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-center">
-                    <div className="text-xl font-bold text-neutral-900 dark:text-white">≤{benchmark.low}%</div>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    Average
-                  </label>
-                  <div className="px-4 py-4 bg-neutral-100 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-center">
-                    <div className="text-xl font-bold text-neutral-900 dark:text-white">~{benchmark.average}%</div>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    Needs Work
-                  </label>
-                  <div className="px-4 py-4 bg-neutral-100 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-center">
-                    <div className="text-xl font-bold text-neutral-900 dark:text-white">≥{benchmark.high}%</div>
-                  </div>
-                </div>
-              </div>
-
-              {(() => {
-                const perf = getPerformanceLevel(bounceRate);
-                const colorClasses = {
-                  emerald: "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-900 text-emerald-900 dark:text-emerald-200",
-                  blue: "bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-900 text-blue-900 dark:text-blue-200",
-                  orange: "bg-orange-50 dark:bg-orange-950/30 border-orange-200 dark:border-orange-900 text-orange-900 dark:text-orange-200",
-                  red: "bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-900 text-red-900 dark:text-red-200"
-                };
-
-                return (
-                  <div className={`p-4 rounded-lg border ${colorClasses[perf.color as keyof typeof colorClasses]}`}>
-                    <p className="text-sm">
-                      <strong>{perf.label}!</strong> {
-                        perf.label === "Excellent" ? `Your bounce rate is well below the ${industry.toLowerCase()} average of ${benchmark.average}%. You're doing great at keeping visitors engaged!` :
-                        perf.label === "Good" ? `Your bounce rate is close to the ${industry.toLowerCase()} average of ${benchmark.average}%. There's room for improvement.` :
-                        perf.label === "Needs Improvement" ? `Your bounce rate is above the ${industry.toLowerCase()} average of ${benchmark.average}%. Consider improving page load speed, content quality, or user experience.` :
-                        `Your bounce rate is significantly higher than the ${industry.toLowerCase()} average of ${benchmark.average}%. Focus on improving content relevance, page speed, and user experience.`
-                      }
-                    </p>
-                  </div>
-                );
-              })()}
-            </div>
-          )}
-
-          {/* Buttons */}
-          <div className="flex gap-4 pt-4">
-            <button
-              onClick={clearForm}
-              className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-            >
-              Clear
-            </button>
-          </div>
-        </div>
+      <div className="flex gap-3 pt-2">
+        <ToolButton variant="secondary" onClick={clearForm}>
+          Clear
+        </ToolButton>
       </div>
-
-      {/* FAQ Section */}
-      <div className="mb-12">
-        <h2 className="text-2xl font-bold text-neutral-900 dark:text-white mb-6">Frequently Asked Questions</h2>
-        <div className="bg-neutral-100/50 dark:bg-neutral-800/20 backdrop-blur-sm border border-neutral-300/50 dark:border-neutral-800/50 rounded-xl overflow-hidden">
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="item-1">
-              <AccordionTrigger>What is bounce rate?</AccordionTrigger>
-              <AccordionContent>
-                Bounce rate is the percentage of visitors who leave your website after viewing only one page without any interaction. A high bounce rate might indicate that your landing pages aren't relevant to visitors or your site has usability issues.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-2">
-              <AccordionTrigger>What's a good bounce rate?</AccordionTrigger>
-              <AccordionContent>
-                A "good" bounce rate varies by industry and page type. E-commerce sites typically aim for 20-45%, while blogs may see 65-90% and still be healthy. Landing pages naturally have higher bounce rates (60-90%) since they're designed for a single action.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-3">
-              <AccordionTrigger>How can I reduce my bounce rate?</AccordionTrigger>
-              <AccordionContent>
-                To reduce bounce rate: improve page load speed, ensure mobile responsiveness, create compelling content, add clear calls-to-action, use internal linking, improve content readability, and ensure your pages match visitor intent. Track your improvements with{" "}
-                <Link href="https://app.rybbit.io" className="text-emerald-600 dark:text-emerald-400 hover:underline">
-                  Rybbit Analytics
-                </Link>{" "}
-                to see what works.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-4">
-              <AccordionTrigger>Does bounce rate affect SEO?</AccordionTrigger>
-              <AccordionContent>
-                While bounce rate isn't a direct Google ranking factor, it can indirectly impact SEO. A high bounce rate suggests poor user experience or irrelevant content, which can lead to lower engagement signals. Google may interpret this as lower quality, potentially affecting your rankings over time.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-5" className="border-b-0">
-              <AccordionTrigger>Why is bounce rate different in different tools?</AccordionTrigger>
-              <AccordionContent>
-                Different analytics tools may calculate bounce rate differently based on how they track sessions, handle direct traffic, and count interactions. Some tools exclude certain traffic sources or implement different session timeouts. Always use the same tool consistently for accurate comparisons.
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </div>
-      </div>
-    </>
+    </div>
   );
 }

--- a/docs/src/app/[locale]/(home)/tools/components/index.ts
+++ b/docs/src/app/[locale]/(home)/tools/components/index.ts
@@ -1,3 +1,15 @@
 export { ToolCTA } from "./ToolCTA";
 export { ToolPageLayout } from "./ToolPageLayout";
 export type { ToolPageLayoutProps, FAQItem } from "./ToolPageLayout";
+export {
+  ToolField,
+  ToolInput,
+  ToolTextarea,
+  ToolSelect,
+  ToolButton,
+  CopyButton,
+  ToolResult,
+  ToolStat,
+  ToolCallout,
+  ToolResultDivider,
+} from "./tool-ui";

--- a/docs/src/app/[locale]/(home)/tools/components/tool-ui.tsx
+++ b/docs/src/app/[locale]/(home)/tools/components/tool-ui.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import {
+  AlertTriangle,
+  Check,
+  ChevronDown,
+  Copy,
+  Info,
+  Lightbulb,
+  Loader2,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  forwardRef,
+  useState,
+  type ButtonHTMLAttributes,
+  type InputHTMLAttributes,
+  type ReactNode,
+  type SelectHTMLAttributes,
+  type TextareaHTMLAttributes,
+} from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared UI primitives for the free tools.
+ *
+ * These encode Rybbit's "instrument panel" vocabulary once — tight `rounded-md`
+ * geometry, hairline neutral borders, flat surfaces (depth via borders, not
+ * shadows), `font-medium`/`font-semibold` weights, and a single emerald accent —
+ * so every calculator and generator reads like the rest of the app instead of a
+ * one-off form. Match these classes to `InteriorPageHero` / `ToolCTA`.
+ */
+
+/* -------------------------------------------------------------------------- */
+/*  Field                                                                     */
+/* -------------------------------------------------------------------------- */
+
+interface ToolFieldProps {
+  label: ReactNode;
+  htmlFor?: string;
+  required?: boolean;
+  hint?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}
+
+/** Label + control + optional hint, with a consistent required marker. */
+export function ToolField({ label, htmlFor, required, hint, className, children }: ToolFieldProps) {
+  return (
+    <div className={className}>
+      <label
+        htmlFor={htmlFor}
+        className="mb-2 block text-sm font-medium text-neutral-900 dark:text-neutral-100"
+      >
+        {label}
+        {required && (
+          <span className="ml-0.5 text-emerald-600 dark:text-emerald-400" aria-hidden="true">
+            *
+          </span>
+        )}
+      </label>
+      {children}
+      {hint && <p className="mt-1.5 text-xs leading-5 text-neutral-500 dark:text-neutral-400">{hint}</p>}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Inputs                                                                    */
+/* -------------------------------------------------------------------------- */
+
+const controlBase =
+  "w-full rounded-md border border-neutral-300 bg-white px-3.5 text-sm text-neutral-900 transition-colors " +
+  "placeholder:text-neutral-400 focus-visible:border-emerald-500 focus-visible:outline-none " +
+  "focus-visible:ring-2 focus-visible:ring-emerald-500/30 disabled:cursor-not-allowed disabled:opacity-50 " +
+  "dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50 dark:placeholder:text-neutral-500";
+
+export const ToolInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+  function ToolInput({ className, ...props }, ref) {
+    return <input ref={ref} className={cn(controlBase, "h-10", className)} {...props} />;
+  }
+);
+
+export const ToolTextarea = forwardRef<HTMLTextAreaElement, TextareaHTMLAttributes<HTMLTextAreaElement>>(
+  function ToolTextarea({ className, ...props }, ref) {
+    return <textarea ref={ref} className={cn(controlBase, "min-h-[104px] py-2.5 leading-6", className)} {...props} />;
+  }
+);
+
+export const ToolSelect = forwardRef<HTMLSelectElement, SelectHTMLAttributes<HTMLSelectElement>>(
+  function ToolSelect({ className, children, ...props }, ref) {
+    return (
+      <div className="relative">
+        <select
+          ref={ref}
+          className={cn(controlBase, "h-10 cursor-pointer appearance-none pr-10", className)}
+          {...props}
+        >
+          {children}
+        </select>
+        <ChevronDown
+          className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-neutral-400 dark:text-neutral-500"
+          aria-hidden="true"
+        />
+      </div>
+    );
+  }
+);
+
+/* -------------------------------------------------------------------------- */
+/*  Buttons                                                                    */
+/* -------------------------------------------------------------------------- */
+
+type ToolButtonVariant = "primary" | "secondary" | "ghost";
+
+const buttonVariants: Record<ToolButtonVariant, string> = {
+  primary:
+    "bg-emerald-600 text-white hover:bg-emerald-500 focus-visible:ring-emerald-500 " +
+    "disabled:hover:bg-emerald-600",
+  secondary:
+    "border border-neutral-300 bg-transparent text-neutral-700 hover:bg-neutral-100 hover:text-neutral-900 " +
+    "focus-visible:ring-neutral-500 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800 " +
+    "dark:hover:text-white",
+  ghost:
+    "bg-transparent text-emerald-700 hover:bg-emerald-50 focus-visible:ring-emerald-500 " +
+    "dark:text-emerald-400 dark:hover:bg-emerald-950/40",
+};
+
+interface ToolButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ToolButtonVariant;
+  loading?: boolean;
+  icon?: LucideIcon;
+}
+
+export const ToolButton = forwardRef<HTMLButtonElement, ToolButtonProps>(function ToolButton(
+  { variant = "primary", loading = false, icon: Icon, className, children, disabled, ...props },
+  ref
+) {
+  return (
+    <button
+      ref={ref}
+      disabled={disabled || loading}
+      className={cn(
+        "inline-flex min-h-10 items-center justify-center gap-2 rounded-md px-4 text-sm font-medium",
+        "transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+        "focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60",
+        "dark:focus-visible:ring-offset-neutral-950",
+        buttonVariants[variant],
+        className
+      )}
+      {...props}
+    >
+      {loading ? (
+        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+      ) : (
+        Icon && <Icon className="size-4" aria-hidden="true" />
+      )}
+      {children}
+    </button>
+  );
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Copy button                                                                */
+/* -------------------------------------------------------------------------- */
+
+interface CopyButtonProps {
+  value: string;
+  variant?: ToolButtonVariant;
+  label?: string;
+  copiedLabel?: string;
+  className?: string;
+}
+
+/** Copies `value` to the clipboard and flips to a confirmation state for 2s. */
+export function CopyButton({
+  value,
+  variant = "secondary",
+  label = "Copy",
+  copiedLabel = "Copied",
+  className,
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable — no-op */
+    }
+  };
+
+  return (
+    <ToolButton
+      type="button"
+      variant={variant}
+      onClick={copy}
+      className={className}
+      icon={copied ? Check : Copy}
+      aria-label={copied ? copiedLabel : label}
+    >
+      {copied ? copiedLabel : label}
+    </ToolButton>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Results                                                                    */
+/* -------------------------------------------------------------------------- */
+
+interface ToolResultProps {
+  label: ReactNode;
+  value: ReactNode;
+  sub?: ReactNode;
+  /** Colour the value with the emerald signal (the tool's answer). Default true. */
+  accent?: boolean;
+  className?: string;
+}
+
+/** The primary metric a tool produces — one focal number on a flat panel. */
+export function ToolResult({ label, value, sub, accent = true, className }: ToolResultProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-neutral-200 bg-neutral-50 p-6 text-center dark:border-neutral-800 dark:bg-neutral-900/50",
+        className
+      )}
+    >
+      <div className="text-sm font-medium text-neutral-500 dark:text-neutral-400">{label}</div>
+      <div
+        className={cn(
+          "mt-2 text-4xl font-semibold tracking-tight",
+          accent ? "text-emerald-600 dark:text-emerald-400" : "text-neutral-950 dark:text-neutral-50"
+        )}
+      >
+        {value}
+      </div>
+      {sub && <div className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">{sub}</div>}
+    </div>
+  );
+}
+
+interface ToolStatProps {
+  label: ReactNode;
+  value: ReactNode;
+  className?: string;
+}
+
+/** A compact secondary stat, for grids beneath the primary result. */
+export function ToolStat({ label, value, className }: ToolStatProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-neutral-200 bg-neutral-50 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900/50",
+        className
+      )}
+    >
+      <div className="text-xs font-medium text-neutral-500 dark:text-neutral-400">{label}</div>
+      <div className="mt-1 text-lg font-semibold text-neutral-900 dark:text-neutral-50">{value}</div>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Callout                                                                    */
+/* -------------------------------------------------------------------------- */
+
+type ToolCalloutVariant = "info" | "tip" | "success" | "warning" | "error";
+
+const calloutVariants: Record<
+  ToolCalloutVariant,
+  { surface: string; icon: string; defaultIcon: LucideIcon }
+> = {
+  info: {
+    surface: "border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900/50",
+    icon: "text-neutral-500 dark:text-neutral-400",
+    defaultIcon: Info,
+  },
+  tip: {
+    surface: "border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900/50",
+    icon: "text-emerald-600 dark:text-emerald-400",
+    defaultIcon: Lightbulb,
+  },
+  success: {
+    surface: "border-emerald-200 bg-emerald-50 dark:border-emerald-900/50 dark:bg-emerald-950/25",
+    icon: "text-emerald-600 dark:text-emerald-400",
+    defaultIcon: Check,
+  },
+  warning: {
+    surface: "border-amber-200 bg-amber-50 dark:border-amber-900/50 dark:bg-amber-950/25",
+    icon: "text-amber-600 dark:text-amber-500",
+    defaultIcon: AlertTriangle,
+  },
+  error: {
+    surface: "border-red-200 bg-red-50 dark:border-red-900/50 dark:bg-red-950/25",
+    icon: "text-red-600 dark:text-red-400",
+    defaultIcon: AlertTriangle,
+  },
+};
+
+interface ToolCalloutProps {
+  variant?: ToolCalloutVariant;
+  title?: ReactNode;
+  icon?: LucideIcon | null;
+  className?: string;
+  children: ReactNode;
+}
+
+/** A restrained tip / info / warning box — calm surface, single semantic icon. */
+export function ToolCallout({ variant = "info", title, icon, className, children }: ToolCalloutProps) {
+  const styles = calloutVariants[variant];
+  const Icon = icon === null ? null : icon ?? styles.defaultIcon;
+
+  return (
+    <div className={cn("flex gap-3 rounded-md border p-4", styles.surface, className)}>
+      {Icon && <Icon className={cn("mt-0.5 size-4 shrink-0", styles.icon)} aria-hidden="true" />}
+      <div className="min-w-0 text-sm leading-relaxed text-neutral-700 dark:text-neutral-300">
+        {title && <div className="mb-1 font-semibold text-neutral-900 dark:text-white">{title}</div>}
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Layout helpers                                                             */
+/* -------------------------------------------------------------------------- */
+
+/** Divider that opens the results region below the inputs. */
+export function ToolResultDivider({ className, children }: { className?: string; children: ReactNode }) {
+  return (
+    <div className={cn("space-y-4 border-t border-neutral-200 pt-6 dark:border-neutral-800", className)}>
+      {children}
+    </div>
+  );
+}

--- a/docs/src/app/[locale]/(home)/tools/conversion-rate-calculator/ConversionRateForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/conversion-rate-calculator/ConversionRateForm.tsx
@@ -1,6 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResult,
+  ToolResultDivider,
+  ToolSelect,
+  ToolStat,
+} from "../components/tool-ui";
 
 export function ConversionRateForm() {
   const [visitors, setVisitors] = useState("");
@@ -52,163 +62,102 @@ export function ConversionRateForm() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Total Visitors <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField label="Total Visitors" htmlFor="crc-visitors" required hint="Total number of visitors or sessions">
+        <ToolInput
+          id="crc-visitors"
           type="number"
           value={visitors}
-          onChange={(e) => setVisitors(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateConversionRate()}
+          onChange={e => setVisitors(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateConversionRate()}
           placeholder="10000"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Total number of visitors or sessions
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Total Conversions <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Total Conversions"
+        htmlFor="crc-conversions"
+        required
+        hint="Number of successful conversions (purchases, sign-ups, etc.)"
+      >
+        <ToolInput
+          id="crc-conversions"
           type="number"
           value={conversions}
-          onChange={(e) => setConversions(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateConversionRate()}
+          onChange={e => setConversions(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateConversionRate()}
           placeholder="235"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Number of successful conversions (purchases, sign-ups, etc.)
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Traffic Source / Type
-        </label>
-        <select
-          value={selectedSource}
-          onChange={(e) => setSelectedSource(e.target.value)}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
-        >
-          {Object.keys(sourceBenchmarks).map((source) => (
+      <ToolField
+        label="Traffic Source / Type"
+        htmlFor="crc-source"
+        hint="Select traffic source to compare against benchmarks"
+      >
+        <ToolSelect id="crc-source" value={selectedSource} onChange={e => setSelectedSource(e.target.value)}>
+          {Object.keys(sourceBenchmarks).map(source => (
             <option key={source} value={source}>
               {source}
             </option>
           ))}
-        </select>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Select traffic source to compare against benchmarks
-        </p>
-      </div>
+        </ToolSelect>
+      </ToolField>
 
       {conversionRate !== null && (
-        <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-          <div className="px-4 py-6 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-center">
-            <div className="text-sm text-emerald-700 dark:text-emerald-300 font-medium mb-2">
-              Conversion Rate
-            </div>
-            <div className="text-4xl font-bold text-emerald-600 dark:text-emerald-400">
-              {conversionRate.toFixed(2)}%
-            </div>
-          </div>
+        <ToolResultDivider>
+          <ToolResult label="Conversion Rate" value={`${conversionRate.toFixed(2)}%`} />
 
           {comparison && (
-            <div
-              className={`px-4 py-4 rounded-lg border ${
-                comparison.difference >= 0
-                  ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-300 dark:border-emerald-800"
-                  : comparison.difference >= -0.5
-                  ? "bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-900"
-                  : "bg-orange-50 dark:bg-orange-950/30 border-orange-200 dark:border-orange-900"
-              }`}
+            <ToolCallout
+              variant={comparison.difference >= 0 ? "success" : comparison.difference >= -0.5 ? "info" : "warning"}
+              icon={null}
+              title={`Benchmark: ${selectedSource} — ${comparison.benchmark.toFixed(2)}%`}
             >
-              <div className="text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                Benchmark: {selectedSource}
-              </div>
-              <div className="text-2xl font-bold text-neutral-900 dark:text-white mb-2">
-                {comparison.benchmark.toFixed(2)}%
-              </div>
-              <div className="text-sm text-neutral-700 dark:text-neutral-300">
-                {comparison.difference >= 0 ? (
-                  <>
-                    Your conversion rate is{" "}
-                    <span className="font-semibold text-emerald-600 dark:text-emerald-400">
-                      {comparison.difference.toFixed(2)}%
-                    </span>{" "}
-                    above the benchmark
-                  </>
-                ) : (
-                  <>
-                    Your conversion rate is{" "}
-                    <span className="font-semibold text-orange-600 dark:text-orange-400">
-                      {Math.abs(comparison.difference).toFixed(2)}%
-                    </span>{" "}
-                    below the benchmark
-                  </>
-                )}
-              </div>
-            </div>
+              {comparison.difference >= 0 ? (
+                <>
+                  Your conversion rate is{" "}
+                  <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+                    {comparison.difference.toFixed(2)}%
+                  </span>{" "}
+                  above the benchmark.
+                </>
+              ) : (
+                <>
+                  Your conversion rate is{" "}
+                  <span className="font-semibold text-amber-600 dark:text-amber-500">
+                    {Math.abs(comparison.difference).toFixed(2)}%
+                  </span>{" "}
+                  below the benchmark.
+                </>
+              )}
+            </ToolCallout>
           )}
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Total Visitors
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                {parseFloat(visitors).toLocaleString()}
-              </div>
-            </div>
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Conversions
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                {parseFloat(conversions).toLocaleString()}
-              </div>
-            </div>
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Non-Conversions
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                {(parseFloat(visitors) - parseFloat(conversions)).toLocaleString()}
-              </div>
-            </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <ToolStat label="Total Visitors" value={parseFloat(visitors).toLocaleString()} />
+            <ToolStat label="Conversions" value={parseFloat(conversions).toLocaleString()} />
+            <ToolStat
+              label="Non-Conversions"
+              value={(parseFloat(visitors) - parseFloat(conversions)).toLocaleString()}
+            />
           </div>
 
           {conversionRate < 1 && (
-            <div className="px-4 py-3 bg-orange-50 dark:bg-orange-950/30 border border-orange-200 dark:border-orange-900 rounded-lg">
-              <div className="text-sm font-medium text-orange-900 dark:text-orange-200 mb-1">
-                Low Conversion Rate
-              </div>
-              <div className="text-xs text-orange-700 dark:text-orange-300">
-                Consider optimizing your landing page, improving your value proposition, or
-                refining your targeting to improve conversions.
-              </div>
-            </div>
+            <ToolCallout variant="warning" title="Low conversion rate">
+              Consider optimizing your landing page, improving your value proposition, or refining your targeting to
+              improve conversions.
+            </ToolCallout>
           )}
-        </div>
+        </ToolResultDivider>
       )}
 
-      <div className="flex gap-4 pt-4">
-        <button
-          onClick={calculateConversionRate}
-          className="flex-1 px-6 py-3 bg-emerald-600 hover:bg-emerald-500 text-white font-medium rounded-lg transition-colors"
-        >
+      <div className="flex gap-3 pt-2">
+        <ToolButton onClick={calculateConversionRate} className="flex-1">
           Calculate Conversion Rate
-        </button>
-        <button
-          onClick={clearForm}
-          className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-        >
+        </ToolButton>
+        <ToolButton variant="secondary" onClick={clearForm}>
           Clear
-        </button>
+        </ToolButton>
       </div>
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/cost-per-acquisition-calculator/CostPerAcquisitionForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/cost-per-acquisition-calculator/CostPerAcquisitionForm.tsx
@@ -1,6 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResult,
+  ToolResultDivider,
+  ToolSelect,
+  ToolStat,
+} from "../components/tool-ui";
 
 export function CostPerAcquisitionForm() {
   const [spend, setSpend] = useState("");
@@ -52,143 +62,92 @@ export function CostPerAcquisitionForm() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Total Marketing Spend ($) <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Total Marketing Spend ($)"
+        htmlFor="cpa-spend"
+        required
+        hint="Total amount spent on marketing campaigns"
+      >
+        <ToolInput
+          id="cpa-spend"
           type="number"
           value={spend}
-          onChange={(e) => setSpend(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCPA()}
+          onChange={e => setSpend(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCPA()}
           placeholder="10000"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Total amount spent on marketing campaigns
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Number of Conversions <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Number of Conversions"
+        htmlFor="cpa-conversions"
+        required
+        hint="Total number of acquisitions or conversions achieved"
+      >
+        <ToolInput
+          id="cpa-conversions"
           type="number"
           value={conversions}
-          onChange={(e) => setConversions(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCPA()}
+          onChange={e => setConversions(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCPA()}
           placeholder="150"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Total number of acquisitions or conversions achieved
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Industry
-        </label>
-        <select
-          value={selectedIndustry}
-          onChange={(e) => setSelectedIndustry(e.target.value)}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
-        >
-          {Object.keys(industryBenchmarks).map((industry) => (
+      <ToolField label="Industry" htmlFor="cpa-industry" hint="Select your industry to compare against benchmarks">
+        <ToolSelect id="cpa-industry" value={selectedIndustry} onChange={e => setSelectedIndustry(e.target.value)}>
+          {Object.keys(industryBenchmarks).map(industry => (
             <option key={industry} value={industry}>
               {industry}
             </option>
           ))}
-        </select>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Select your industry to compare against benchmarks
-        </p>
-      </div>
+        </ToolSelect>
+      </ToolField>
 
       {cpa !== null && (
-        <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-          <div className="px-4 py-6 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-center">
-            <div className="text-sm text-emerald-700 dark:text-emerald-300 font-medium mb-2">
-              Cost Per Acquisition
-            </div>
-            <div className="text-4xl font-bold text-emerald-600 dark:text-emerald-400">
-              ${cpa.toFixed(2)}
-            </div>
-          </div>
+        <ToolResultDivider>
+          <ToolResult label="Cost Per Acquisition" value={`$${cpa.toFixed(2)}`} />
 
           {comparison && (
-            <div
-              className={`px-4 py-4 rounded-lg border ${
-                comparison.difference <= 0
-                  ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-300 dark:border-emerald-800"
-                  : comparison.difference <= 20
-                  ? "bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-900"
-                  : "bg-orange-50 dark:bg-orange-950/30 border-orange-200 dark:border-orange-900"
-              }`}
+            <ToolCallout
+              variant={comparison.difference <= 0 ? "success" : comparison.difference <= 20 ? "info" : "warning"}
+              icon={null}
+              title={`Industry Benchmark: ${selectedIndustry} — $${comparison.benchmark.toFixed(2)}`}
             >
-              <div className="text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                Industry Benchmark: {selectedIndustry}
-              </div>
-              <div className="text-2xl font-bold text-neutral-900 dark:text-white mb-2">
-                ${comparison.benchmark.toFixed(2)}
-              </div>
-              <div className="text-sm text-neutral-700 dark:text-neutral-300">
-                {comparison.difference <= 0 ? (
-                  <>
-                    Your CPA is{" "}
-                    <span className="font-semibold text-emerald-600 dark:text-emerald-400">
-                      {Math.abs(comparison.difference).toFixed(1)}% below
-                    </span>{" "}
-                    the industry average
-                  </>
-                ) : (
-                  <>
-                    Your CPA is{" "}
-                    <span className="font-semibold text-orange-600 dark:text-orange-400">
-                      {comparison.difference.toFixed(1)}% above
-                    </span>{" "}
-                    the industry average
-                  </>
-                )}
-              </div>
-            </div>
+              {comparison.difference <= 0 ? (
+                <>
+                  Your CPA is{" "}
+                  <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+                    {Math.abs(comparison.difference).toFixed(1)}% below
+                  </span>{" "}
+                  the industry average
+                </>
+              ) : (
+                <>
+                  Your CPA is{" "}
+                  <span className="font-semibold text-amber-600 dark:text-amber-500">
+                    {comparison.difference.toFixed(1)}% above
+                  </span>{" "}
+                  the industry average
+                </>
+              )}
+            </ToolCallout>
           )}
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Total Spend
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                ${parseFloat(spend).toLocaleString()}
-              </div>
-            </div>
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Conversions
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                {parseFloat(conversions).toLocaleString()}
-              </div>
-            </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <ToolStat label="Total Spend" value={`$${parseFloat(spend).toLocaleString()}`} />
+            <ToolStat label="Conversions" value={parseFloat(conversions).toLocaleString()} />
           </div>
-        </div>
+        </ToolResultDivider>
       )}
 
-      <div className="flex gap-4 pt-4">
-        <button
-          onClick={calculateCPA}
-          className="flex-1 px-6 py-3 bg-emerald-600 hover:bg-emerald-500 text-white font-medium rounded-lg transition-colors"
-        >
+      <div className="flex gap-3 pt-2">
+        <ToolButton onClick={calculateCPA} className="flex-1">
           Calculate CPA
-        </button>
-        <button
-          onClick={clearForm}
-          className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-        >
+        </ToolButton>
+        <ToolButton variant="secondary" onClick={clearForm}>
           Clear
-        </button>
+        </ToolButton>
       </div>
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/cost-per-lead-calculator/CostPerLeadForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/cost-per-lead-calculator/CostPerLeadForm.tsx
@@ -1,6 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResult,
+  ToolResultDivider,
+  ToolSelect,
+  ToolStat,
+} from "../components/tool-ui";
 
 export function CostPerLeadForm() {
   const [spend, setSpend] = useState("");
@@ -52,155 +62,98 @@ export function CostPerLeadForm() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Total Marketing Spend ($) <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Total Marketing Spend ($)"
+        htmlFor="cpl-spend"
+        required
+        hint="Total amount spent on lead generation"
+      >
+        <ToolInput
+          id="cpl-spend"
           type="number"
           value={spend}
-          onChange={(e) => setSpend(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCPL()}
+          onChange={e => setSpend(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCPL()}
           placeholder="5000"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Total amount spent on lead generation
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Number of Leads Generated <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Number of Leads Generated"
+        htmlFor="cpl-leads"
+        required
+        hint="Total number of qualified leads acquired"
+      >
+        <ToolInput
+          id="cpl-leads"
           type="number"
           value={leads}
-          onChange={(e) => setLeads(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCPL()}
+          onChange={e => setLeads(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCPL()}
           placeholder="50"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Total number of qualified leads acquired
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Marketing Channel
-        </label>
-        <select
-          value={selectedChannel}
-          onChange={(e) => setSelectedChannel(e.target.value)}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
-        >
-          {Object.keys(channelBenchmarks).map((channel) => (
+      <ToolField label="Marketing Channel" htmlFor="cpl-channel" hint="Select channel to compare against benchmarks">
+        <ToolSelect id="cpl-channel" value={selectedChannel} onChange={e => setSelectedChannel(e.target.value)}>
+          {Object.keys(channelBenchmarks).map(channel => (
             <option key={channel} value={channel}>
               {channel}
             </option>
           ))}
-        </select>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Select channel to compare against benchmarks
-        </p>
-      </div>
+        </ToolSelect>
+      </ToolField>
 
       {cpl !== null && (
-        <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-          <div className="px-4 py-6 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-center">
-            <div className="text-sm text-emerald-700 dark:text-emerald-300 font-medium mb-2">
-              Cost Per Lead
-            </div>
-            <div className="text-4xl font-bold text-emerald-600 dark:text-emerald-400">
-              ${cpl.toFixed(2)}
-            </div>
-          </div>
+        <ToolResultDivider>
+          <ToolResult label="Cost Per Lead" value={`$${cpl.toFixed(2)}`} />
 
           {comparison && (
-            <div
-              className={`px-4 py-4 rounded-lg border ${
-                comparison.difference <= 0
-                  ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-300 dark:border-emerald-800"
-                  : comparison.difference <= 20
-                  ? "bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-900"
-                  : "bg-orange-50 dark:bg-orange-950/30 border-orange-200 dark:border-orange-900"
-              }`}
+            <ToolCallout
+              variant={comparison.difference <= 0 ? "success" : comparison.difference <= 20 ? "info" : "warning"}
+              icon={null}
+              title={`Channel Benchmark: ${selectedChannel} — $${comparison.benchmark.toFixed(2)}`}
             >
-              <div className="text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                Channel Benchmark: {selectedChannel}
-              </div>
-              <div className="text-2xl font-bold text-neutral-900 dark:text-white mb-2">
-                ${comparison.benchmark.toFixed(2)}
-              </div>
-              <div className="text-sm text-neutral-700 dark:text-neutral-300">
-                {comparison.difference <= 0 ? (
-                  <>
-                    Your CPL is{" "}
-                    <span className="font-semibold text-emerald-600 dark:text-emerald-400">
-                      {Math.abs(comparison.difference).toFixed(1)}% below
-                    </span>{" "}
-                    the channel average
-                  </>
-                ) : (
-                  <>
-                    Your CPL is{" "}
-                    <span className="font-semibold text-orange-600 dark:text-orange-400">
-                      {comparison.difference.toFixed(1)}% above
-                    </span>{" "}
-                    the channel average
-                  </>
-                )}
-              </div>
-            </div>
+              {comparison.difference <= 0 ? (
+                <>
+                  Your CPL is{" "}
+                  <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+                    {Math.abs(comparison.difference).toFixed(1)}% below
+                  </span>{" "}
+                  the channel average
+                </>
+              ) : (
+                <>
+                  Your CPL is{" "}
+                  <span className="font-semibold text-amber-600 dark:text-amber-500">
+                    {comparison.difference.toFixed(1)}% above
+                  </span>{" "}
+                  the channel average
+                </>
+              )}
+            </ToolCallout>
           )}
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Total Spend
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                ${parseFloat(spend).toLocaleString()}
-              </div>
-            </div>
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Leads Generated
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                {parseFloat(leads).toLocaleString()}
-              </div>
-            </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <ToolStat label="Total Spend" value={`$${parseFloat(spend).toLocaleString()}`} />
+            <ToolStat label="Leads Generated" value={parseFloat(leads).toLocaleString()} />
           </div>
 
-          <div className="px-4 py-3 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded-lg">
-            <div className="text-sm font-medium text-blue-900 dark:text-blue-200 mb-1">
-              Lead to Customer Conversion
-            </div>
-            <div className="text-xs text-blue-700 dark:text-blue-300">
-              If your lead-to-customer conversion rate is <strong>20%</strong>, your cost per
-              acquisition would be approximately{" "}
-              <strong>${(cpl / 0.2).toFixed(2)}</strong>. Improving your conversion rate
-              directly reduces acquisition costs.
-            </div>
-          </div>
-        </div>
+          <ToolCallout variant="info" title="Lead to Customer Conversion">
+            If your lead-to-customer conversion rate is <strong>20%</strong>, your cost per acquisition would be
+            approximately <strong>${(cpl / 0.2).toFixed(2)}</strong>. Improving your conversion rate directly reduces
+            acquisition costs.
+          </ToolCallout>
+        </ToolResultDivider>
       )}
 
-      <div className="flex gap-4 pt-4">
-        <button
-          onClick={calculateCPL}
-          className="flex-1 px-6 py-3 bg-emerald-600 hover:bg-emerald-500 text-white font-medium rounded-lg transition-colors"
-        >
+      <div className="flex gap-3 pt-2">
+        <ToolButton onClick={calculateCPL} className="flex-1">
           Calculate CPL
-        </button>
-        <button
-          onClick={clearForm}
-          className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-        >
+        </ToolButton>
+        <ToolButton variant="secondary" onClick={clearForm}>
           Clear
-        </button>
+        </ToolButton>
       </div>
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/cost-per-mille-calculator/CostPerMilleForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/cost-per-mille-calculator/CostPerMilleForm.tsx
@@ -1,6 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResult,
+  ToolResultDivider,
+  ToolSelect,
+  ToolStat,
+} from "../components/tool-ui";
 
 export function CostPerMilleForm() {
   const [spend, setSpend] = useState("");
@@ -52,158 +62,101 @@ export function CostPerMilleForm() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Total Ad Spend ($) <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Total Ad Spend ($)"
+        htmlFor="cpm-spend"
+        required
+        hint="Total amount spent on advertising"
+      >
+        <ToolInput
+          id="cpm-spend"
           type="number"
           value={spend}
-          onChange={(e) => setSpend(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCPM()}
+          onChange={e => setSpend(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCPM()}
           placeholder="5000"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Total amount spent on advertising
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Total Impressions <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Total Impressions"
+        htmlFor="cpm-impressions"
+        required
+        hint="Number of times your ad was displayed"
+      >
+        <ToolInput
+          id="cpm-impressions"
           type="number"
           value={impressions}
-          onChange={(e) => setImpressions(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCPM()}
+          onChange={e => setImpressions(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCPM()}
           placeholder="500000"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Number of times your ad was displayed
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Platform
-        </label>
-        <select
-          value={selectedPlatform}
-          onChange={(e) => setSelectedPlatform(e.target.value)}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
-        >
-          {Object.keys(platformBenchmarks).map((platform) => (
+      <ToolField
+        label="Platform"
+        htmlFor="cpm-platform"
+        hint="Select advertising platform to compare against benchmarks"
+      >
+        <ToolSelect id="cpm-platform" value={selectedPlatform} onChange={e => setSelectedPlatform(e.target.value)}>
+          {Object.keys(platformBenchmarks).map(platform => (
             <option key={platform} value={platform}>
               {platform}
             </option>
           ))}
-        </select>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Select advertising platform to compare against benchmarks
-        </p>
-      </div>
+        </ToolSelect>
+      </ToolField>
 
       {cpm !== null && (
-        <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-          <div className="px-4 py-6 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-center">
-            <div className="text-sm text-emerald-700 dark:text-emerald-300 font-medium mb-2">
-              Cost Per Mille (CPM)
-            </div>
-            <div className="text-4xl font-bold text-emerald-600 dark:text-emerald-400">
-              ${cpm.toFixed(2)}
-            </div>
-            <div className="text-xs text-emerald-700 dark:text-emerald-300 mt-2">
-              Cost per 1,000 impressions
-            </div>
-          </div>
+        <ToolResultDivider>
+          <ToolResult label="Cost Per Mille (CPM)" value={`$${cpm.toFixed(2)}`} sub="Cost per 1,000 impressions" />
 
           {comparison && (
-            <div
-              className={`px-4 py-4 rounded-lg border ${
-                comparison.difference <= 0
-                  ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-300 dark:border-emerald-800"
-                  : comparison.difference <= 20
-                  ? "bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-900"
-                  : "bg-orange-50 dark:bg-orange-950/30 border-orange-200 dark:border-orange-900"
-              }`}
+            <ToolCallout
+              variant={comparison.difference <= 0 ? "success" : comparison.difference <= 20 ? "info" : "warning"}
+              icon={null}
+              title={`Platform Benchmark: ${selectedPlatform} — $${comparison.benchmark.toFixed(2)}`}
             >
-              <div className="text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                Platform Benchmark: {selectedPlatform}
-              </div>
-              <div className="text-2xl font-bold text-neutral-900 dark:text-white mb-2">
-                ${comparison.benchmark.toFixed(2)}
-              </div>
-              <div className="text-sm text-neutral-700 dark:text-neutral-300">
-                {comparison.difference <= 0 ? (
-                  <>
-                    Your CPM is{" "}
-                    <span className="font-semibold text-emerald-600 dark:text-emerald-400">
-                      {Math.abs(comparison.difference).toFixed(1)}% below
-                    </span>{" "}
-                    the platform average
-                  </>
-                ) : (
-                  <>
-                    Your CPM is{" "}
-                    <span className="font-semibold text-orange-600 dark:text-orange-400">
-                      {comparison.difference.toFixed(1)}% above
-                    </span>{" "}
-                    the platform average
-                  </>
-                )}
-              </div>
-            </div>
+              {comparison.difference <= 0 ? (
+                <>
+                  Your CPM is{" "}
+                  <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+                    {Math.abs(comparison.difference).toFixed(1)}% below
+                  </span>{" "}
+                  the platform average
+                </>
+              ) : (
+                <>
+                  Your CPM is{" "}
+                  <span className="font-semibold text-amber-600 dark:text-amber-500">
+                    {comparison.difference.toFixed(1)}% above
+                  </span>{" "}
+                  the platform average
+                </>
+              )}
+            </ToolCallout>
           )}
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Total Spend
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                ${parseFloat(spend).toLocaleString()}
-              </div>
-            </div>
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Total Impressions
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                {parseFloat(impressions).toLocaleString()}
-              </div>
-            </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <ToolStat label="Total Spend" value={`$${parseFloat(spend).toLocaleString()}`} />
+            <ToolStat label="Total Impressions" value={parseFloat(impressions).toLocaleString()} />
           </div>
 
-          <div className="px-4 py-3 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded-lg">
-            <div className="text-sm font-medium text-blue-900 dark:text-blue-200 mb-1">
-              Estimated Reach
-            </div>
-            <div className="text-xs text-blue-700 dark:text-blue-300">
-              At an average frequency of 3, your {parseFloat(impressions).toLocaleString()}{" "}
-              impressions reached approximately{" "}
-              <strong>{Math.round(parseFloat(impressions) / 3).toLocaleString()}</strong>{" "}
-              unique users.
-            </div>
-          </div>
-        </div>
+          <ToolCallout variant="info" title="Estimated Reach">
+            At an average frequency of 3, your {parseFloat(impressions).toLocaleString()} impressions reached
+            approximately <strong>{Math.round(parseFloat(impressions) / 3).toLocaleString()}</strong> unique users.
+          </ToolCallout>
+        </ToolResultDivider>
       )}
 
-      <div className="flex gap-4 pt-4">
-        <button
-          onClick={calculateCPM}
-          className="flex-1 px-6 py-3 bg-emerald-600 hover:bg-emerald-500 text-white font-medium rounded-lg transition-colors"
-        >
+      <div className="flex gap-3 pt-2">
+        <ToolButton onClick={calculateCPM} className="flex-1">
           Calculate CPM
-        </button>
-        <button
-          onClick={clearForm}
-          className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-        >
+        </ToolButton>
+        <ToolButton variant="secondary" onClick={clearForm}>
           Clear
-        </button>
+        </ToolButton>
       </div>
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/cost-per-view-calculator/CostPerViewForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/cost-per-view-calculator/CostPerViewForm.tsx
@@ -1,6 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResult,
+  ToolResultDivider,
+  ToolSelect,
+  ToolStat,
+} from "../components/tool-ui";
 
 export function CostPerViewForm() {
   const [spend, setSpend] = useState("");
@@ -50,163 +60,99 @@ export function CostPerViewForm() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Total Ad Spend ($) <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Total Ad Spend ($)"
+        htmlFor="cpv-spend"
+        required
+        hint="Total amount spent on video advertising"
+      >
+        <ToolInput
+          id="cpv-spend"
           type="number"
           value={spend}
-          onChange={(e) => setSpend(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCPV()}
+          onChange={e => setSpend(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCPV()}
           placeholder="1000"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Total amount spent on video advertising
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Total Video Views <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Total Video Views"
+        htmlFor="cpv-views"
+        required
+        hint="Number of times your video ad was viewed"
+      >
+        <ToolInput
+          id="cpv-views"
           type="number"
           value={views}
-          onChange={(e) => setViews(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCPV()}
+          onChange={e => setViews(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCPV()}
           placeholder="15000"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Number of times your video ad was viewed
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Platform
-        </label>
-        <select
-          value={selectedPlatform}
-          onChange={(e) => setSelectedPlatform(e.target.value)}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
-        >
-          {Object.keys(platformBenchmarks).map((platform) => (
+      <ToolField label="Platform" htmlFor="cpv-platform" hint="Select platform to compare against benchmarks">
+        <ToolSelect id="cpv-platform" value={selectedPlatform} onChange={e => setSelectedPlatform(e.target.value)}>
+          {Object.keys(platformBenchmarks).map(platform => (
             <option key={platform} value={platform}>
               {platform}
             </option>
           ))}
-        </select>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Select platform to compare against benchmarks
-        </p>
-      </div>
+        </ToolSelect>
+      </ToolField>
 
       {cpv !== null && (
-        <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-          <div className="px-4 py-6 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-center">
-            <div className="text-sm text-emerald-700 dark:text-emerald-300 font-medium mb-2">
-              Cost Per View
-            </div>
-            <div className="text-4xl font-bold text-emerald-600 dark:text-emerald-400">
-              ${cpv.toFixed(3)}
-            </div>
-          </div>
+        <ToolResultDivider>
+          <ToolResult label="Cost Per View" value={`$${cpv.toFixed(3)}`} />
 
           {comparison && (
-            <div
-              className={`px-4 py-4 rounded-lg border ${
-                comparison.difference <= 0
-                  ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-300 dark:border-emerald-800"
-                  : comparison.difference <= 20
-                  ? "bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-900"
-                  : "bg-orange-50 dark:bg-orange-950/30 border-orange-200 dark:border-orange-900"
-              }`}
+            <ToolCallout
+              variant={comparison.difference <= 0 ? "success" : comparison.difference <= 20 ? "info" : "warning"}
+              icon={null}
+              title={`Platform Benchmark: ${selectedPlatform} — $${comparison.benchmark.toFixed(3)}`}
             >
-              <div className="text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                Platform Benchmark: {selectedPlatform}
-              </div>
-              <div className="text-2xl font-bold text-neutral-900 dark:text-white mb-2">
-                ${comparison.benchmark.toFixed(3)}
-              </div>
-              <div className="text-sm text-neutral-700 dark:text-neutral-300">
-                {comparison.difference <= 0 ? (
-                  <>
-                    Your CPV is{" "}
-                    <span className="font-semibold text-emerald-600 dark:text-emerald-400">
-                      {Math.abs(comparison.difference).toFixed(1)}% below
-                    </span>{" "}
-                    the platform average
-                  </>
-                ) : (
-                  <>
-                    Your CPV is{" "}
-                    <span className="font-semibold text-orange-600 dark:text-orange-400">
-                      {comparison.difference.toFixed(1)}% above
-                    </span>{" "}
-                    the platform average
-                  </>
-                )}
-              </div>
-            </div>
+              {comparison.difference <= 0 ? (
+                <>
+                  Your CPV is{" "}
+                  <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+                    {Math.abs(comparison.difference).toFixed(1)}% below
+                  </span>{" "}
+                  the platform average
+                </>
+              ) : (
+                <>
+                  Your CPV is{" "}
+                  <span className="font-semibold text-amber-600 dark:text-amber-500">
+                    {comparison.difference.toFixed(1)}% above
+                  </span>{" "}
+                  the platform average
+                </>
+              )}
+            </ToolCallout>
           )}
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Total Spend
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                ${parseFloat(spend).toLocaleString()}
-              </div>
-            </div>
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Total Views
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                {parseFloat(views).toLocaleString()}
-              </div>
-            </div>
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Cost Per 1K Views
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                ${(cpv * 1000).toFixed(2)}
-              </div>
-            </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <ToolStat label="Total Spend" value={`$${parseFloat(spend).toLocaleString()}`} />
+            <ToolStat label="Total Views" value={parseFloat(views).toLocaleString()} />
+            <ToolStat label="Cost Per 1K Views" value={`$${(cpv * 1000).toFixed(2)}`} />
           </div>
 
-          <div className="px-4 py-3 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded-lg">
-            <div className="text-sm font-medium text-blue-900 dark:text-blue-200 mb-1">
-              View-Through Rate (VTR)
-            </div>
-            <div className="text-xs text-blue-700 dark:text-blue-300">
-              If you received {parseFloat(views).toLocaleString()} views from{" "}
-              {Math.round(parseFloat(views) * 2).toLocaleString()} impressions, your
-              view-through rate would be <strong>50%</strong>. Higher VTR indicates more
-              engaging content and better targeting.
-            </div>
-          </div>
-        </div>
+          <ToolCallout variant="info" title="View-Through Rate (VTR)">
+            If you received {parseFloat(views).toLocaleString()} views from{" "}
+            {Math.round(parseFloat(views) * 2).toLocaleString()} impressions, your view-through rate would be{" "}
+            <strong>50%</strong>. Higher VTR indicates more engaging content and better targeting.
+          </ToolCallout>
+        </ToolResultDivider>
       )}
 
-      <div className="flex gap-4 pt-4">
-        <button
-          onClick={calculateCPV}
-          className="flex-1 px-6 py-3 bg-emerald-600 hover:bg-emerald-500 text-white font-medium rounded-lg transition-colors"
-        >
+      <div className="flex gap-3 pt-2">
+        <ToolButton onClick={calculateCPV} className="flex-1">
           Calculate CPV
-        </button>
-        <button
-          onClick={clearForm}
-          className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-        >
+        </ToolButton>
+        <ToolButton variant="secondary" onClick={clearForm}>
           Clear
-        </button>
+        </ToolButton>
       </div>
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/ctr-calculator/CTRCalculatorForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/ctr-calculator/CTRCalculatorForm.tsx
@@ -1,11 +1,21 @@
 "use client";
 
 import { useState } from "react";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResult,
+  ToolResultDivider,
+  ToolSelect,
+  ToolStat,
+} from "../components/tool-ui";
 
 const industryBenchmarks: Record<string, number> = {
   "Search Ads": 3.17,
   "Display Ads": 0.46,
-  "Social Media": 0.90,
+  "Social Media": 0.9,
   "Email Marketing": 2.6,
   "E-commerce": 2.69,
   "B2B": 2.41,
@@ -34,125 +44,93 @@ export function CTRCalculatorForm() {
   };
 
   return (
-    <>
-      {/* Tool Section */}
-      <div className="mb-16">
-        <div className="space-y-6">
-          {/* Impressions */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Total Impressions <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="number"
-              value={impressions}
-              onChange={e => setImpressions(e.target.value)}
-              placeholder="10000"
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+    <div className="space-y-6">
+      <ToolField label="Total Impressions" htmlFor="ctr-impressions" required hint="How many times your ad was shown">
+        <ToolInput
+          id="ctr-impressions"
+          type="number"
+          value={impressions}
+          onChange={e => setImpressions(e.target.value)}
+          placeholder="10000"
+        />
+      </ToolField>
+
+      <ToolField label="Total Clicks" htmlFor="ctr-clicks" required hint="How many clicks your ad received">
+        <ToolInput
+          id="ctr-clicks"
+          type="number"
+          value={clicks}
+          onChange={e => setClicks(e.target.value)}
+          placeholder="300"
+        />
+      </ToolField>
+
+      <ToolField
+        label="Industry / Channel"
+        htmlFor="ctr-industry"
+        hint="Select your industry to compare with benchmarks"
+      >
+        <ToolSelect id="ctr-industry" value={industry} onChange={e => setIndustry(e.target.value)}>
+          {Object.keys(industryBenchmarks).map(ind => (
+            <option key={ind} value={ind}>
+              {ind}
+            </option>
+          ))}
+        </ToolSelect>
+      </ToolField>
+
+      {ctr !== null && (
+        <ToolResultDivider>
+          <ToolResult label="Your CTR" value={`${ctr.toFixed(2)}%`} />
+
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <ToolStat label={`${industry} Benchmark`} value={`${benchmark.toFixed(2)}%`} />
+            <ToolStat
+              label="vs. Benchmark"
+              value={
+                <span
+                  className={
+                    ctr >= benchmark ? "text-emerald-600 dark:text-emerald-400" : "text-amber-600 dark:text-amber-500"
+                  }
+                >
+                  {ctr >= benchmark ? "+" : ""}
+                  {(((ctr - benchmark) / benchmark) * 100).toFixed(1)}%
+                </span>
+              }
             />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">How many times your ad was shown</p>
           </div>
 
-          {/* Clicks */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Total Clicks <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="number"
-              value={clicks}
-              onChange={e => setClicks(e.target.value)}
-              placeholder="300"
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">How many clicks your ad received</p>
-          </div>
+          <ToolCallout
+            variant={ctr >= benchmark ? "success" : "warning"}
+            icon={null}
+            title={ctr >= benchmark ? "Great job!" : "Room for improvement"}
+          >
+            {ctr >= benchmark ? (
+              <>
+                Your CTR is{" "}
+                <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+                  {(((ctr - benchmark) / benchmark) * 100).toFixed(1)}%
+                </span>{" "}
+                higher than the {industry.toLowerCase()} benchmark.
+              </>
+            ) : (
+              <>
+                Your CTR is{" "}
+                <span className="font-semibold text-amber-600 dark:text-amber-500">
+                  {Math.abs(((ctr - benchmark) / benchmark) * 100).toFixed(1)}%
+                </span>{" "}
+                below the {industry.toLowerCase()} benchmark. Consider improving your ad copy, targeting, or creative.
+              </>
+            )}
+          </ToolCallout>
+        </ToolResultDivider>
+      )}
 
-          {/* Industry */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">Industry / Channel</label>
-            <select
-              value={industry}
-              onChange={e => setIndustry(e.target.value)}
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            >
-              {Object.keys(industryBenchmarks).map(ind => (
-                <option key={ind} value={ind}>
-                  {ind}
-                </option>
-              ))}
-            </select>
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-              Select your industry to compare with benchmarks
-            </p>
-          </div>
-
-          {/* Results */}
-          {ctr !== null && (
-            <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">Your CTR</label>
-                <div className="px-4 py-6 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-center">
-                  <div className="text-4xl font-bold text-emerald-600 dark:text-emerald-400">{ctr.toFixed(2)}%</div>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    {industry} Benchmark
-                  </label>
-                  <div className="px-4 py-4 bg-neutral-100 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-center">
-                    <div className="text-2xl font-bold text-neutral-900 dark:text-white">{benchmark.toFixed(2)}%</div>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    vs. Benchmark
-                  </label>
-                  <div className="px-4 py-4 bg-neutral-100 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-center">
-                    <div
-                      className={`text-2xl font-bold ${
-                        ctr >= benchmark
-                          ? "text-emerald-600 dark:text-emerald-400"
-                          : "text-orange-600 dark:text-orange-400"
-                      }`}
-                    >
-                      {ctr >= benchmark ? "+" : ""}
-                      {((ctr - benchmark) / benchmark * 100).toFixed(1)}%
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="p-4 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded-lg">
-                <p className="text-sm text-blue-900 dark:text-blue-200">
-                  {ctr >= benchmark ? (
-                    <>
-                      <strong>Great job!</strong> Your CTR is {((ctr - benchmark) / benchmark * 100).toFixed(1)}% higher than the {industry.toLowerCase()} benchmark.
-                    </>
-                  ) : (
-                    <>
-                      <strong>Room for improvement.</strong> Your CTR is {Math.abs((ctr - benchmark) / benchmark * 100).toFixed(1)}% below the {industry.toLowerCase()} benchmark. Consider improving your ad copy, targeting, or creative.
-                    </>
-                  )}
-                </p>
-              </div>
-            </div>
-          )}
-
-          {/* Buttons */}
-          <div className="flex gap-4 pt-4">
-            <button
-              onClick={clearForm}
-              className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-            >
-              Clear
-            </button>
-          </div>
-        </div>
+      <div className="flex gap-3 pt-2">
+        <ToolButton variant="secondary" onClick={clearForm}>
+          Clear
+        </ToolButton>
       </div>
-    </>
+    </div>
   );
 }

--- a/docs/src/app/[locale]/(home)/tools/customer-lifetime-value-calculator/CustomerLifetimeValueForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/customer-lifetime-value-calculator/CustomerLifetimeValueForm.tsx
@@ -1,6 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResult,
+  ToolResultDivider,
+  ToolSelect,
+  ToolStat,
+} from "../components/tool-ui";
 
 export function CustomerLifetimeValueForm() {
   const [averageValue, setAverageValue] = useState("");
@@ -73,217 +83,166 @@ export function CustomerLifetimeValueForm() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Average Purchase Value ($) <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Average Purchase Value ($)"
+        htmlFor="clv-average-value"
+        required
+        hint="Average amount a customer spends per purchase"
+      >
+        <ToolInput
+          id="clv-average-value"
           type="number"
           value={averageValue}
-          onChange={(e) => setAverageValue(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCLV()}
+          onChange={e => setAverageValue(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCLV()}
           placeholder="100"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Average amount a customer spends per purchase
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Purchase Frequency (per year) <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Purchase Frequency (per year)"
+        htmlFor="clv-purchase-frequency"
+        required
+        hint="Number of purchases per customer per year"
+      >
+        <ToolInput
+          id="clv-purchase-frequency"
           type="number"
           value={purchaseFrequency}
-          onChange={(e) => setPurchaseFrequency(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCLV()}
+          onChange={e => setPurchaseFrequency(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCLV()}
           placeholder="12"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Number of purchases per customer per year
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Customer Lifespan (years) <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Customer Lifespan (years)"
+        htmlFor="clv-lifespan"
+        required
+        hint="Average number of years a customer stays with you"
+      >
+        <ToolInput
+          id="clv-lifespan"
           type="number"
           value={customerLifespan}
-          onChange={(e) => setCustomerLifespan(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCLV()}
+          onChange={e => setCustomerLifespan(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCLV()}
           placeholder="3"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Average number of years a customer stays with you
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Profit Margin (%) <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Profit Margin (%)"
+        htmlFor="clv-margin"
+        required
+        hint="Average profit margin percentage"
+      >
+        <ToolInput
+          id="clv-margin"
           type="number"
           value={profitMargin}
-          onChange={(e) => setProfitMargin(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCLV()}
+          onChange={e => setProfitMargin(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCLV()}
           placeholder="20"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Average profit margin percentage
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Retention Rate (%) <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Retention Rate (%)"
+        htmlFor="clv-retention"
+        required
+        hint={
+          <>
+            Percentage of customers retained annually
+            {churnRate && ` (Churn rate: ${churnRate}%)`}
+          </>
+        }
+      >
+        <ToolInput
+          id="clv-retention"
           type="number"
           value={retentionRate}
-          onChange={(e) => setRetentionRate(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateCLV()}
+          onChange={e => setRetentionRate(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateCLV()}
           placeholder="85"
           max="100"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Percentage of customers retained annually
-          {churnRate && ` (Churn rate: ${churnRate}%)`}
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Industry
-        </label>
-        <select
-          value={selectedIndustry}
-          onChange={(e) => setSelectedIndustry(e.target.value)}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
-        >
-          {Object.keys(industryBenchmarks).map((industry) => (
+      <ToolField label="Industry" htmlFor="clv-industry" hint="Select your industry to compare against benchmarks">
+        <ToolSelect id="clv-industry" value={selectedIndustry} onChange={e => setSelectedIndustry(e.target.value)}>
+          {Object.keys(industryBenchmarks).map(industry => (
             <option key={industry} value={industry}>
               {industry}
             </option>
           ))}
-        </select>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Select your industry to compare against benchmarks
-        </p>
-      </div>
+        </ToolSelect>
+      </ToolField>
 
       {clv !== null && (
-        <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-          <div className="px-4 py-6 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-center">
-            <div className="text-sm text-emerald-700 dark:text-emerald-300 font-medium mb-2">
-              Customer Lifetime Value
-            </div>
-            <div className="text-4xl font-bold text-emerald-600 dark:text-emerald-400">
-              ${clv.toFixed(2)}
-            </div>
-          </div>
+        <ToolResultDivider>
+          <ToolResult label="Customer Lifetime Value" value={`$${clv.toFixed(2)}`} />
 
           {comparison && (
-            <div
-              className={`px-4 py-4 rounded-lg border ${
-                comparison.difference >= 0
-                  ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-300 dark:border-emerald-800"
-                  : comparison.difference >= -20
-                  ? "bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-900"
-                  : "bg-orange-50 dark:bg-orange-950/30 border-orange-200 dark:border-orange-900"
-              }`}
+            <ToolCallout
+              variant={comparison.difference >= 0 ? "success" : comparison.difference >= -20 ? "info" : "warning"}
+              icon={null}
+              title={`Industry Benchmark: ${selectedIndustry} — $${comparison.benchmark.toLocaleString()}`}
             >
-              <div className="text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                Industry Benchmark: {selectedIndustry}
-              </div>
-              <div className="text-2xl font-bold text-neutral-900 dark:text-white mb-2">
-                ${comparison.benchmark.toLocaleString()}
-              </div>
-              <div className="text-sm text-neutral-700 dark:text-neutral-300">
-                {comparison.difference >= 0 ? (
-                  <>
-                    Your CLV is{" "}
-                    <span className="font-semibold text-emerald-600 dark:text-emerald-400">
-                      {comparison.difference.toFixed(1)}% above
-                    </span>{" "}
-                    the industry average
-                  </>
-                ) : (
-                  <>
-                    Your CLV is{" "}
-                    <span className="font-semibold text-orange-600 dark:text-orange-400">
-                      {Math.abs(comparison.difference).toFixed(1)}% below
-                    </span>{" "}
-                    the industry average
-                  </>
-                )}
-              </div>
-            </div>
+              {comparison.difference >= 0 ? (
+                <>
+                  Your CLV is{" "}
+                  <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+                    {comparison.difference.toFixed(1)}% above
+                  </span>{" "}
+                  the industry average
+                </>
+              ) : (
+                <>
+                  Your CLV is{" "}
+                  <span className="font-semibold text-amber-600 dark:text-amber-500">
+                    {Math.abs(comparison.difference).toFixed(1)}% below
+                  </span>{" "}
+                  the industry average
+                </>
+              )}
+            </ToolCallout>
           )}
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Annual Customer Value
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                $
-                {(
-                  parseFloat(averageValue) *
-                  parseFloat(purchaseFrequency) *
-                  (parseFloat(profitMargin) / 100)
-                ).toFixed(2)}
-              </div>
-            </div>
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Total Revenue Potential
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                $
-                {(
-                  parseFloat(averageValue) *
-                  parseFloat(purchaseFrequency) *
-                  parseFloat(customerLifespan)
-                ).toFixed(2)}
-              </div>
-            </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <ToolStat
+              label="Annual Customer Value"
+              value={`$${(
+                parseFloat(averageValue) *
+                parseFloat(purchaseFrequency) *
+                (parseFloat(profitMargin) / 100)
+              ).toFixed(2)}`}
+            />
+            <ToolStat
+              label="Total Revenue Potential"
+              value={`$${(
+                parseFloat(averageValue) *
+                parseFloat(purchaseFrequency) *
+                parseFloat(customerLifespan)
+              ).toFixed(2)}`}
+            />
           </div>
 
-          <div className="px-4 py-3 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded-lg">
-            <div className="text-sm font-medium text-blue-900 dark:text-blue-200 mb-1">
-              CLV:CAC Ratio Guidance
-            </div>
-            <div className="text-xs text-blue-700 dark:text-blue-300">
-              A healthy business should have a CLV that's at least <strong>3x</strong> your
-              Customer Acquisition Cost (CAC). With a CLV of ${clv.toFixed(2)}, your maximum
-              sustainable CAC is approximately <strong>${(clv / 3).toFixed(2)}</strong>.
-            </div>
-          </div>
-        </div>
+          <ToolCallout variant="info" title="CLV:CAC Ratio Guidance">
+            A healthy business should have a CLV that's at least <strong>3x</strong> your Customer Acquisition Cost
+            (CAC). With a CLV of ${clv.toFixed(2)}, your maximum sustainable CAC is approximately{" "}
+            <strong>${(clv / 3).toFixed(2)}</strong>.
+          </ToolCallout>
+        </ToolResultDivider>
       )}
 
-      <div className="flex gap-4 pt-4">
-        <button
-          onClick={calculateCLV}
-          className="flex-1 px-6 py-3 bg-emerald-600 hover:bg-emerald-500 text-white font-medium rounded-lg transition-colors"
-        >
+      <div className="flex gap-3 pt-2">
+        <ToolButton onClick={calculateCLV} className="flex-1">
           Calculate CLV
-        </button>
-        <button
-          onClick={clearForm}
-          className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-        >
+        </ToolButton>
+        <ToolButton variant="secondary" onClick={clearForm}>
           Clear
-        </button>
+        </ToolButton>
       </div>
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/funnel-visualizer/FunnelVisualizerForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/funnel-visualizer/FunnelVisualizerForm.tsx
@@ -3,6 +3,7 @@
 import { Plus, X } from "lucide-react";
 import { useState } from "react";
 import { round } from "lodash";
+import { ToolButton, ToolInput } from "../components/tool-ui";
 
 interface FunnelStep {
   name: string;
@@ -88,25 +89,24 @@ export function FunnelVisualizerForm() {
               </div>
             </div>
             <div className="flex-1 grid grid-cols-2 gap-3">
-              <input
+              <ToolInput
                 type="text"
                 value={step.name}
                 onChange={e => updateStep(index, "name", e.target.value)}
                 placeholder={`Step ${index + 1} name`}
-                className="px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
               />
-              <input
+              <ToolInput
                 type="number"
                 value={step.visitors}
                 onChange={e => updateStep(index, "visitors", e.target.value)}
                 placeholder="Visitors"
-                className="px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
               />
             </div>
             {steps.length > 2 && (
               <button
                 onClick={() => removeStep(index)}
-                className="flex-shrink-0 w-10 h-10 flex items-center justify-center text-neutral-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30 rounded-lg transition-colors"
+                aria-label={`Remove step ${index + 1}`}
+                className="flex-shrink-0 w-10 h-10 flex items-center justify-center rounded-md text-neutral-500 transition-colors hover:bg-red-50 hover:text-red-600 dark:text-neutral-400 dark:hover:bg-red-950/30 dark:hover:text-red-400"
               >
                 <X className="w-5 h-5" />
               </button>
@@ -115,13 +115,9 @@ export function FunnelVisualizerForm() {
         ))}
       </div>
 
-      <button
-        onClick={addStep}
-        className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-emerald-600 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-950/30 rounded-lg transition-colors"
-      >
-        <Plus className="w-4 h-4" />
+      <ToolButton variant="ghost" icon={Plus} onClick={addStep}>
         Add Step
-      </button>
+      </ToolButton>
 
       {/* Funnel Visualization */}
       {chartData && chartData.length > 0 && (
@@ -138,7 +134,7 @@ export function FunnelVisualizerForm() {
                 <div key={step.stepNumber} className="relative pb-4">
                   {/* Step Header */}
                   <div className="flex items-center p-2">
-                    <div className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-100 dark:bg-neutral-800 flex items-center justify-center text-xs mr-2">
+                    <div className="flex-shrink-0 w-6 h-6 rounded-full bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 flex items-center justify-center text-xs mr-2">
                       {step.stepNumber}
                     </div>
                     <div className="font-medium text-sm flex-1">{step.stepName}</div>
@@ -153,14 +149,14 @@ export function FunnelVisualizerForm() {
                         <span className="text-sm text-neutral-500 dark:text-neutral-400 ml-1">visitors</span>
                       </div>
                       {index !== 0 && (
-                        <div className="flex items-baseline text-orange-500 text-xs font-medium">
+                        <div className="flex items-baseline text-amber-600 dark:text-amber-500 text-xs font-medium">
                           {droppedFromPrevious.toLocaleString()} dropped
                         </div>
                       )}
                     </div>
 
                     {/* Bar */}
-                    <div className="flex-grow h-10 bg-neutral-100 dark:bg-neutral-800 rounded-md overflow-hidden relative mt-2">
+                    <div className="flex-grow h-10 bg-neutral-50 dark:bg-neutral-900/50 rounded-md overflow-hidden relative mt-2">
                       {/* Relative conversion bar (from previous step) */}
                       {index > 0 && prevStep && (
                         <div
@@ -218,12 +214,9 @@ export function FunnelVisualizerForm() {
 
       {/* Buttons */}
       <div className="flex gap-4 pt-4">
-        <button
-          onClick={clearForm}
-          className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-        >
+        <ToolButton variant="secondary" onClick={clearForm}>
           Clear
-        </button>
+        </ToolButton>
       </div>
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/marketing-roi-calculator/MarketingROIForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/marketing-roi-calculator/MarketingROIForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { ToolButton, ToolCallout, ToolField, ToolInput, ToolResult, ToolResultDivider, ToolStat } from "../components/tool-ui";
 
 export interface Metrics {
   profit: number;
@@ -39,172 +40,109 @@ export function MarketingROIForm() {
 
   return (
     <div className="space-y-6">
-      {/* Ad Spend */}
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Ad Spend <span className="text-red-500">*</span>
-        </label>
+      <ToolField label="Ad Spend" htmlFor="mroi-ad-spend" required hint="Total amount spent on advertising">
         <div className="relative">
-          <span className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400">$</span>
-          <input
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500 dark:text-neutral-400">
+            $
+          </span>
+          <ToolInput
+            id="mroi-ad-spend"
             type="number"
             value={adSpend}
             onChange={e => setAdSpend(e.target.value)}
             placeholder="5000"
-            className="w-full pl-8 pr-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            className="pl-7 pr-3.5"
           />
         </div>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Total amount spent on advertising</p>
-      </div>
+      </ToolField>
 
-      {/* Revenue */}
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Revenue Generated <span className="text-red-500">*</span>
-        </label>
+      <ToolField label="Revenue Generated" htmlFor="mroi-revenue" required hint="Total revenue from the campaign">
         <div className="relative">
-          <span className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400">$</span>
-          <input
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500 dark:text-neutral-400">
+            $
+          </span>
+          <ToolInput
+            id="mroi-revenue"
             type="number"
             value={revenue}
             onChange={e => setRevenue(e.target.value)}
             placeholder="15000"
-            className="w-full pl-8 pr-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            className="pl-7 pr-3.5"
           />
         </div>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Total revenue from the campaign</p>
-      </div>
+      </ToolField>
 
-      {/* Cost of Goods Sold */}
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Cost of Goods Sold (Optional)
-        </label>
+      <ToolField
+        label="Cost of Goods Sold (Optional)"
+        htmlFor="mroi-cogs"
+        hint="Direct costs of products sold (leave blank if not applicable)"
+      >
         <div className="relative">
-          <span className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400">$</span>
-          <input
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500 dark:text-neutral-400">
+            $
+          </span>
+          <ToolInput
+            id="mroi-cogs"
             type="number"
             value={costOfGoodsSold}
             onChange={e => setCostOfGoodsSold(e.target.value)}
             placeholder="3000"
-            className="w-full pl-8 pr-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            className="pl-7 pr-3.5"
           />
         </div>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Direct costs of products sold (leave blank if not applicable)
-        </p>
-      </div>
+      </ToolField>
 
-      {/* Results */}
       {metrics && (
-        <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {/* ROI */}
-            <div>
-              <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                ROI (Return on Investment)
-              </label>
-              <div className="px-4 py-6 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-center">
-                <div
-                  className={`text-4xl font-bold ${
-                    metrics.roi >= 0
-                      ? "text-emerald-600 dark:text-emerald-400"
-                      : "text-red-600 dark:text-red-400"
-                  }`}
-                >
-                  {metrics.roi >= 0 ? "+" : ""}
-                  {metrics.roi.toFixed(1)}%
-                </div>
-              </div>
-            </div>
+        <ToolResultDivider>
+          <ToolResult
+            label="ROI (Return on Investment)"
+            value={
+              <span className={metrics.roi >= 0 ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400"}>
+                {metrics.roi >= 0 ? "+" : ""}
+                {metrics.roi.toFixed(1)}%
+              </span>
+            }
+            accent={false}
+          />
 
-            {/* ROAS */}
-            <div>
-              <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                ROAS (Return on Ad Spend)
-              </label>
-              <div className="px-4 py-6 bg-blue-50 dark:bg-blue-950/30 border border-blue-300 dark:border-blue-800 rounded-lg text-center">
-                <div className="text-4xl font-bold text-blue-600 dark:text-blue-400">
-                  {metrics.roas.toFixed(2)}x
-                </div>
-              </div>
-            </div>
-
-            {/* Profit */}
-            <div>
-              <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                Net Profit
-              </label>
-              <div className="px-4 py-6 bg-neutral-100 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-center">
-                <div
-                  className={`text-3xl font-bold ${
-                    metrics.profit >= 0
-                      ? "text-emerald-600 dark:text-emerald-400"
-                      : "text-red-600 dark:text-red-400"
-                  }`}
-                >
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <ToolStat label="ROAS (Return on Ad Spend)" value={`${metrics.roas.toFixed(2)}x`} />
+            <ToolStat
+              label="Net Profit"
+              value={
+                <span className={metrics.profit >= 0 ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400"}>
                   {metrics.profit >= 0 ? "+" : "-"}${Math.abs(metrics.profit).toLocaleString()}
-                </div>
-              </div>
-            </div>
-
-            {/* Profit Margin */}
-            <div>
-              <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                Profit Margin
-              </label>
-              <div className="px-4 py-6 bg-neutral-100 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-center">
-                <div className="text-3xl font-bold text-neutral-900 dark:text-white">
-                  {metrics.profitMargin.toFixed(1)}%
-                </div>
-              </div>
-            </div>
+                </span>
+              }
+            />
+            <ToolStat label="Profit Margin" value={`${metrics.profitMargin.toFixed(1)}%`} />
           </div>
 
-          <div
-            className={`p-4 rounded-lg border ${
-              metrics.roi >= 100
-                ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-900"
-                : metrics.roi >= 0
-                  ? "bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-900"
-                  : "bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-900"
-            }`}
-          >
-            <p
-              className={`text-sm ${
-                metrics.roi >= 100
-                  ? "text-emerald-900 dark:text-emerald-200"
-                  : metrics.roi >= 0
-                    ? "text-blue-900 dark:text-blue-200"
-                    : "text-red-900 dark:text-red-200"
-              }`}
-            >
-              {metrics.roi >= 100 ? (
-                <>
-                  <strong>Excellent ROI!</strong> You're generating ${metrics.roas.toFixed(2)} in revenue for every $1 spent. Your campaign is highly profitable.
-                </>
-              ) : metrics.roi >= 0 ? (
-                <>
-                  <strong>Positive ROI.</strong> You're making a profit, but there may be room for optimization to improve returns.
-                </>
-              ) : (
-                <>
-                  <strong>Negative ROI.</strong> Your campaign is losing money. Consider reviewing your targeting, creative, or product-market fit.
-                </>
-              )}
-            </p>
-          </div>
-        </div>
+          <ToolCallout variant={metrics.roi >= 100 ? "success" : metrics.roi >= 0 ? "info" : "error"}>
+            {metrics.roi >= 100 ? (
+              <>
+                <strong>Excellent ROI!</strong> You're generating ${metrics.roas.toFixed(2)} in revenue for every $1
+                spent. Your campaign is highly profitable.
+              </>
+            ) : metrics.roi >= 0 ? (
+              <>
+                <strong>Positive ROI.</strong> You're making a profit, but there may be room for optimization to
+                improve returns.
+              </>
+            ) : (
+              <>
+                <strong>Negative ROI.</strong> Your campaign is losing money. Consider reviewing your targeting,
+                creative, or product-market fit.
+              </>
+            )}
+          </ToolCallout>
+        </ToolResultDivider>
       )}
 
-      {/* Buttons */}
-      <div className="flex gap-4 pt-4">
-        <button
-          onClick={clearForm}
-          className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-        >
+      <div className="flex gap-3 pt-2">
+        <ToolButton variant="secondary" onClick={clearForm}>
           Clear
-        </button>
+        </ToolButton>
       </div>
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/meta-description-generator/MetaDescriptionForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/meta-description-generator/MetaDescriptionForm.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { TrackedButton } from "@/components/TrackedButton";
-import { DEFAULT_EVENT_LIMIT } from "@/lib/const";
-import { CheckCircle, Copy, Loader2 } from "lucide-react";
 import { useState } from "react";
+import { CopyButton, ToolButton, ToolCallout, ToolField, ToolInput } from "../components/tool-ui";
 
 interface DescriptionOption {
   description: string;
@@ -17,7 +15,6 @@ export function MetaDescriptionForm() {
   const [descriptions, setDescriptions] = useState<DescriptionOption[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
   const [remainingRequests, setRemainingRequests] = useState<number | null>(null);
 
   const generateDescriptions = async () => {
@@ -54,143 +51,70 @@ export function MetaDescriptionForm() {
     }
   };
 
-  const copyDescription = async (description: string, index: number) => {
-    await navigator.clipboard.writeText(description);
-    setCopiedIndex(index);
-    setTimeout(() => setCopiedIndex(null), 2000);
-  };
-
   const getLengthColor = (length: number) => {
     if (length >= 150 && length <= 160) return "text-emerald-600 dark:text-emerald-400";
-    if (length > 160 && length <= 170) return "text-orange-600 dark:text-orange-400";
+    if (length > 160 && length <= 170) return "text-amber-600 dark:text-amber-500";
     return "text-red-600 dark:text-red-400";
   };
 
   return (
-    <>
+    <div className="space-y-6">
       {remainingRequests !== null && (
-        <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-4">
-          {remainingRequests} requests remaining this minute
-        </p>
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">{remainingRequests} requests remaining this minute</p>
       )}
 
-      <div className="mb-16">
-        <div className="space-y-6">
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Page Topic <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="text"
-              value={topic}
-              onChange={e => setTopic(e.target.value)}
-              placeholder="e.g., Complete Guide to Content Marketing Strategy"
-              disabled={isLoading}
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50"
-            />
-          </div>
+      <ToolField label="Page Topic" htmlFor="meta-topic" required>
+        <ToolInput
+          id="meta-topic"
+          type="text"
+          value={topic}
+          onChange={e => setTopic(e.target.value)}
+          placeholder="e.g., Complete Guide to Content Marketing Strategy"
+          disabled={isLoading}
+        />
+      </ToolField>
 
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Target Keywords (Optional)
-            </label>
-            <input
-              type="text"
-              value={keywords}
-              onChange={e => setKeywords(e.target.value)}
-              placeholder="e.g., content marketing, SEO, digital strategy"
-              disabled={isLoading}
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50"
-            />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Comma-separated keywords to include</p>
-          </div>
+      <ToolField label="Target Keywords (Optional)" htmlFor="meta-keywords" hint="Comma-separated keywords to include">
+        <ToolInput
+          id="meta-keywords"
+          type="text"
+          value={keywords}
+          onChange={e => setKeywords(e.target.value)}
+          placeholder="e.g., content marketing, SEO, digital strategy"
+          disabled={isLoading}
+        />
+      </ToolField>
 
-          {error && (
-            <div className="p-4 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded-lg">
-              <p className="text-sm text-red-900 dark:text-red-200">{error}</p>
-            </div>
-          )}
+      {error && <ToolCallout variant="error">{error}</ToolCallout>}
 
-          <button
-            onClick={generateDescriptions}
-            disabled={isLoading}
-            className="w-full px-6 py-3 bg-emerald-600 hover:bg-emerald-500 disabled:bg-neutral-400 dark:disabled:bg-neutral-700 text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
-          >
-            {isLoading ? (
-              <>
-                <Loader2 className="w-5 h-5 animate-spin" />
-                Generating Descriptions...
-              </>
-            ) : (
-              "Generate Meta Descriptions"
-            )}
-          </button>
+      <ToolButton onClick={generateDescriptions} loading={isLoading} className="w-full">
+        {isLoading ? "Generating Descriptions..." : "Generate Meta Descriptions"}
+      </ToolButton>
 
-          {descriptions.length > 0 && (
-            <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-3">
-              <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">Generated Descriptions</h3>
-              {descriptions.map((option, index) => (
-                <div
-                  key={index}
-                  className="p-4 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:border-emerald-500/40 dark:hover:border-emerald-500/30 transition-colors"
-                >
-                  <div className="flex items-start justify-between gap-4 mb-2">
-                    <p className="flex-1 text-neutral-900 dark:text-white">{option.description}</p>
-                    <button
-                      onClick={() => copyDescription(option.description, index)}
-                      className="flex-shrink-0 px-3 py-1.5 bg-neutral-200 dark:bg-neutral-700 hover:bg-neutral-300 dark:hover:bg-neutral-600 text-neutral-900 dark:text-white text-sm rounded-lg transition-colors flex items-center gap-2"
-                    >
-                      {copiedIndex === index ? (
-                        <>
-                          <CheckCircle className="w-4 h-4" />
-                          Copied
-                        </>
-                      ) : (
-                        <>
-                          <Copy className="w-4 h-4" />
-                          Copy
-                        </>
-                      )}
-                    </button>
-                  </div>
-                  <div className="flex items-center gap-4 text-xs">
-                    <span className={`font-medium ${getLengthColor(option.length)}`}>{option.length} characters</span>
-
-                    <span className="text-neutral-600 dark:text-neutral-400">{option.approach}</span>
-                  </div>
-                </div>
-              ))}
-              <div className="p-3 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded-lg">
-                <p className="text-sm text-blue-900 dark:text-blue-200">
-                  <strong>Tip:</strong> Optimal meta description length is 150-160 characters. Longer descriptions may
-                  be truncated in search results.
-                </p>
+      {descriptions.length > 0 && (
+        <div className="space-y-3 border-t border-neutral-200 pt-6 dark:border-neutral-800">
+          <h3 className="text-base font-semibold text-neutral-900 dark:text-white">Generated Descriptions</h3>
+          {descriptions.map((option, index) => (
+            <div
+              key={index}
+              className="rounded-md border border-neutral-200 bg-neutral-50 p-4 transition-colors hover:border-neutral-300 dark:border-neutral-800 dark:bg-neutral-900/50 dark:hover:border-neutral-700"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <p className="flex-1 text-neutral-900 dark:text-white">{option.description}</p>
+                <CopyButton value={option.description} className="shrink-0" />
+              </div>
+              <div className="mt-2 flex items-center gap-4 text-xs">
+                <span className={`font-medium ${getLengthColor(option.length)}`}>{option.length} characters</span>
+                <span className="text-neutral-500 dark:text-neutral-400">{option.approach}</span>
               </div>
             </div>
-          )}
+          ))}
+          <ToolCallout variant="tip">
+            <strong>Tip:</strong> Optimal meta description length is 150-160 characters. Longer descriptions may be
+            truncated in search results.
+          </ToolCallout>
         </div>
-      </div>
-
-      {/* CTA */}
-      <div className="border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-20 -mx-6">
-        <div className="max-w-4xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 dark:text-white mb-4">
-            Optimize your content with Rybbit
-          </h2>
-          <p className="text-lg text-neutral-600 dark:text-neutral-400 mb-8 max-w-2xl mx-auto">
-            Track which pages perform best and refine your meta descriptions based on real visitor data. Get started for
-            free with up to {DEFAULT_EVENT_LIMIT.toLocaleString()} pageviews per month.
-          </p>
-          <TrackedButton
-            href="https://app.rybbit.io/signup"
-            eventName="signup"
-            eventProps={{ location: "meta_description_generator_cta" }}
-            className="inline-block bg-emerald-600 hover:bg-emerald-500 text-white font-semibold px-10 py-4 text-lg rounded-lg shadow-lg shadow-emerald-900/20 transform hover:-translate-y-0.5 transition-all duration-200"
-          >
-            Start tracking for free
-          </TrackedButton>
-        </div>
-      </div>
-    </>
+      )}
+    </div>
   );
 }

--- a/docs/src/app/[locale]/(home)/tools/og-tag-generator/OGTagForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/og-tag-generator/OGTagForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { CheckCircle, Copy, Loader2 } from "lucide-react";
 import { useState } from "react";
+import { CopyButton, ToolButton, ToolCallout, ToolField, ToolInput, ToolSelect, ToolTextarea } from "../components/tool-ui";
 
 interface OGVariation {
   variation: string;
@@ -20,7 +20,6 @@ export function OGTagForm() {
   const [variations, setVariations] = useState<OGVariation[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
   const [remainingRequests, setRemainingRequests] = useState<number | null>(null);
 
   const generateOGTags = async () => {
@@ -57,142 +56,95 @@ export function OGTagForm() {
     }
   };
 
-  const copyCode = async (code: string, index: number) => {
-    await navigator.clipboard.writeText(code);
-    setCopiedIndex(index);
-    setTimeout(() => setCopiedIndex(null), 2000);
-  };
-
   return (
     <div className="space-y-6">
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Page Title <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField label="Page Title" htmlFor="og-title" required>
+        <ToolInput
+          id="og-title"
           type="text"
           value={pageTitle}
           onChange={e => setPageTitle(e.target.value)}
           placeholder="e.g., The Ultimate Guide to Web Analytics"
           disabled={isLoading}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50"
         />
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Page Description <span className="text-red-500">*</span>
-        </label>
-        <textarea
+      <ToolField label="Page Description" htmlFor="og-description" required>
+        <ToolTextarea
+          id="og-description"
           value={pageDescription}
           onChange={e => setPageDescription(e.target.value)}
           placeholder="e.g., Learn how to track website visitors, measure conversions, and grow your business with privacy-focused analytics..."
           disabled={isLoading}
           rows={4}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50"
         />
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Page Type
-        </label>
-        <select
+      <ToolField label="Page Type" htmlFor="og-type">
+        <ToolSelect
+          id="og-type"
           value={pageType}
           onChange={e => setPageType(e.target.value as typeof pageType)}
           disabled={isLoading}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50"
         >
           <option value="website">Website</option>
           <option value="article">Article</option>
           <option value="blog">Blog Post</option>
           <option value="product">Product</option>
-        </select>
-      </div>
+        </ToolSelect>
+      </ToolField>
 
-      {error && (
-        <div className="p-4 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded-lg">
-          <p className="text-sm text-red-900 dark:text-red-200">{error}</p>
-        </div>
-      )}
+      {error && <ToolCallout variant="error">{error}</ToolCallout>}
 
       {remainingRequests !== null && (
-        <p className="text-sm text-neutral-500 dark:text-neutral-400">
-          {remainingRequests} requests remaining this minute
-        </p>
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">{remainingRequests} requests remaining this minute</p>
       )}
 
-      <button
-        onClick={generateOGTags}
-        disabled={isLoading}
-        className="w-full px-6 py-3 bg-emerald-600 hover:bg-emerald-500 disabled:bg-neutral-400 dark:disabled:bg-neutral-700 text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
-      >
-        {isLoading ? (
-          <>
-            <Loader2 className="w-5 h-5 animate-spin" />
-            Generating OG Tags...
-          </>
-        ) : (
-          "Generate Open Graph Tags"
-        )}
-      </button>
+      <ToolButton onClick={generateOGTags} loading={isLoading} className="w-full">
+        {isLoading ? "Generating OG Tags..." : "Generate Open Graph Tags"}
+      </ToolButton>
 
       {variations.length > 0 && (
-        <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-6">
-          <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">Generated Variations</h3>
+        <div className="space-y-6 border-t border-neutral-200 pt-6 dark:border-neutral-800">
+          <h3 className="text-base font-semibold text-neutral-900 dark:text-white">Generated Variations</h3>
           {variations.map((variation, index) => (
             <div
               key={index}
-              className="p-6 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg"
+              className="rounded-md border border-neutral-200 bg-neutral-50 p-6 dark:border-neutral-800 dark:bg-neutral-900/50"
             >
-              <div className="flex items-center justify-between mb-4">
-                <h4 className="text-lg font-semibold text-neutral-900 dark:text-white">{variation.variation}</h4>
-                <button
-                  onClick={() => copyCode(variation.htmlCode, index)}
-                  className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2"
-                >
-                  {copiedIndex === index ? (
-                    <>
-                      <CheckCircle className="w-4 h-4" />
-                      Copied!
-                    </>
-                  ) : (
-                    <>
-                      <Copy className="w-4 h-4" />
-                      Copy HTML
-                    </>
-                  )}
-                </button>
+              <div className="mb-4 flex items-center justify-between gap-4">
+                <h4 className="text-base font-semibold text-neutral-900 dark:text-white">{variation.variation}</h4>
+                <CopyButton value={variation.htmlCode} variant="primary" label="Copy HTML" copiedLabel="Copied!" className="shrink-0" />
               </div>
 
-              <div className="space-y-3 mb-4">
+              <div className="mb-4 space-y-3">
                 <div>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">Title</p>
-                  <p className="text-sm text-neutral-900 dark:text-white font-medium">{variation.ogTitle}</p>
+                  <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">Title</p>
+                  <p className="text-sm font-medium text-neutral-900 dark:text-white">{variation.ogTitle}</p>
                 </div>
                 <div>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">Description</p>
+                  <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">Description</p>
                   <p className="text-sm text-neutral-900 dark:text-white">{variation.ogDescription}</p>
                 </div>
                 <div className="grid grid-cols-2 gap-3">
                   <div>
-                    <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">Type</p>
+                    <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">Type</p>
                     <p className="text-sm text-neutral-900 dark:text-white">{variation.ogType}</p>
                   </div>
                   <div>
-                    <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">Twitter Card</p>
+                    <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">Twitter Card</p>
                     <p className="text-sm text-neutral-900 dark:text-white">{variation.twitterCard}</p>
                   </div>
                 </div>
                 <div>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">Image Suggestion</p>
+                  <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">Image Suggestion</p>
                   <p className="text-sm text-neutral-600 dark:text-neutral-300">{variation.ogImageSuggestion}</p>
                 </div>
               </div>
 
               <div>
-                <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-2">HTML Code</p>
-                <pre className="p-3 bg-neutral-100 dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-700 rounded-lg overflow-x-auto">
+                <p className="mb-2 text-xs text-neutral-500 dark:text-neutral-400">HTML Code</p>
+                <pre className="overflow-x-auto rounded-md border border-neutral-200 bg-neutral-100 p-3 dark:border-neutral-800 dark:bg-neutral-950">
                   <code className="text-xs text-neutral-900 dark:text-neutral-100">{variation.htmlCode}</code>
                 </pre>
               </div>

--- a/docs/src/app/[locale]/(home)/tools/page-speed-calculator/PageSpeedForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/page-speed-calculator/PageSpeedForm.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { TrackedButton } from "@/components/TrackedButton";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import { DEFAULT_EVENT_LIMIT } from "@/lib/const";
-import Link from "next/link";
 import { useState } from "react";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResult,
+  ToolResultDivider,
+  ToolStat,
+} from "../components/tool-ui";
 
 interface CalculateImpactResult {
   conversionImpact: number;
@@ -85,322 +90,179 @@ export function PageSpeedForm() {
   };
 
   return (
-    <>
-      {/* Tool */}
-      <div className="mb-16">
-        <div className="space-y-6">
-          {/* Current Load Time */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Current Page Load Time <span className="text-red-500">*</span>
-            </label>
-            <div className="relative">
-              <input
-                type="number"
-                step="0.1"
-                value={currentLoadTime}
-                onChange={e => setCurrentLoadTime(e.target.value)}
-                placeholder="4.5"
-                className="w-full pl-4 pr-20 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-              />
-              <span className="absolute right-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400">
-                seconds
-              </span>
-            </div>
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-              Your current page load time (check with PageSpeed Insights)
-            </p>
-          </div>
+    <div className="space-y-6">
+      <ToolField
+        label="Current Page Load Time"
+        htmlFor="psc-current-load-time"
+        required
+        hint="Your current page load time (check with PageSpeed Insights)"
+      >
+        <div className="relative">
+          <ToolInput
+            id="psc-current-load-time"
+            type="number"
+            step="0.1"
+            value={currentLoadTime}
+            onChange={e => setCurrentLoadTime(e.target.value)}
+            placeholder="4.5"
+            className="pl-3.5 pr-16"
+          />
+          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500 dark:text-neutral-400">
+            seconds
+          </span>
+        </div>
+      </ToolField>
 
-          {/* Target Load Time */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Target Page Load Time <span className="text-red-500">*</span>
-            </label>
-            <div className="relative">
-              <input
-                type="number"
-                step="0.1"
-                value={targetLoadTime}
-                onChange={e => setTargetLoadTime(e.target.value)}
-                placeholder="2.0"
-                className="w-full pl-4 pr-20 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-              />
-              <span className="absolute right-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400">
-                seconds
-              </span>
-            </div>
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-              Your target load time (recommended: under 3 seconds)
-            </p>
-          </div>
+      <ToolField
+        label="Target Page Load Time"
+        htmlFor="psc-target-load-time"
+        required
+        hint="Your target load time (recommended: under 3 seconds)"
+      >
+        <div className="relative">
+          <ToolInput
+            id="psc-target-load-time"
+            type="number"
+            step="0.1"
+            value={targetLoadTime}
+            onChange={e => setTargetLoadTime(e.target.value)}
+            placeholder="2.0"
+            className="pl-3.5 pr-16"
+          />
+          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500 dark:text-neutral-400">
+            seconds
+          </span>
+        </div>
+      </ToolField>
 
-          {/* Monthly Visitors */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Monthly Visitors <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="number"
-              value={monthlyVisitors}
-              onChange={e => setMonthlyVisitors(e.target.value)}
-              placeholder="50000"
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Total monthly visitors</p>
-          </div>
+      <ToolField label="Monthly Visitors" htmlFor="psc-visitors" required hint="Total monthly visitors">
+        <ToolInput
+          id="psc-visitors"
+          type="number"
+          value={monthlyVisitors}
+          onChange={e => setMonthlyVisitors(e.target.value)}
+          placeholder="50000"
+        />
+      </ToolField>
 
-          {/* Conversion Rate */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Current Conversion Rate <span className="text-red-500">*</span>
-            </label>
-            <div className="relative">
-              <input
-                type="number"
-                step="0.01"
-                value={conversionRate}
-                onChange={e => setConversionRate(e.target.value)}
-                placeholder="2.5"
-                className="w-full pl-4 pr-10 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-              />
-              <span className="absolute right-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400">
-                %
-              </span>
-            </div>
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Your current conversion rate</p>
-          </div>
+      <ToolField
+        label="Current Conversion Rate"
+        htmlFor="psc-conversion-rate"
+        required
+        hint="Your current conversion rate"
+      >
+        <div className="relative">
+          <ToolInput
+            id="psc-conversion-rate"
+            type="number"
+            step="0.01"
+            value={conversionRate}
+            onChange={e => setConversionRate(e.target.value)}
+            placeholder="2.5"
+            className="pl-3.5 pr-10"
+          />
+          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500 dark:text-neutral-400">
+            %
+          </span>
+        </div>
+      </ToolField>
 
-          {/* Average Order Value */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Average Order Value <span className="text-red-500">*</span>
-            </label>
-            <div className="relative">
-              <span className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400">$</span>
-              <input
-                type="number"
-                step="0.01"
-                value={averageOrderValue}
-                onChange={e => setAverageOrderValue(e.target.value)}
-                placeholder="75.00"
-                className="w-full pl-8 pr-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-              />
-            </div>
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Average value per conversion</p>
-          </div>
+      <ToolField
+        label="Average Order Value"
+        htmlFor="psc-aov"
+        required
+        hint="Average value per conversion"
+      >
+        <div className="relative">
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500 dark:text-neutral-400">
+            $
+          </span>
+          <ToolInput
+            id="psc-aov"
+            type="number"
+            step="0.01"
+            value={averageOrderValue}
+            onChange={e => setAverageOrderValue(e.target.value)}
+            placeholder="75.00"
+            className="pl-7 pr-3.5"
+          />
+        </div>
+      </ToolField>
 
-          {/* Results */}
-          {metrics && (
-            <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                  {metrics.monthlyImpact >= 0 ? "Monthly Revenue Gain" : "Monthly Revenue Loss"}
-                </label>
-                <div
-                  className={`px-4 py-6 border rounded-lg text-center ${
-                    metrics.monthlyImpact >= 0
-                      ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-300 dark:border-emerald-800"
-                      : "bg-red-50 dark:bg-red-950/30 border-red-300 dark:border-red-800"
-                  }`}
-                >
-                  <div
-                    className={`text-4xl font-bold ${
-                      metrics.monthlyImpact >= 0
-                        ? "text-emerald-600 dark:text-emerald-400"
-                        : "text-red-600 dark:text-red-400"
-                    }`}
-                  >
-                    {metrics.monthlyImpact >= 0 ? "+" : "-"}$
-                    {Math.abs(metrics.monthlyImpact).toLocaleString(undefined, { maximumFractionDigits: 0 })}
-                  </div>
-                  <div className="text-sm text-neutral-600 dark:text-neutral-400 mt-1">per month</div>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    Annual Impact
-                  </label>
-                  <div
-                    className={`px-4 py-4 border rounded-lg text-center ${
-                      metrics.annualImpact >= 0
-                        ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-300 dark:border-emerald-800"
-                        : "bg-red-50 dark:bg-red-950/30 border-red-300 dark:border-red-800"
-                    }`}
-                  >
-                    <div
-                      className={`text-2xl font-bold ${
-                        metrics.annualImpact >= 0
-                          ? "text-emerald-600 dark:text-emerald-400"
-                          : "text-red-600 dark:text-red-400"
-                      }`}
-                    >
-                      {metrics.annualImpact >= 0 ? "+" : "-"}$
-                      {Math.abs(metrics.annualImpact).toLocaleString(undefined, { maximumFractionDigits: 0 })}
-                    </div>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    Conversion Rate Change
-                  </label>
-                  <div className="px-4 py-4 bg-neutral-100 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-center">
-                    <div className="text-2xl font-bold text-neutral-900 dark:text-white">
-                      {metrics.conversionImpact >= 0 ? "+" : ""}
-                      {metrics.conversionImpact.toFixed(1)}%
-                    </div>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    New Conversion Rate
-                  </label>
-                  <div className="px-4 py-4 bg-blue-50 dark:bg-blue-950/30 border border-blue-300 dark:border-blue-800 rounded-lg text-center">
-                    <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
-                      {metrics.newConversionRate.toFixed(2)}%
-                    </div>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    Bounce Rate Impact
-                  </label>
-                  <div className="px-4 py-4 bg-blue-50 dark:bg-blue-950/30 border border-blue-300 dark:border-blue-800 rounded-lg text-center">
-                    <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
-                      {metrics.timeDifference > 0 ? "+" : ""}
-                      {metrics.bounceRateChange.toFixed(1)}%
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div
-                className={`p-4 rounded-lg border ${
+      {metrics && (
+        <ToolResultDivider>
+          <ToolResult
+            label={metrics.monthlyImpact >= 0 ? "Monthly Revenue Gain" : "Monthly Revenue Loss"}
+            value={
+              <span
+                className={
                   metrics.monthlyImpact >= 0
-                    ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-900 text-emerald-900 dark:text-emerald-200"
-                    : "bg-orange-50 dark:bg-orange-950/30 border-orange-200 dark:border-orange-900 text-orange-900 dark:text-orange-200"
-                }`}
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-red-600 dark:text-red-400"
+                }
               >
-                <h3 className="font-semibold mb-2">Impact Summary:</h3>
-                <ul className="text-sm space-y-1">
-                  <li>
-                    Improving load time from <strong>{currentLoadTime}s</strong> to <strong>{targetLoadTime}s</strong>
-                  </li>
-                  <li>
-                    Conversion rate changes from <strong>{parseFloat(conversionRate).toFixed(2)}%</strong> to{" "}
-                    <strong>{metrics.newConversionRate.toFixed(2)}%</strong>
-                  </li>
-                  <li>
-                    Potential revenue impact:{" "}
-                    <strong>
-                      ${Math.abs(metrics.monthlyImpact).toLocaleString(undefined, { maximumFractionDigits: 0 })}/month
-                    </strong>{" "}
-                    ({metrics.monthlyImpact >= 0 ? "gain" : "loss"})
-                  </li>
-                  <li>Based on industry research: 7% conversion impact per second of load time</li>
-                </ul>
-              </div>
-            </div>
-          )}
+                {metrics.monthlyImpact >= 0 ? "+" : "-"}$
+                {Math.abs(metrics.monthlyImpact).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+              </span>
+            }
+            sub="per month"
+            accent={false}
+          />
 
-          {/* Buttons */}
-          <div className="flex gap-4 pt-4">
-            <button
-              onClick={clearForm}
-              className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-            >
-              Clear
-            </button>
+          <div className="grid grid-cols-2 gap-3">
+            <ToolStat
+              label="Annual Impact"
+              value={
+                <span
+                  className={
+                    metrics.annualImpact >= 0
+                      ? "text-emerald-600 dark:text-emerald-400"
+                      : "text-red-600 dark:text-red-400"
+                  }
+                >
+                  {metrics.annualImpact >= 0 ? "+" : "-"}$
+                  {Math.abs(metrics.annualImpact).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                </span>
+              }
+            />
+            <ToolStat
+              label="Conversion Rate Change"
+              value={`${metrics.conversionImpact >= 0 ? "+" : ""}${metrics.conversionImpact.toFixed(1)}%`}
+            />
+            <ToolStat label="New Conversion Rate" value={`${metrics.newConversionRate.toFixed(2)}%`} />
+            <ToolStat
+              label="Bounce Rate Impact"
+              value={`${metrics.timeDifference > 0 ? "+" : ""}${metrics.bounceRateChange.toFixed(1)}%`}
+            />
           </div>
-        </div>
+
+          <ToolCallout variant={metrics.monthlyImpact >= 0 ? "success" : "warning"} title="Impact Summary:">
+            <ul className="space-y-1">
+              <li>
+                Improving load time from <strong>{currentLoadTime}s</strong> to <strong>{targetLoadTime}s</strong>
+              </li>
+              <li>
+                Conversion rate changes from <strong>{parseFloat(conversionRate).toFixed(2)}%</strong> to{" "}
+                <strong>{metrics.newConversionRate.toFixed(2)}%</strong>
+              </li>
+              <li>
+                Potential revenue impact:{" "}
+                <strong>
+                  ${Math.abs(metrics.monthlyImpact).toLocaleString(undefined, { maximumFractionDigits: 0 })}/month
+                </strong>{" "}
+                ({metrics.monthlyImpact >= 0 ? "gain" : "loss"})
+              </li>
+              <li>Based on industry research: 7% conversion impact per second of load time</li>
+            </ul>
+          </ToolCallout>
+        </ToolResultDivider>
+      )}
+
+      <div className="flex gap-3 pt-2">
+        <ToolButton variant="secondary" onClick={clearForm}>
+          Clear
+        </ToolButton>
       </div>
-
-      {/* FAQ Section */}
-      <div className="mb-16">
-        <h2 className="text-2xl font-bold text-neutral-900 dark:text-white mb-6">Frequently Asked Questions</h2>
-        <div className="bg-neutral-100/50 dark:bg-neutral-800/20 backdrop-blur-sm border border-neutral-300/50 dark:border-neutral-800/50 rounded-xl overflow-hidden">
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="item-1">
-              <AccordionTrigger>How much does page speed really matter?</AccordionTrigger>
-              <AccordionContent>
-                Studies show that for every 1 second delay in page load time, conversions decrease by approximately 7%,
-                bounce rate increases by 7%, and customer satisfaction drops by 16%. A 2-second delay can result in
-                abandonment rates up to 87% for e-commerce sites. This makes page speed a critical business metric.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-2">
-              <AccordionTrigger>What are Google Core Web Vitals and why are they important?</AccordionTrigger>
-              <AccordionContent>
-                Google Core Web Vitals are three key metrics that measure user experience: Largest Contentful Paint
-                (LCP, visual loading speed), First Input Delay (FID, responsiveness), and Cumulative Layout Shift (CLS,
-                visual stability). Google uses these metrics as ranking factors in search results, making them essential
-                for SEO. Meeting these thresholds directly impacts your site's visibility and traffic.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-3">
-              <AccordionTrigger>What's a good page load time?</AccordionTrigger>
-              <AccordionContent>
-                Google recommends pages load in under 3 seconds on mobile. However, the faster the better—pages that
-                load in under 1 second see significantly higher engagement. Amazon found that every 100ms improvement in
-                load time increased revenue by 1%. Most successful e-commerce sites target between 1-2 seconds.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-4">
-              <AccordionTrigger>What are the best ways to improve page speed?</AccordionTrigger>
-              <AccordionContent>
-                Key improvements include: optimizing images (compress and use modern formats like WebP), minifying
-                CSS/JS files, enabling browser caching, using a Content Delivery Network (CDN), reducing server response
-                time, eliminating render-blocking resources, lazy-loading below-the-fold content, and choosing
-                lightweight analytics tools like{" "}
-                <Link href="https://app.rybbit.io" className="text-emerald-600 dark:text-emerald-400 hover:underline">
-                  Rybbit
-                </Link>{" "}
-                which adds minimal overhead (just 3KB).
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-5" className="border-b-0">
-              <AccordionTrigger>How can analytics tools affect my page speed?</AccordionTrigger>
-              <AccordionContent>
-                Many analytics tools can significantly impact page performance by loading large scripts synchronously
-                and making blocking network requests. This reduces your page's speed and negatively affects user
-                experience. Tools like Rybbit are designed to minimize this impact with lightweight asynchronous loading
-                (3KB script, loaded after page interactive), ensuring you get the insights you need without compromising
-                performance.
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </div>
-      </div>
-
-      {/* CTA */}
-      <div className="border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-20">
-        <div className="max-w-4xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 dark:text-white mb-4">
-            Lightning-fast analytics that won't slow you down
-          </h2>
-          <p className="text-lg text-neutral-600 dark:text-neutral-400 mb-8 max-w-2xl mx-auto">
-            Rybbit's tiny 3KB script loads asynchronously and won't impact your page speed. Get started for free with up
-            to {DEFAULT_EVENT_LIMIT.toLocaleString()} pageviews per month.
-          </p>
-          <TrackedButton
-            href="https://app.rybbit.io/signup"
-            eventName="signup"
-            eventProps={{ location: "page_speed_calculator_cta" }}
-            className="inline-block bg-emerald-600 hover:bg-emerald-500 text-white font-semibold px-10 py-4 text-lg rounded-lg shadow-lg shadow-emerald-900/20 transform hover:-translate-y-0.5 transition-all duration-200"
-          >
-            Start tracking for free
-          </TrackedButton>
-        </div>
-      </div>
-    </>
+    </div>
   );
 }

--- a/docs/src/app/[locale]/(home)/tools/privacy-policy-builder/PrivacyPolicyBuilderForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/privacy-policy-builder/PrivacyPolicyBuilderForm.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { TrackedButton } from "@/components/TrackedButton";
-import { CheckCircle, Copy } from "lucide-react";
 import { useState } from "react";
+import { CopyButton, ToolButton, ToolField, ToolInput } from "../components/tool-ui";
 
 export function PrivacyPolicyBuilderForm() {
   const [companyName, setCompanyName] = useState("");
@@ -12,7 +11,6 @@ export function PrivacyPolicyBuilderForm() {
   const [usesCookies, setUsesCookies] = useState(false);
   const [usesAnalytics, setUsesAnalytics] = useState(false);
   const [sharesData, setSharesData] = useState(false);
-  const [copied, setCopied] = useState(false);
 
   const generatePolicy = () => {
     if (!companyName || !websiteUrl || !contactEmail) return "";
@@ -126,14 +124,6 @@ If you have any questions about this Privacy Policy, please contact us at:
 
   const policy = generatePolicy();
 
-  const copyToClipboard = async () => {
-    if (policy) {
-      await navigator.clipboard.writeText(policy);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
-  };
-
   const downloadPolicy = () => {
     if (!policy) return;
 
@@ -156,179 +146,122 @@ If you have any questions about this Privacy Policy, please contact us at:
     setUsesCookies(false);
     setUsesAnalytics(false);
     setSharesData(false);
-    setCopied(false);
   };
 
   return (
-    <div className="mb-16">
-      <div className="space-y-6">
-        {/* Company Name */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-            Company Name <span className="text-red-500">*</span>
-          </label>
+    <div className="space-y-6">
+      <ToolField label="Company Name" htmlFor="privacy-company" required>
+        <ToolInput
+          id="privacy-company"
+          type="text"
+          value={companyName}
+          onChange={e => setCompanyName(e.target.value)}
+          placeholder="Acme Inc."
+        />
+      </ToolField>
+
+      <ToolField label="Website URL" htmlFor="privacy-url" required>
+        <ToolInput
+          id="privacy-url"
+          type="text"
+          value={websiteUrl}
+          onChange={e => setWebsiteUrl(e.target.value)}
+          placeholder="https://example.com"
+        />
+      </ToolField>
+
+      <ToolField label="Contact Email" htmlFor="privacy-email" required>
+        <ToolInput
+          id="privacy-email"
+          type="email"
+          value={contactEmail}
+          onChange={e => setContactEmail(e.target.value)}
+          placeholder="privacy@example.com"
+        />
+      </ToolField>
+
+      {/* Checkboxes */}
+      <div className="space-y-3 border-t border-neutral-200 pt-4 dark:border-neutral-800">
+        <p className="mb-3 text-sm font-medium text-neutral-900 dark:text-white">What does your website do?</p>
+
+        <label className="flex cursor-pointer items-start gap-3">
           <input
-            type="text"
-            value={companyName}
-            onChange={e => setCompanyName(e.target.value)}
-            placeholder="Acme Inc."
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            type="checkbox"
+            checked={collectsPersonalData}
+            onChange={e => setCollectsPersonalData(e.target.checked)}
+            className="mt-1 size-4 rounded border-neutral-300 text-emerald-600 focus:ring-emerald-500 dark:border-neutral-700"
           />
-        </div>
-
-        {/* Website URL */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-            Website URL <span className="text-red-500">*</span>
-          </label>
-          <input
-            type="text"
-            value={websiteUrl}
-            onChange={e => setWebsiteUrl(e.target.value)}
-            placeholder="https://example.com"
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-          />
-        </div>
-
-        {/* Contact Email */}
-        <div>
-          <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-            Contact Email <span className="text-red-500">*</span>
-          </label>
-          <input
-            type="email"
-            value={contactEmail}
-            onChange={e => setContactEmail(e.target.value)}
-            placeholder="privacy@example.com"
-            className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-          />
-        </div>
-
-        {/* Checkboxes */}
-        <div className="space-y-3 pt-4 border-t border-neutral-200 dark:border-neutral-800">
-          <p className="text-sm font-medium text-neutral-900 dark:text-white mb-3">What does your website do?</p>
-
-          <label className="flex items-start gap-3 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={collectsPersonalData}
-              onChange={e => setCollectsPersonalData(e.target.checked)}
-              className="mt-1 w-4 h-4 text-emerald-600 border-neutral-300 dark:border-neutral-700 rounded focus:ring-emerald-500"
-            />
-            <div>
-              <div className="text-sm font-medium text-neutral-900 dark:text-white">Collects personal data</div>
-              <div className="text-xs text-neutral-600 dark:text-neutral-400">
-                Name, email, phone number, payment info, etc.
-              </div>
-            </div>
-          </label>
-
-          <label className="flex items-start gap-3 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={usesCookies}
-              onChange={e => setUsesCookies(e.target.checked)}
-              className="mt-1 w-4 h-4 text-emerald-600 border-neutral-300 dark:border-neutral-700 rounded focus:ring-emerald-500"
-            />
-            <div>
-              <div className="text-sm font-medium text-neutral-900 dark:text-white">Uses cookies</div>
-              <div className="text-xs text-neutral-600 dark:text-neutral-400">
-                Session cookies, tracking cookies, etc.
-              </div>
-            </div>
-          </label>
-
-          <label className="flex items-start gap-3 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={usesAnalytics}
-              onChange={e => setUsesAnalytics(e.target.checked)}
-              className="mt-1 w-4 h-4 text-emerald-600 border-neutral-300 dark:border-neutral-700 rounded focus:ring-emerald-500"
-            />
-            <div>
-              <div className="text-sm font-medium text-neutral-900 dark:text-white">Uses analytics</div>
-              <div className="text-xs text-neutral-600 dark:text-neutral-400">
-                Google Analytics, Rybbit, Plausible, etc.
-              </div>
-            </div>
-          </label>
-
-          <label className="flex items-start gap-3 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={sharesData}
-              onChange={e => setSharesData(e.target.checked)}
-              className="mt-1 w-4 h-4 text-emerald-600 border-neutral-300 dark:border-neutral-700 rounded focus:ring-emerald-500"
-            />
-            <div>
-              <div className="text-sm font-medium text-neutral-900 dark:text-white">Shares data with third parties</div>
-              <div className="text-xs text-neutral-600 dark:text-neutral-400">
-                Service providers, partners, advertisers, etc.
-              </div>
-            </div>
-          </label>
-        </div>
-
-        {/* Preview */}
-        {policy && (
-          <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800">
-            <div className="flex items-center justify-between mb-3">
-              <label className="block text-sm font-medium text-neutral-900 dark:text-white">
-                Your Privacy Policy (Markdown)
-              </label>
-              <div className="flex gap-2">
-                <button
-                  onClick={copyToClipboard}
-                  className="px-4 py-2 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2"
-                >
-                  {copied ? <CheckCircle className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-                  {copied ? "Copied!" : "Copy"}
-                </button>
-                <button
-                  onClick={downloadPolicy}
-                  className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-medium rounded-lg transition-colors"
-                >
-                  Download
-                </button>
-              </div>
-            </div>
-            <div className="max-h-96 overflow-y-auto p-4 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg">
-              <pre className="text-xs text-neutral-900 dark:text-neutral-100 whitespace-pre-wrap font-mono">
-                {policy}
-              </pre>
+          <div>
+            <div className="text-sm font-medium text-neutral-900 dark:text-white">Collects personal data</div>
+            <div className="text-xs text-neutral-600 dark:text-neutral-400">
+              Name, email, phone number, payment info, etc.
             </div>
           </div>
-        )}
+        </label>
 
-        {/* Buttons */}
-        <div className="flex gap-4 pt-4">
-          <button
-            onClick={clearForm}
-            className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-          >
-            Clear
-          </button>
-        </div>
+        <label className="flex cursor-pointer items-start gap-3">
+          <input
+            type="checkbox"
+            checked={usesCookies}
+            onChange={e => setUsesCookies(e.target.checked)}
+            className="mt-1 size-4 rounded border-neutral-300 text-emerald-600 focus:ring-emerald-500 dark:border-neutral-700"
+          />
+          <div>
+            <div className="text-sm font-medium text-neutral-900 dark:text-white">Uses cookies</div>
+            <div className="text-xs text-neutral-600 dark:text-neutral-400">Session cookies, tracking cookies, etc.</div>
+          </div>
+        </label>
+
+        <label className="flex cursor-pointer items-start gap-3">
+          <input
+            type="checkbox"
+            checked={usesAnalytics}
+            onChange={e => setUsesAnalytics(e.target.checked)}
+            className="mt-1 size-4 rounded border-neutral-300 text-emerald-600 focus:ring-emerald-500 dark:border-neutral-700"
+          />
+          <div>
+            <div className="text-sm font-medium text-neutral-900 dark:text-white">Uses analytics</div>
+            <div className="text-xs text-neutral-600 dark:text-neutral-400">Google Analytics, Rybbit, Plausible, etc.</div>
+          </div>
+        </label>
+
+        <label className="flex cursor-pointer items-start gap-3">
+          <input
+            type="checkbox"
+            checked={sharesData}
+            onChange={e => setSharesData(e.target.checked)}
+            className="mt-1 size-4 rounded border-neutral-300 text-emerald-600 focus:ring-emerald-500 dark:border-neutral-700"
+          />
+          <div>
+            <div className="text-sm font-medium text-neutral-900 dark:text-white">Shares data with third parties</div>
+            <div className="text-xs text-neutral-600 dark:text-neutral-400">
+              Service providers, partners, advertisers, etc.
+            </div>
+          </div>
+        </label>
       </div>
 
-      {/* CTA */}
-      <div className="border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-20 -mx-6 mt-16">
-        <div className="max-w-4xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 dark:text-white mb-4">
-            Privacy-first analytics with Rybbit
-          </h2>
-          <p className="text-lg text-neutral-600 dark:text-neutral-400 mb-8 max-w-2xl mx-auto">
-            No cookies, no tracking, full GDPR compliance. Get powerful analytics without compromising your users' privacy.
-          </p>
-          <TrackedButton
-            href="https://app.rybbit.io/signup"
-            eventName="signup"
-            eventProps={{ location: "privacy_policy_builder_cta" }}
-            className="inline-block bg-emerald-600 hover:bg-emerald-500 text-white font-semibold px-10 py-4 text-lg rounded-lg shadow-lg shadow-emerald-900/20 transform hover:-translate-y-0.5 transition-all duration-200"
-          >
-            Start tracking for free
-          </TrackedButton>
+      {/* Preview */}
+      {policy && (
+        <div className="border-t border-neutral-200 pt-6 dark:border-neutral-800">
+          <div className="mb-3 flex items-center justify-between gap-4">
+            <span className="text-sm font-medium text-neutral-900 dark:text-white">Your Privacy Policy (Markdown)</span>
+            <div className="flex gap-2">
+              <CopyButton value={policy} copiedLabel="Copied!" />
+              <ToolButton onClick={downloadPolicy}>Download</ToolButton>
+            </div>
+          </div>
+          <div className="max-h-96 overflow-y-auto rounded-md border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900/50">
+            <pre className="whitespace-pre-wrap font-mono text-xs text-neutral-900 dark:text-neutral-100">{policy}</pre>
+          </div>
         </div>
+      )}
+
+      {/* Buttons */}
+      <div className="flex gap-4 pt-4">
+        <ToolButton variant="secondary" onClick={clearForm}>
+          Clear
+        </ToolButton>
       </div>
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/retention-rate-calculator/RetentionRateForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/retention-rate-calculator/RetentionRateForm.tsx
@@ -1,6 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResult,
+  ToolResultDivider,
+  ToolSelect,
+  ToolStat,
+} from "../components/tool-ui";
 
 export function RetentionRateForm() {
   const [customersStart, setCustomersStart] = useState("");
@@ -54,203 +64,140 @@ export function RetentionRateForm() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Customers at Start of Period <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Customers at Start of Period"
+        htmlFor="rr-start"
+        required
+        hint="Number of customers at the beginning of the period"
+      >
+        <ToolInput
+          id="rr-start"
           type="number"
           value={customersStart}
-          onChange={(e) => setCustomersStart(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateRetentionRate()}
+          onChange={e => setCustomersStart(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateRetentionRate()}
           placeholder="1000"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Number of customers at the beginning of the period
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Customers at End of Period <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="Customers at End of Period"
+        htmlFor="rr-end"
+        required
+        hint="Number of customers at the end of the period"
+      >
+        <ToolInput
+          id="rr-end"
           type="number"
           value={customersEnd}
-          onChange={(e) => setCustomersEnd(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateRetentionRate()}
+          onChange={e => setCustomersEnd(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateRetentionRate()}
           placeholder="920"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Number of customers at the end of the period
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          New Customers Acquired <span className="text-red-500">*</span>
-        </label>
-        <input
+      <ToolField
+        label="New Customers Acquired"
+        htmlFor="rr-new"
+        required
+        hint="Number of new customers acquired during the period"
+      >
+        <ToolInput
+          id="rr-new"
           type="number"
           value={newCustomers}
-          onChange={(e) => setNewCustomers(e.target.value)}
-          onKeyPress={(e) => e.key === "Enter" && calculateRetentionRate()}
+          onChange={e => setNewCustomers(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && calculateRetentionRate()}
           placeholder="150"
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
         />
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Number of new customers acquired during the period
-        </p>
-      </div>
+      </ToolField>
 
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Industry
-        </label>
-        <select
-          value={selectedIndustry}
-          onChange={(e) => setSelectedIndustry(e.target.value)}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
-        >
-          {Object.keys(industryBenchmarks).map((industry) => (
+      <ToolField label="Industry" htmlFor="rr-industry" hint="Select your industry to compare against benchmarks">
+        <ToolSelect id="rr-industry" value={selectedIndustry} onChange={e => setSelectedIndustry(e.target.value)}>
+          {Object.keys(industryBenchmarks).map(industry => (
             <option key={industry} value={industry}>
               {industry}
             </option>
           ))}
-        </select>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Select your industry to compare against benchmarks
-        </p>
-      </div>
+        </ToolSelect>
+      </ToolField>
 
       {retentionRate !== null && (
-        <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-          <div className="px-4 py-6 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-center">
-            <div className="text-sm text-emerald-700 dark:text-emerald-300 font-medium mb-2">
-              Retention Rate
-            </div>
-            <div className="text-4xl font-bold text-emerald-600 dark:text-emerald-400">
-              {retentionRate.toFixed(2)}%
-            </div>
-            <div className="text-xs text-emerald-700 dark:text-emerald-300 mt-2">
-              Churn Rate: {(100 - retentionRate).toFixed(2)}%
-            </div>
-          </div>
+        <ToolResultDivider>
+          <ToolResult
+            label="Retention Rate"
+            value={`${retentionRate.toFixed(2)}%`}
+            sub={`Churn Rate: ${(100 - retentionRate).toFixed(2)}%`}
+          />
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
             {monthlyComparison && (
-              <div
-                className={`px-4 py-4 rounded-lg border ${
-                  monthlyComparison.difference >= 0
-                    ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-300 dark:border-emerald-800"
-                    : "bg-orange-50 dark:bg-orange-950/30 border-orange-200 dark:border-orange-900"
-                }`}
+              <ToolCallout
+                variant={monthlyComparison.difference >= 0 ? "success" : "warning"}
+                icon={null}
+                title={`Monthly Benchmark — ${monthlyComparison.benchmark}%`}
               >
-                <div className="text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                  Monthly Benchmark
-                </div>
-                <div className="text-2xl font-bold text-neutral-900 dark:text-white mb-2">
-                  {monthlyComparison.benchmark}%
-                </div>
-                <div className="text-sm text-neutral-700 dark:text-neutral-300">
-                  {monthlyComparison.difference >= 0 ? (
-                    <>
-                      <span className="font-semibold text-emerald-600 dark:text-emerald-400">
-                        {monthlyComparison.difference.toFixed(1)}%
-                      </span>{" "}
-                      above average
-                    </>
-                  ) : (
-                    <>
-                      <span className="font-semibold text-orange-600 dark:text-orange-400">
-                        {Math.abs(monthlyComparison.difference).toFixed(1)}%
-                      </span>{" "}
-                      below average
-                    </>
-                  )}
-                </div>
-              </div>
+                {monthlyComparison.difference >= 0 ? (
+                  <>
+                    <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+                      {monthlyComparison.difference.toFixed(1)}%
+                    </span>{" "}
+                    above average
+                  </>
+                ) : (
+                  <>
+                    <span className="font-semibold text-amber-600 dark:text-amber-500">
+                      {Math.abs(monthlyComparison.difference).toFixed(1)}%
+                    </span>{" "}
+                    below average
+                  </>
+                )}
+              </ToolCallout>
             )}
 
             {annualComparison && (
-              <div
-                className={`px-4 py-4 rounded-lg border ${
-                  annualComparison.difference >= 0
-                    ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-300 dark:border-emerald-800"
-                    : "bg-orange-50 dark:bg-orange-950/30 border-orange-200 dark:border-orange-900"
-                }`}
+              <ToolCallout
+                variant={annualComparison.difference >= 0 ? "success" : "warning"}
+                icon={null}
+                title={`Annual Benchmark — ${annualComparison.benchmark}%`}
               >
-                <div className="text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                  Annual Benchmark
-                </div>
-                <div className="text-2xl font-bold text-neutral-900 dark:text-white mb-2">
-                  {annualComparison.benchmark}%
-                </div>
-                <div className="text-sm text-neutral-700 dark:text-neutral-300">
-                  {annualComparison.difference >= 0 ? (
-                    <>
-                      <span className="font-semibold text-emerald-600 dark:text-emerald-400">
-                        {annualComparison.difference.toFixed(1)}%
-                      </span>{" "}
-                      above average
-                    </>
-                  ) : (
-                    <>
-                      <span className="font-semibold text-orange-600 dark:text-orange-400">
-                        {Math.abs(annualComparison.difference).toFixed(1)}%
-                      </span>{" "}
-                      below average
-                    </>
-                  )}
-                </div>
-              </div>
+                {annualComparison.difference >= 0 ? (
+                  <>
+                    <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+                      {annualComparison.difference.toFixed(1)}%
+                    </span>{" "}
+                    above average
+                  </>
+                ) : (
+                  <>
+                    <span className="font-semibold text-amber-600 dark:text-amber-500">
+                      {Math.abs(annualComparison.difference).toFixed(1)}%
+                    </span>{" "}
+                    below average
+                  </>
+                )}
+              </ToolCallout>
             )}
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Starting Customers
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                {parseFloat(customersStart).toLocaleString()}
-              </div>
-            </div>
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Ending Customers
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                {parseFloat(customersEnd).toLocaleString()}
-              </div>
-            </div>
-            <div className="px-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-lg">
-              <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-                Retained Customers
-              </div>
-              <div className="text-lg font-semibold text-neutral-900 dark:text-white">
-                {(parseFloat(customersEnd) - parseFloat(newCustomers)).toLocaleString()}
-              </div>
-            </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <ToolStat label="Starting Customers" value={parseFloat(customersStart).toLocaleString()} />
+            <ToolStat label="Ending Customers" value={parseFloat(customersEnd).toLocaleString()} />
+            <ToolStat
+              label="Retained Customers"
+              value={(parseFloat(customersEnd) - parseFloat(newCustomers)).toLocaleString()}
+            />
           </div>
-        </div>
+        </ToolResultDivider>
       )}
 
-      <div className="flex gap-4 pt-4">
-        <button
-          onClick={calculateRetentionRate}
-          className="flex-1 px-6 py-3 bg-emerald-600 hover:bg-emerald-500 text-white font-medium rounded-lg transition-colors"
-        >
+      <div className="flex gap-3 pt-2">
+        <ToolButton onClick={calculateRetentionRate} className="flex-1">
           Calculate Retention Rate
-        </button>
-        <button
-          onClick={clearForm}
-          className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-        >
+        </ToolButton>
+        <ToolButton variant="secondary" onClick={clearForm}>
           Clear
-        </button>
+        </ToolButton>
       </div>
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/sample-size-calculator/SampleSizeForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/sample-size-calculator/SampleSizeForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { ToolButton, ToolCallout, ToolField, ToolInput, ToolResult, ToolResultDivider, ToolSelect, ToolStat } from "../components/tool-ui";
 
 export function SampleSizeForm() {
   const [baselineConversion, setBaselineConversion] = useState("");
@@ -44,134 +45,106 @@ export function SampleSizeForm() {
 
   return (
     <div className="space-y-6">
-      {/* Baseline Conversion Rate */}
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Baseline Conversion Rate <span className="text-red-500">*</span>
-        </label>
+      <ToolField
+        label="Baseline Conversion Rate"
+        htmlFor="ssc-baseline"
+        required
+        hint="Your current conversion rate (control variant)"
+      >
         <div className="relative">
-          <input
+          <ToolInput
+            id="ssc-baseline"
             type="number"
             step="0.1"
             value={baselineConversion}
             onChange={e => setBaselineConversion(e.target.value)}
             placeholder="2.5"
-            className="w-full pl-4 pr-10 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            className="pr-10"
           />
-          <span className="absolute right-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400">%</span>
+          <span className="pointer-events-none absolute right-3.5 top-1/2 -translate-y-1/2 text-sm text-neutral-500 dark:text-neutral-400">
+            %
+          </span>
         </div>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Your current conversion rate (control variant)</p>
-      </div>
+      </ToolField>
 
-      {/* Minimum Detectable Effect */}
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-          Minimum Detectable Effect (MDE) <span className="text-red-500">*</span>
-        </label>
+      <ToolField
+        label="Minimum Detectable Effect (MDE)"
+        htmlFor="ssc-mde"
+        required
+        hint="Smallest improvement you want to detect (e.g., 0.5% absolute increase)"
+      >
         <div className="relative">
-          <input
+          <ToolInput
+            id="ssc-mde"
             type="number"
             step="0.1"
             value={minimumDetectableEffect}
             onChange={e => setMinimumDetectableEffect(e.target.value)}
             placeholder="0.5"
-            className="w-full pl-4 pr-10 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            className="pr-10"
           />
-          <span className="absolute right-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400">%</span>
+          <span className="pointer-events-none absolute right-3.5 top-1/2 -translate-y-1/2 text-sm text-neutral-500 dark:text-neutral-400">
+            %
+          </span>
         </div>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Smallest improvement you want to detect (e.g., 0.5% absolute increase)
-        </p>
-      </div>
+      </ToolField>
 
-      {/* Confidence Level */}
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">Confidence Level</label>
-        <select
-          value={confidenceLevel}
-          onChange={e => setConfidenceLevel(e.target.value)}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
-        >
+      <ToolField
+        label="Confidence Level"
+        htmlFor="ssc-confidence"
+        hint="How confident you want to be in your results"
+      >
+        <ToolSelect id="ssc-confidence" value={confidenceLevel} onChange={e => setConfidenceLevel(e.target.value)}>
           <option value="90">90% (10% chance of false positive)</option>
           <option value="95">95% (5% chance of false positive) - Recommended</option>
           <option value="99">99% (1% chance of false positive)</option>
-        </select>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          How confident you want to be in your results
-        </p>
-      </div>
+        </ToolSelect>
+      </ToolField>
 
-      {/* Statistical Power */}
-      <div>
-        <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">Statistical Power</label>
-        <select
-          value={statisticalPower}
-          onChange={e => setStatisticalPower(e.target.value)}
-          className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
-        >
+      <ToolField
+        label="Statistical Power"
+        htmlFor="ssc-power"
+        hint="Probability of detecting an effect if it exists"
+      >
+        <ToolSelect id="ssc-power" value={statisticalPower} onChange={e => setStatisticalPower(e.target.value)}>
           <option value="80">80% (20% chance of false negative) - Recommended</option>
           <option value="90">90% (10% chance of false negative)</option>
-        </select>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Probability of detecting an effect if it exists
-        </p>
-      </div>
+        </ToolSelect>
+      </ToolField>
 
-      {/* Results */}
       {sampleSize !== null && totalVisitors !== null && (
-        <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Sample Size Per Variant
-            </label>
-            <div className="px-4 py-6 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-center">
-              <div className="text-4xl font-bold text-emerald-600 dark:text-emerald-400">
-                {sampleSize.toLocaleString()}
-              </div>
-              <div className="text-sm text-neutral-600 dark:text-neutral-400 mt-1">visitors per variant (A and B)</div>
-            </div>
-          </div>
+        <ToolResultDivider>
+          <ToolResult
+            label="Sample Size Per Variant"
+            value={sampleSize.toLocaleString()}
+            sub="visitors per variant (A and B)"
+          />
 
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Total Test Size
-            </label>
-            <div className="px-4 py-6 bg-blue-50 dark:bg-blue-950/30 border border-blue-300 dark:border-blue-800 rounded-lg text-center">
-              <div className="text-4xl font-bold text-blue-600 dark:text-blue-400">
-                {totalVisitors.toLocaleString()}
-              </div>
-              <div className="text-sm text-neutral-600 dark:text-neutral-400 mt-1">total visitors needed</div>
-            </div>
-          </div>
+          <ToolStat label="Total Test Size" value={`${totalVisitors.toLocaleString()} total visitors needed`} />
 
-          <div className="p-4 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded-lg">
-            <p className="text-sm text-blue-900 dark:text-blue-200">
-              <strong>Test Duration:</strong> If you get 1,000 visitors per day, you'll need approximately{" "}
-              <strong>{Math.ceil(totalVisitors / 1000)} days</strong> to complete this test. At 5,000 visitors per day,
-              you'll need <strong>{Math.ceil(totalVisitors / 5000)} days</strong>.
-            </p>
-          </div>
+          <ToolCallout variant="info" title="Test Duration">
+            If you get 1,000 visitors per day, you&apos;ll need approximately{" "}
+            <strong>{Math.ceil(totalVisitors / 1000)} days</strong> to complete this test. At 5,000 visitors per day,
+            you&apos;ll need <strong>{Math.ceil(totalVisitors / 5000)} days</strong>.
+          </ToolCallout>
 
-          <div className="p-4 bg-neutral-100 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg">
-            <h3 className="font-semibold text-neutral-900 dark:text-white mb-2">What this means:</h3>
-            <ul className="text-sm text-neutral-700 dark:text-neutral-300 space-y-1">
+          <ToolCallout variant="tip" title="What this means:">
+            <ul className="space-y-1">
               <li>You need {sampleSize.toLocaleString()} visitors to see variant A (control)</li>
               <li>You need {sampleSize.toLocaleString()} visitors to see variant B (treatment)</li>
-              <li>This gives you {confidenceLevel}% confidence in detecting a {minimumDetectableEffect}% improvement</li>
+              <li>
+                This gives you {confidenceLevel}% confidence in detecting a {minimumDetectableEffect}% improvement
+              </li>
               <li>With {statisticalPower}% power to avoid false negatives</li>
             </ul>
-          </div>
-        </div>
+          </ToolCallout>
+        </ToolResultDivider>
       )}
 
-      {/* Buttons */}
-      <div className="flex gap-4 pt-4">
-        <button
-          onClick={clearForm}
-          className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-        >
+      <div className="flex gap-3 pt-2">
+        <ToolButton variant="secondary" onClick={clearForm}>
           Clear
-        </button>
+        </ToolButton>
       </div>
     </div>
   );

--- a/docs/src/app/[locale]/(home)/tools/seo-title-generator/SEOTitleForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/seo-title-generator/SEOTitleForm.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { TrackedButton } from "@/components/TrackedButton";
-import { DEFAULT_EVENT_LIMIT } from "@/lib/const";
-import { CheckCircle, Copy, Loader2 } from "lucide-react";
-import Link from "next/link";
 import { useState } from "react";
+import { CopyButton, ToolButton, ToolCallout, ToolField, ToolInput } from "../components/tool-ui";
 
 interface TitleOption {
   title: string;
@@ -18,7 +15,6 @@ export function SEOTitleForm() {
   const [titles, setTitles] = useState<TitleOption[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
   const [remainingRequests, setRemainingRequests] = useState<number | null>(null);
 
   const generateTitles = async () => {
@@ -55,143 +51,73 @@ export function SEOTitleForm() {
     }
   };
 
-  const copyTitle = async (title: string, index: number) => {
-    await navigator.clipboard.writeText(title);
-    setCopiedIndex(index);
-    setTimeout(() => setCopiedIndex(null), 2000);
-  };
-
   const getLengthColor = (length: number) => {
     if (length >= 50 && length <= 60) return "text-emerald-600 dark:text-emerald-400";
-    if (length > 60 && length <= 70) return "text-orange-600 dark:text-orange-400";
+    if (length > 60 && length <= 70) return "text-amber-600 dark:text-amber-500";
     return "text-red-600 dark:text-red-400";
   };
 
   return (
-    <>
+    <div className="space-y-6">
       {remainingRequests !== null && (
-        <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-4">
-          {remainingRequests} requests remaining this minute
-        </p>
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">{remainingRequests} requests remaining this minute</p>
       )}
 
-      <div className="mb-16">
-        <div className="space-y-6">
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Page Topic <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="text"
-              value={topic}
-              onChange={e => setTopic(e.target.value)}
-              placeholder="e.g., Best Project Management Software for Teams"
-              disabled={isLoading}
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50"
-            />
-          </div>
+      <ToolField label="Page Topic" htmlFor="seo-topic" required>
+        <ToolInput
+          id="seo-topic"
+          type="text"
+          value={topic}
+          onChange={e => setTopic(e.target.value)}
+          placeholder="e.g., Best Project Management Software for Teams"
+          disabled={isLoading}
+        />
+      </ToolField>
 
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Target Keywords (Optional)
-            </label>
-            <input
-              type="text"
-              value={keywords}
-              onChange={e => setKeywords(e.target.value)}
-              placeholder="e.g., project management, team collaboration, productivity"
-              disabled={isLoading}
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50"
-            />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Comma-separated keywords to include</p>
-          </div>
+      <ToolField
+        label="Target Keywords"
+        htmlFor="seo-keywords"
+        hint="Comma-separated keywords to include (optional)"
+      >
+        <ToolInput
+          id="seo-keywords"
+          type="text"
+          value={keywords}
+          onChange={e => setKeywords(e.target.value)}
+          placeholder="e.g., project management, team collaboration, productivity"
+          disabled={isLoading}
+        />
+      </ToolField>
 
-          {error && (
-            <div className="p-4 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded-lg">
-              <p className="text-sm text-red-900 dark:text-red-200">{error}</p>
-            </div>
-          )}
+      {error && <ToolCallout variant="error">{error}</ToolCallout>}
 
-          <button
-            onClick={generateTitles}
-            disabled={isLoading}
-            className="w-full px-6 py-3 bg-emerald-600 hover:bg-emerald-500 disabled:bg-neutral-400 dark:disabled:bg-neutral-700 text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
-          >
-            {isLoading ? (
-              <>
-                <Loader2 className="w-5 h-5 animate-spin" />
-                Generating Titles...
-              </>
-            ) : (
-              "Generate SEO Titles"
-            )}
-          </button>
+      <ToolButton onClick={generateTitles} loading={isLoading} className="w-full">
+        {isLoading ? "Generating titles…" : "Generate SEO titles"}
+      </ToolButton>
 
-          {titles.length > 0 && (
-            <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-3">
-              <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">Generated Titles</h3>
-              {titles.map((option, index) => (
-                <div
-                  key={index}
-                  className="p-4 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:border-emerald-500/40 dark:hover:border-emerald-500/30 transition-colors"
-                >
-                  <div className="flex items-start justify-between gap-4 mb-2">
-                    <p className="flex-1 text-neutral-900 dark:text-white font-medium">{option.title}</p>
-                    <button
-                      onClick={() => copyTitle(option.title, index)}
-                      className="flex-shrink-0 px-3 py-1.5 bg-neutral-200 dark:bg-neutral-700 hover:bg-neutral-300 dark:hover:bg-neutral-600 text-neutral-900 dark:text-white text-sm rounded-lg transition-colors flex items-center gap-2"
-                    >
-                      {copiedIndex === index ? (
-                        <>
-                          <CheckCircle className="w-4 h-4" />
-                          Copied
-                        </>
-                      ) : (
-                        <>
-                          <Copy className="w-4 h-4" />
-                          Copy
-                        </>
-                      )}
-                    </button>
-                  </div>
-                  <div className="flex items-center gap-4 text-xs">
-                    <span className={`font-medium ${getLengthColor(option.length)}`}>{option.length} characters</span>
-
-                    <span className="text-neutral-600 dark:text-neutral-400">{option.approach}</span>
-                  </div>
-                </div>
-              ))}
-              <div className="p-3 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded-lg">
-                <p className="text-sm text-blue-900 dark:text-blue-200">
-                  <strong>Tip:</strong> Optimal title length is 50-60 characters. Longer titles may be truncated in
-                  search results.
-                </p>
+      {titles.length > 0 && (
+        <div className="space-y-3 border-t border-neutral-200 pt-6 dark:border-neutral-800">
+          <h3 className="text-base font-semibold text-neutral-900 dark:text-white">Generated titles</h3>
+          {titles.map((option, index) => (
+            <div
+              key={index}
+              className="rounded-md border border-neutral-200 bg-neutral-50 p-4 transition-colors hover:border-neutral-300 dark:border-neutral-800 dark:bg-neutral-900/50 dark:hover:border-neutral-700"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <p className="flex-1 font-medium text-neutral-900 dark:text-white">{option.title}</p>
+                <CopyButton value={option.title} className="shrink-0" />
+              </div>
+              <div className="mt-2 flex items-center gap-4 text-xs">
+                <span className={`font-medium ${getLengthColor(option.length)}`}>{option.length} characters</span>
+                <span className="text-neutral-500 dark:text-neutral-400">{option.approach}</span>
               </div>
             </div>
-          )}
+          ))}
+          <ToolCallout variant="tip">
+            Optimal title length is 50–60 characters. Longer titles may be truncated in search results.
+          </ToolCallout>
         </div>
-      </div>
-
-      {/* CTA */}
-      <div className="border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-20 -mx-6">
-        <div className="max-w-4xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 dark:text-white mb-4">
-            Track your SEO performance with Rybbit
-          </h2>
-          <p className="text-lg text-neutral-600 dark:text-neutral-400 mb-8 max-w-2xl mx-auto">
-            See which pages drive organic traffic and optimize your titles based on real data. Get started for free with
-            up to {DEFAULT_EVENT_LIMIT.toLocaleString()} pageviews per month.
-          </p>
-          <TrackedButton
-            href="https://app.rybbit.io/signup"
-            eventName="signup"
-            eventProps={{ location: "seo_title_generator_cta" }}
-            className="inline-block bg-emerald-600 hover:bg-emerald-500 text-white font-semibold px-10 py-4 text-lg rounded-lg shadow-lg shadow-emerald-900/20 transform hover:-translate-y-0.5 transition-all duration-200"
-          >
-            Start tracking for free
-          </TrackedButton>
-        </div>
-      </div>
-    </>
+      )}
+    </div>
   );
 }

--- a/docs/src/app/[locale]/(home)/tools/traffic-value-calculator/TrafficValueForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/traffic-value-calculator/TrafficValueForm.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import Link from "next/link";
 import { useState } from "react";
+import {
+  ToolButton,
+  ToolCallout,
+  ToolField,
+  ToolInput,
+  ToolResult,
+  ToolResultDivider,
+  ToolStat,
+} from "../components/tool-ui";
 
 export function TrafficValueForm() {
   const [monthlyVisitors, setMonthlyVisitors] = useState("");
@@ -43,234 +50,140 @@ export function TrafficValueForm() {
   };
 
   return (
-    <>
-      {/* Tool Section */}
-      <div className="mb-16">
-        <div className="space-y-6">
-          {/* Monthly Visitors */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Monthly Visitors <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="number"
-              value={monthlyVisitors}
-              onChange={(e) => setMonthlyVisitors(e.target.value)}
-              placeholder="50000"
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+    <div className="space-y-6">
+      <ToolField label="Monthly Visitors" htmlFor="tvc-visitors" required hint="Total visitors per month">
+        <ToolInput
+          id="tvc-visitors"
+          type="number"
+          value={monthlyVisitors}
+          onChange={e => setMonthlyVisitors(e.target.value)}
+          placeholder="50000"
+        />
+      </ToolField>
+
+      <ToolField
+        label="Conversion Rate"
+        htmlFor="tvc-conversion-rate"
+        required
+        hint="Percentage of visitors who convert"
+      >
+        <div className="relative">
+          <ToolInput
+            id="tvc-conversion-rate"
+            type="number"
+            step="0.01"
+            value={conversionRate}
+            onChange={e => setConversionRate(e.target.value)}
+            placeholder="2.5"
+            className="pl-3.5 pr-10"
+          />
+          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500 dark:text-neutral-400">
+            %
+          </span>
+        </div>
+      </ToolField>
+
+      <ToolField
+        label="Average Order Value"
+        htmlFor="tvc-aov"
+        required
+        hint="Average revenue per conversion"
+      >
+        <div className="relative">
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500 dark:text-neutral-400">
+            $
+          </span>
+          <ToolInput
+            id="tvc-aov"
+            type="number"
+            step="0.01"
+            value={averageOrderValue}
+            onChange={e => setAverageOrderValue(e.target.value)}
+            placeholder="75.00"
+            className="pl-7 pr-3.5"
+          />
+        </div>
+      </ToolField>
+
+      <ToolField label="Profit Margin" htmlFor="tvc-margin" required hint="Net profit margin per sale">
+        <div className="relative">
+          <ToolInput
+            id="tvc-margin"
+            type="number"
+            step="0.1"
+            value={profitMargin}
+            onChange={e => setProfitMargin(e.target.value)}
+            placeholder="30"
+            className="pl-3.5 pr-10"
+          />
+          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500 dark:text-neutral-400">
+            %
+          </span>
+        </div>
+      </ToolField>
+
+      {metrics && (
+        <ToolResultDivider>
+          <ToolResult label="Value Per Visitor" value={`$${metrics.valuePerVisitor.toFixed(2)}`} sub="per visitor" />
+
+          <div className="grid grid-cols-2 gap-3">
+            <ToolStat label="Monthly Conversions" value={Math.round(metrics.conversions).toLocaleString()} />
+            <ToolStat
+              label="Monthly Revenue"
+              value={`$${metrics.revenue.toLocaleString(undefined, { maximumFractionDigits: 0 })}`}
             />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Total visitors per month</p>
+            <ToolStat
+              label="Monthly Profit"
+              value={`$${metrics.profit.toLocaleString(undefined, { maximumFractionDigits: 0 })}`}
+            />
+            <ToolStat
+              label="Annual Profit"
+              value={`$${metrics.annualProfit.toLocaleString(undefined, { maximumFractionDigits: 0 })}`}
+            />
           </div>
 
-          {/* Conversion Rate */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Conversion Rate <span className="text-red-500">*</span>
-            </label>
-            <div className="relative">
-              <input
-                type="number"
-                step="0.01"
-                value={conversionRate}
-                onChange={(e) => setConversionRate(e.target.value)}
-                placeholder="2.5"
-                className="w-full pl-4 pr-10 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-              />
-              <span className="absolute right-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400">%</span>
-            </div>
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Percentage of visitors who convert</p>
-          </div>
+          <ToolCallout variant="tip" title="What this means:">
+            <ul className="space-y-1">
+              <li>
+                Each visitor is worth <strong>${metrics.valuePerVisitor.toFixed(2)}</strong> in profit
+              </li>
+              <li>
+                A <strong>10% traffic increase</strong> would add{" "}
+                <strong>
+                  ${(metrics.profit * 0.1).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                  /month
+                </strong>{" "}
+                in profit
+              </li>
+              <li>
+                A <strong>1% conversion rate improvement</strong> would add{" "}
+                <strong>
+                  $
+                  {(
+                    (parseFloat(monthlyVisitors) *
+                      0.01 *
+                      parseFloat(averageOrderValue) *
+                      parseFloat(profitMargin)) /
+                    100
+                  ).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                  /month
+                </strong>{" "}
+                in profit
+              </li>
+              <li>
+                You can afford to spend up to <strong>${metrics.valuePerVisitor.toFixed(2)}</strong> per visitor on
+                acquisition
+              </li>
+            </ul>
+          </ToolCallout>
+        </ToolResultDivider>
+      )}
 
-          {/* Average Order Value */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Average Order Value <span className="text-red-500">*</span>
-            </label>
-            <div className="relative">
-              <span className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400">$</span>
-              <input
-                type="number"
-                step="0.01"
-                value={averageOrderValue}
-                onChange={(e) => setAverageOrderValue(e.target.value)}
-                placeholder="75.00"
-                className="w-full pl-8 pr-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-              />
-            </div>
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Average revenue per conversion</p>
-          </div>
-
-          {/* Profit Margin */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Profit Margin <span className="text-red-500">*</span>
-            </label>
-            <div className="relative">
-              <input
-                type="number"
-                step="0.1"
-                value={profitMargin}
-                onChange={(e) => setProfitMargin(e.target.value)}
-                placeholder="30"
-                className="w-full pl-4 pr-10 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-              />
-              <span className="absolute right-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400">%</span>
-            </div>
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Net profit margin per sale</p>
-          </div>
-
-          {/* Results */}
-          {metrics && (
-            <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800 space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                  Value Per Visitor
-                </label>
-                <div className="px-4 py-6 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-center">
-                  <div className="text-4xl font-bold text-emerald-600 dark:text-emerald-400">
-                    ${metrics.valuePerVisitor.toFixed(2)}
-                  </div>
-                  <div className="text-sm text-neutral-600 dark:text-neutral-400 mt-1">per visitor</div>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    Monthly Conversions
-                  </label>
-                  <div className="px-4 py-4 bg-neutral-100 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-center">
-                    <div className="text-2xl font-bold text-neutral-900 dark:text-white">
-                      {Math.round(metrics.conversions).toLocaleString()}
-                    </div>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    Monthly Revenue
-                  </label>
-                  <div className="px-4 py-4 bg-neutral-100 dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-center">
-                    <div className="text-2xl font-bold text-neutral-900 dark:text-white">
-                      ${metrics.revenue.toLocaleString(undefined, { maximumFractionDigits: 0 })}
-                    </div>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    Monthly Profit
-                  </label>
-                  <div className="px-4 py-4 bg-blue-50 dark:bg-blue-950/30 border border-blue-300 dark:border-blue-800 rounded-lg text-center">
-                    <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
-                      ${metrics.profit.toLocaleString(undefined, { maximumFractionDigits: 0 })}
-                    </div>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-                    Annual Profit
-                  </label>
-                  <div className="px-4 py-4 bg-blue-50 dark:bg-blue-950/30 border border-blue-300 dark:border-blue-800 rounded-lg text-center">
-                    <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
-                      ${metrics.annualProfit.toLocaleString(undefined, { maximumFractionDigits: 0 })}
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="p-4 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-900 rounded-lg">
-                <h3 className="font-semibold text-emerald-900 dark:text-emerald-200 mb-2">What this means:</h3>
-                <ul className="text-sm text-emerald-900 dark:text-emerald-200 space-y-1">
-                  <li>Each visitor is worth <strong>${metrics.valuePerVisitor.toFixed(2)}</strong> in profit</li>
-                  <li>
-                    A <strong>10% traffic increase</strong> would add{" "}
-                    <strong>
-                      ${(metrics.profit * 0.1).toLocaleString(undefined, { maximumFractionDigits: 0 })}
-                      /month
-                    </strong>{" "}
-                    in profit
-                  </li>
-                  <li>
-                    A <strong>1% conversion rate improvement</strong> would add{" "}
-                    <strong>
-                      $
-                      {(
-                        (parseFloat(monthlyVisitors) *
-                          0.01 *
-                          parseFloat(averageOrderValue) *
-                          parseFloat(profitMargin)) /
-                        100
-                      ).toLocaleString(undefined, { maximumFractionDigits: 0 })}
-                      /month
-                    </strong>{" "}
-                    in profit
-                  </li>
-                  <li>You can afford to spend up to <strong>${metrics.valuePerVisitor.toFixed(2)}</strong> per visitor on acquisition</li>
-                </ul>
-              </div>
-            </div>
-          )}
-
-          {/* Buttons */}
-          <div className="flex gap-4 pt-4">
-            <button
-              onClick={clearForm}
-              className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-            >
-              Clear
-            </button>
-          </div>
-        </div>
+      <div className="flex gap-3 pt-2">
+        <ToolButton variant="secondary" onClick={clearForm}>
+          Clear
+        </ToolButton>
       </div>
-
-      {/* FAQ Section */}
-      <div className="mb-12">
-        <h2 className="text-2xl font-bold text-neutral-900 dark:text-white mb-6">Frequently Asked Questions</h2>
-        <div className="bg-neutral-100/50 dark:bg-neutral-800/20 backdrop-blur-sm border border-neutral-300/50 dark:border-neutral-800/50 rounded-xl overflow-hidden">
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="item-1">
-              <AccordionTrigger>Why is knowing visitor value important?</AccordionTrigger>
-              <AccordionContent>
-                Understanding visitor value helps you make informed decisions about marketing spend, SEO investments, and website optimization. If each visitor is worth $2, you can confidently spend up to $2 per visitor on advertising while breaking even, and anything less is profitable.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-2">
-              <AccordionTrigger>How can I increase visitor value?</AccordionTrigger>
-              <AccordionContent>
-                You can increase visitor value by: improving conversion rate (better UX, faster site, clearer CTAs), increasing average order value (upsells, cross-sells, bundles), improving profit margins (better pricing, lower costs), or attracting higher-intent traffic (better targeting, SEO for buyer keywords).
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-3">
-              <AccordionTrigger>Should I include customer lifetime value?</AccordionTrigger>
-              <AccordionContent>
-                This calculator shows immediate value per visitor. For businesses with repeat customers, your actual visitor value is higher when including lifetime value (LTV). Track customer behavior over time with{" "}
-                <Link href="https://app.rybbit.io" className="text-emerald-600 dark:text-emerald-400 hover:underline">
-                  Rybbit Analytics
-                </Link>{" "}
-                to understand true LTV.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-4">
-              <AccordionTrigger>How do I calculate traffic value?</AccordionTrigger>
-              <AccordionContent>
-                Traffic value = (Monthly Visitors × Conversion Rate × Average Order Value × Profit Margin). This shows what each visitor is worth in profit. Our calculator does this automatically, but understanding the formula helps you see how each metric impacts your total value.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-5" className="border-b-0">
-              <AccordionTrigger>What profit margin should I use?</AccordionTrigger>
-              <AccordionContent>
-                Use your net profit margin (profit after all costs including COGS, wages, overhead, taxes). If you're not sure, calculate it as: (Total Profit / Total Revenue) × 100. Using an accurate margin ensures your visitor value calculations reflect real profitability, not just revenue.
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </div>
-      </div>
-    </>
+    </div>
   );
 }

--- a/docs/src/app/[locale]/(home)/tools/utm-builder/UTMBuilderForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/utm-builder/UTMBuilderForm.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import { CheckCircle, Copy } from "lucide-react";
-import Link from "next/link";
 import { useMemo, useState } from "react";
+import { CopyButton, ToolButton, ToolField, ToolInput } from "../components/tool-ui";
 
 export function UTMBuilderForm() {
   const [url, setUrl] = useState("");
@@ -12,7 +10,6 @@ export function UTMBuilderForm() {
   const [campaign, setCampaign] = useState("");
   const [term, setTerm] = useState("");
   const [content, setContent] = useState("");
-  const [copied, setCopied] = useState(false);
 
   const utmUrl = useMemo(() => {
     if (!url || !source || !medium || !campaign) return "";
@@ -30,14 +27,6 @@ export function UTMBuilderForm() {
     }
   }, [url, source, medium, campaign, term, content]);
 
-  const copyToClipboard = async () => {
-    if (utmUrl) {
-      await navigator.clipboard.writeText(utmUrl);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
-  };
-
   const clearForm = () => {
     setUrl("");
     setSource("");
@@ -45,179 +34,100 @@ export function UTMBuilderForm() {
     setCampaign("");
     setTerm("");
     setContent("");
-    setCopied(false);
   };
 
   return (
-    <>
-      {/* Tool Section */}
-      <div className="mb-16">
-        <div className="space-y-6">
-          {/* Website URL */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Website URL <span className="text-red-500">*</span>
-            </label>
-            <input
+    <div className="space-y-6">
+      <ToolField label="Website URL" htmlFor="utm-url" required>
+        <ToolInput
+          id="utm-url"
+          type="text"
+          value={url}
+          onChange={e => setUrl(e.target.value)}
+          placeholder="https://example.com"
+        />
+      </ToolField>
+
+      <ToolField label="Campaign Source" htmlFor="utm-source" required hint="The referrer (e.g., google, newsletter)">
+        <ToolInput
+          id="utm-source"
+          type="text"
+          value={source}
+          onChange={e => setSource(e.target.value)}
+          placeholder="google, newsletter, facebook"
+        />
+      </ToolField>
+
+      <ToolField
+        label="Campaign Medium"
+        htmlFor="utm-medium"
+        required
+        hint="Marketing medium (e.g., cpc, email, social)"
+      >
+        <ToolInput
+          id="utm-medium"
+          type="text"
+          value={medium}
+          onChange={e => setMedium(e.target.value)}
+          placeholder="cpc, email, social"
+        />
+      </ToolField>
+
+      <ToolField
+        label="Campaign Name"
+        htmlFor="utm-campaign"
+        required
+        hint="Product, promo code, or slogan (e.g., summer_sale)"
+      >
+        <ToolInput
+          id="utm-campaign"
+          type="text"
+          value={campaign}
+          onChange={e => setCampaign(e.target.value)}
+          placeholder="summer_sale, product_launch"
+        />
+      </ToolField>
+
+      <ToolField label="Campaign Term" htmlFor="utm-term" hint="Identify the paid keywords (optional)">
+        <ToolInput
+          id="utm-term"
+          type="text"
+          value={term}
+          onChange={e => setTerm(e.target.value)}
+          placeholder="running_shoes, blue_widget"
+        />
+      </ToolField>
+
+      <ToolField label="Campaign Content" htmlFor="utm-content" hint="Differentiate ads or links (optional)">
+        <ToolInput
+          id="utm-content"
+          type="text"
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          placeholder="logolink, textlink"
+        />
+      </ToolField>
+
+      {utmUrl && (
+        <ToolField label="Your UTM URL" htmlFor="utm-result" className="border-t border-neutral-200 pt-6 dark:border-neutral-800">
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <ToolInput
+              id="utm-result"
               type="text"
-              value={url}
-              onChange={e => setUrl(e.target.value)}
-              placeholder="https://example.com"
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              value={utmUrl}
+              readOnly
+              className="flex-1 font-mono text-xs"
             />
+            <CopyButton value={utmUrl} variant="primary" className="shrink-0" />
           </div>
+        </ToolField>
+      )}
 
-          {/* Campaign Source */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Campaign Source <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="text"
-              value={source}
-              onChange={e => setSource(e.target.value)}
-              placeholder="google, newsletter, facebook"
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">The referrer (e.g., google, newsletter)</p>
-          </div>
-
-          {/* Campaign Medium */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Campaign Medium <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="text"
-              value={medium}
-              onChange={e => setMedium(e.target.value)}
-              placeholder="cpc, email, social"
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Marketing medium (e.g., cpc, email, social)</p>
-          </div>
-
-          {/* Campaign Name */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">
-              Campaign Name <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="text"
-              value={campaign}
-              onChange={e => setCampaign(e.target.value)}
-              placeholder="summer_sale, product_launch"
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Product, promo code, or slogan (e.g., summer_sale)</p>
-          </div>
-
-          {/* Campaign Term (Optional) */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">Campaign Term</label>
-            <input
-              type="text"
-              value={term}
-              onChange={e => setTerm(e.target.value)}
-              placeholder="running_shoes, blue_widget"
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Identify the paid keywords (optional)</p>
-          </div>
-
-          {/* Campaign Content (Optional) */}
-          <div>
-            <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">Campaign Content</label>
-            <input
-              type="text"
-              value={content}
-              onChange={e => setContent(e.target.value)}
-              placeholder="logolink, textlink"
-              className="w-full px-4 py-3 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-700 rounded-lg text-neutral-900 dark:text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-            />
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">Differentiate ads or links (optional)</p>
-          </div>
-
-          {/* Result */}
-          {utmUrl && (
-            <div className="pt-6 border-t border-neutral-200 dark:border-neutral-800">
-              <label className="block text-sm font-medium text-neutral-900 dark:text-white mb-2">Your UTM URL</label>
-              <div className="flex gap-2">
-                <input
-                  type="text"
-                  value={utmUrl}
-                  readOnly
-                  className="flex-1 px-4 py-3 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-neutral-900 dark:text-white font-mono text-sm"
-                />
-                <button
-                  onClick={copyToClipboard}
-                  className="px-6 py-3 bg-emerald-600 hover:bg-emerald-500 text-white font-medium rounded-lg transition-colors flex items-center gap-2"
-                >
-                  {copied ? <CheckCircle className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-                  {copied ? "Copied!" : "Copy"}
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* Buttons */}
-          <div className="flex gap-4 pt-4">
-            <button
-              onClick={clearForm}
-              className="px-6 py-3 bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 text-neutral-900 dark:text-white font-medium rounded-lg transition-colors"
-            >
-              Clear
-            </button>
-          </div>
-        </div>
+      <div className="flex gap-3 pt-2">
+        <ToolButton variant="secondary" onClick={clearForm}>
+          Clear
+        </ToolButton>
       </div>
-
-      {/* FAQ Section */}
-      <div className="mb-12">
-        <h2 className="text-2xl font-bold text-neutral-900 dark:text-white mb-6">Frequently Asked Questions</h2>
-        <div className="bg-neutral-100/50 dark:bg-neutral-800/20 backdrop-blur-sm border border-neutral-300/50 dark:border-neutral-800/50 rounded-xl overflow-hidden">
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="item-1">
-              <AccordionTrigger>What is UTM tracking?</AccordionTrigger>
-              <AccordionContent>
-                UTM (Urchin Tracking Module) parameters are tags added to URLs that help you track the effectiveness of your marketing campaigns in analytics tools like Rybbit, Google Analytics, and others. They tell you exactly where your traffic is coming from and how your campaigns perform.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-2">
-              <AccordionTrigger>What are the required UTM parameters?</AccordionTrigger>
-              <AccordionContent>
-                The three required parameters are: <strong>utm_source</strong> (identifies the source like google or newsletter), <strong>utm_medium</strong> (identifies the medium like cpc or email), and <strong>utm_campaign</strong> (identifies the specific campaign like summer_sale).
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-3">
-              <AccordionTrigger>How do I track UTM links with Rybbit?</AccordionTrigger>
-              <AccordionContent>
-                Once you have Rybbit installed on your website, UTM parameters are automatically tracked. You can view your campaign performance in your{" "}
-                <Link href="https://app.rybbit.io" className="text-emerald-600 dark:text-emerald-400 hover:underline">
-                  Rybbit dashboard
-                </Link>{" "}
-                under the UTM section.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-4">
-              <AccordionTrigger>What are optional UTM parameters?</AccordionTrigger>
-              <AccordionContent>
-                <strong>utm_term</strong> is used for tracking paid search keywords, while <strong>utm_content</strong> helps differentiate between different ads or links within the same campaign. These are optional but useful for deeper campaign analysis and A/B testing.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-5" className="border-b-0">
-              <AccordionTrigger>What naming conventions should I follow?</AccordionTrigger>
-              <AccordionContent>
-                Use lowercase letters and underscores instead of spaces (e.g., summer_sale, not Summer Sale). Be consistent across campaigns so data is properly grouped in analytics. Avoid special characters and keep names descriptive but concise.
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </div>
-      </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## What

The interactive tool **forms** under docs `/tools` used an ad-hoc styling vocabulary that clashed with the "instrument panel" system the surrounding `ToolPageLayout` shell already implements. This brings every tool's layout and design in line with the rest of the app.

**Before → after (per form):**
- `rounded-lg`/`rounded-xl` controls → tight `rounded-md`
- `font-bold` → `font-semibold`
- tall `py-3` inputs with mismatched surfaces → consistent `h-10` controls, hairline borders, flat surfaces (depth via borders, not shadows)
- saturated `bg-emerald-600` + `shadow-lg` buttons → the shell's emerald action button (`bg-emerald-600 hover:bg-emerald-500`, `focus-visible` ring)
- tinted blue/orange callout boxes → a restrained, unified `ToolCallout`
- ad-hoc result boxes → one focal `ToolResult` + neutral `ToolStat` cells

## How

- **New shared primitives** in `tools/components/tool-ui.tsx` — `ToolField`, `ToolInput`, `ToolTextarea`, `ToolSelect`, `ToolButton`, `CopyButton`, `ToolResult`, `ToolStat`, `ToolCallout`, `ToolResultDivider`. These encode the app's control vocabulary once, matching `InteriorPageHero` / `ToolCTA`.
- **All ~30 forms** (calculators, AI generators, utilities, social-media generators, funnel visualizer, character counter, image resizer) refactored onto the primitives. Tool logic, math, fetch calls, and copy are unchanged — only presentation.

## Bugs fixed along the way

Several legacy forms rendered sections the layout **already** renders, so they appeared twice on the live page:
- **Duplicate FAQ** (form embedded its own accordion *and* `ToolPageLayout` renders one from the `faqs` prop): `utm-builder`, `traffic-value-calculator`, `page-speed-calculator`, `bounce-rate-calculator`
- **Duplicate CTA** (form embedded a second signup CTA on top of the layout's `ToolCTA`): `seo-title-generator`, `meta-description-generator`, `privacy-policy-builder`, `page-speed-calculator`

The embedded duplicates were removed.

## Docs

Updated the tools authoring guide (`tools/CLAUDE.md`) to point new tools at the primitives and warn against re-embedding FAQ/CTA.

## Verification

- `tsc --noEmit` clean across the docs app.
- Swept every form for leftover divergent classes (`rounded-lg` controls, `bg-emerald-600` buttons, `font-bold`, `text-orange-*`, embedded FAQ/CTA) — none remain.
- Visually verified a representative sample (calculator result state, AI generator, UTM copy result, funnel visualizer, character counter, image resizer, social generators) in **light and dark**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a consistent interface across generators, calculators, and utility tools.
  * Added standardized fields, buttons, loading states, result displays, callouts, statistics, and copy-to-clipboard controls.
  * Improved presentation of errors, tips, benchmarks, character limits, and generated results.
  * Added clearer reset, download, and calculation actions across supported tools.

* **Documentation**
  * Updated tool-building guidance with examples for the shared interface components and page layout conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->