### PR TITLE
Bring docs free tools in line with the app

### DIFF
--- a/docs/src/app/[locale]/(home)/tools/bounce-rate-calculator/BounceRateForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/bounce-rate-calculator/BounceRateForm.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import Link from "next/link";
 import { useState } from "react";
 
 const industryBenchmarks: Record<string, { low: number; average: number; high: number }> = {
@@ -169,53 +167,6 @@ export function BounceRateForm() {
               Clear
             </button>
           </div>
-        </div>
-      </div>
-
-      {/* FAQ Section */}
-      <div className="mb-12">
-        <h2 className="text-2xl font-bold text-neutral-900 dark:text-white mb-6">Frequently Asked Questions</h2>
-        <div className="bg-neutral-100/50 dark:bg-neutral-800/20 backdrop-blur-sm border border-neutral-300/50 dark:border-neutral-800/50 rounded-xl overflow-hidden">
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="item-1">
-              <AccordionTrigger>What is bounce rate?</AccordionTrigger>
-              <AccordionContent>
-                Bounce rate is the percentage of visitors who leave your website after viewing only one page without any interaction. A high bounce rate might indicate that your landing pages aren't relevant to visitors or your site has usability issues.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-2">
-              <AccordionTrigger>What's a good bounce rate?</AccordionTrigger>
-              <AccordionContent>
-                A "good" bounce rate varies by industry and page type. E-commerce sites typically aim for 20-45%, while blogs may see 65-90% and still be healthy. Landing pages naturally have higher bounce rates (60-90%) since they're designed for a single action.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-3">
-              <AccordionTrigger>How can I reduce my bounce rate?</AccordionTrigger>
-              <AccordionContent>
-                To reduce bounce rate: improve page load speed, ensure mobile responsiveness, create compelling content, add clear calls-to-action, use internal linking, improve content readability, and ensure your pages match visitor intent. Track your improvements with{" "}
-                <Link href="https://app.rybbit.io" className="text-emerald-600 dark:text-emerald-400 hover:underline">
-                  Rybbit Analytics
-                </Link>{" "}
-                to see what works.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-4">
-              <AccordionTrigger>Does bounce rate affect SEO?</AccordionTrigger>
-              <AccordionContent>
-                While bounce rate isn't a direct Google ranking factor, it can indirectly impact SEO. A high bounce rate suggests poor user experience or irrelevant content, which can lead to lower engagement signals. Google may interpret this as lower quality, potentially affecting your rankings over time.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-5" className="border-b-0">
-              <AccordionTrigger>Why is bounce rate different in different tools?</AccordionTrigger>
-              <AccordionContent>
-                Different analytics tools may calculate bounce rate differently based on how they track sessions, handle direct traffic, and count interactions. Some tools exclude certain traffic sources or implement different session timeouts. Always use the same tool consistently for accurate comparisons.
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
         </div>
       </div>
     </>

--- a/docs/src/app/[locale]/(home)/tools/components/BuiltByRybbit.tsx
+++ b/docs/src/app/[locale]/(home)/tools/components/BuiltByRybbit.tsx
@@ -1,34 +1,53 @@
+import Image from "next/image";
 import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
 
 const inlineLinkClassName =
-  "font-medium text-emerald-700 dark:text-emerald-400 underline underline-offset-2 decoration-emerald-700/30 dark:decoration-emerald-400/30 hover:decoration-current transition-colors";
+  "font-medium text-neutral-900 underline decoration-neutral-300 underline-offset-2 transition-colors hover:decoration-emerald-600 dark:text-neutral-100 dark:decoration-neutral-700 dark:hover:decoration-emerald-400";
 
 export function BuiltByRybbit() {
   return (
-    <div className="mt-16 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-neutral-100/60 dark:bg-neutral-900/40 p-6 sm:p-8">
-      <div className="flex items-start gap-4">
-        <span className="text-2xl leading-none mt-0.5" aria-hidden="true">
-          🐸
-        </span>
+    <div>
+      <div className="flex items-center gap-3">
+        <div className="flex size-9 items-center justify-center rounded-md border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
+          <Image src="/rybbit/frog_light green.svg" width={22} height={22} alt="" aria-hidden="true" />
+        </div>
         <div>
-          <h2 className="text-base font-semibold text-neutral-900 dark:text-white mb-2">Built by Rybbit</h2>
-          <p className="text-sm leading-relaxed text-neutral-700 dark:text-neutral-300">
-            This free tool is made by the team behind{" "}
-            <Link href="/" className={inlineLinkClassName}>
-              Rybbit
-            </Link>
-            , the open-source, cookieless{" "}
-            <Link href="/compare/google-analytics" className={inlineLinkClassName}>
-              Google Analytics alternative
-            </Link>
-            . It tracks sessions, funnels, user journeys, and errors — with{" "}
-            <Link href="/features/session-replay" className={inlineLinkClassName}>
-              session replay
-            </Link>{" "}
-            included — and you can self-host it or use the cloud free tier.
-          </p>
+          <p className="text-xs text-neutral-500 dark:text-neutral-400">Made by</p>
+          <h2 className="text-sm font-semibold text-neutral-950 dark:text-neutral-50">Rybbit Analytics</h2>
         </div>
       </div>
+
+      <p className="mt-5 text-sm leading-6 text-neutral-600 dark:text-neutral-300">
+        The open-source, cookieless analytics platform for sessions, funnels, journeys, errors, and replay.
+      </p>
+
+      <dl className="mt-6 divide-y divide-neutral-200 border-y border-neutral-200 text-xs dark:divide-neutral-800 dark:border-neutral-800">
+        <div className="flex items-center justify-between py-3">
+          <dt className="text-neutral-500 dark:text-neutral-400">License</dt>
+          <dd className="font-medium text-neutral-900 dark:text-neutral-100">Open source</dd>
+        </div>
+        <div className="flex items-center justify-between py-3">
+          <dt className="text-neutral-500 dark:text-neutral-400">Tracking</dt>
+          <dd className="font-medium text-neutral-900 dark:text-neutral-100">Cookieless</dd>
+        </div>
+      </dl>
+
+      <p className="mt-5 text-sm leading-6 text-neutral-600 dark:text-neutral-300">
+        Self-host it or use the free cloud tier. Learn why teams choose Rybbit as a{" "}
+        <Link href="/compare/google-analytics" className={inlineLinkClassName}>
+          Google Analytics alternative
+        </Link>
+        .
+      </p>
+
+      <Link
+        href="/features"
+        className="mt-5 inline-flex min-h-9 items-center gap-1.5 rounded-md text-sm font-medium text-neutral-900 transition-colors hover:text-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 dark:text-neutral-100 dark:hover:text-emerald-400"
+      >
+        Explore Rybbit
+        <ArrowUpRight className="size-3.5" aria-hidden="true" />
+      </Link>
     </div>
   );
 }

--- a/docs/src/app/[locale]/(home)/tools/components/ToolCTA.tsx
+++ b/docs/src/app/[locale]/(home)/tools/components/ToolCTA.tsx
@@ -13,15 +13,11 @@ interface ToolCTAProps {
 export function ToolCTA({ title, description, eventLocation, buttonText = "Start tracking for free" }: ToolCTAProps) {
   return (
     <section className="relative overflow-hidden border-b border-emerald-900 bg-emerald-950 text-white">
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-60 [background-image:linear-gradient(to_right,rgba(255,255,255,0.045)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.045)_1px,transparent_1px)] [background-size:40px_40px] [mask-image:linear-gradient(to_bottom,black,transparent_92%)]"
-      />
       <div className="relative mx-auto grid max-w-[1200px] border-x border-white/10 lg:grid-cols-12">
-        <GridCrosses className="text-white/30 dark:text-white/30" />
+        <GridCrosses className="hidden text-white/30 sm:block dark:text-white/30" />
 
-        <div className="relative z-10 border-b border-white/10 px-5 py-16 sm:px-8 md:py-20 lg:col-span-8 lg:border-b-0 lg:border-r lg:px-10">
-          <h2 className="max-w-2xl text-3xl font-semibold leading-[1.04] tracking-[-0.035em] text-balance md:text-5xl">
+        <div className="relative z-10 border-b border-white/10 px-5 py-14 sm:px-8 md:py-16 lg:col-span-8 lg:border-b-0 lg:border-r lg:px-10">
+          <h2 className="max-w-2xl text-3xl font-semibold leading-tight tracking-[-0.03em] text-balance md:text-4xl">
             {title}
           </h2>
         </div>

--- a/docs/src/app/[locale]/(home)/tools/components/ToolPageLayout.module.css
+++ b/docs/src/app/[locale]/(home)/tools/components/ToolPageLayout.module.css
@@ -1,0 +1,148 @@
+.workspace {
+  min-width: 0;
+  width: 100%;
+  color: var(--foreground);
+}
+
+.workspace pre {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.workspace > :global(.mb-16),
+.workspace > :global(.mb-12),
+.workspace > :global(.mb-8) {
+  margin-bottom: 0;
+}
+
+.workspace > :global(.max-w-4xl) {
+  max-width: none;
+  margin-inline: 0;
+}
+
+.workspace :global(.space-y-6),
+.workspace :global(.space-y-4),
+.workspace :global(.space-y-3) {
+  display: flex;
+  flex-direction: column;
+}
+
+.workspace :global(.space-y-6) {
+  gap: 1rem;
+}
+
+.workspace :global(.space-y-4) {
+  gap: 0.75rem;
+}
+
+.workspace :global(.space-y-3) {
+  gap: 0.5rem;
+}
+
+.workspace :global(.space-y-6) > *,
+.workspace :global(.space-y-4) > *,
+.workspace :global(.space-y-3) > * {
+  margin-block: 0;
+}
+
+.workspace input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="file"]),
+.workspace select,
+.workspace textarea {
+  min-height: 2.5rem;
+  border-radius: 0.3rem;
+  border-color: var(--input);
+  background-color: var(--card);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    background-color 160ms ease;
+}
+
+.workspace textarea {
+  min-height: 7.5rem;
+}
+
+.workspace input::placeholder,
+.workspace textarea::placeholder {
+  color: var(--muted-foreground);
+  opacity: 1;
+}
+
+.workspace input:focus-visible,
+.workspace select:focus-visible,
+.workspace textarea:focus-visible {
+  outline: none;
+  border-color: var(--ring);
+  box-shadow: 0 0 0 1px var(--ring);
+}
+
+.workspace button {
+  min-height: 2.5rem;
+  border-radius: 0.3rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  transition-duration: 160ms;
+}
+
+.workspace button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.workspace :global(.rounded-xl),
+.workspace :global(.rounded-lg) {
+  border-radius: 0.3rem;
+}
+
+.workspace :global(.shadow-lg) {
+  box-shadow: none;
+}
+
+.workspace :global(.grid.grid-cols-2) {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.workspace :global(.flex.gap-4) {
+  flex-wrap: wrap;
+}
+
+.workspace :global(.flex.gap-2) {
+  flex-wrap: wrap;
+}
+
+.workspace :global(.flex.gap-2) > input {
+  min-width: 0;
+  flex: 1 1 16rem;
+}
+
+.workspace :global(.flex.gap-4) > button {
+  flex: 1 1 10rem;
+}
+
+@media (min-width: 640px) {
+  .workspace :global(.grid.grid-cols-2) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (pointer: coarse) {
+  .workspace input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="file"]),
+  .workspace select,
+  .workspace button {
+    min-height: 2.75rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace *,
+  .workspace *::before,
+  .workspace *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/docs/src/app/[locale]/(home)/tools/components/ToolPageLayout.tsx
+++ b/docs/src/app/[locale]/(home)/tools/components/ToolPageLayout.tsx
@@ -6,6 +6,7 @@ import { RelatedTools } from "@/components/RelatedTools";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { BuiltByRybbit } from "./BuiltByRybbit";
 import { ToolCTA } from "./ToolCTA";
+import styles from "./ToolPageLayout.module.css";
 
 export interface FAQItem {
   question: string;
@@ -13,23 +14,18 @@ export interface FAQItem {
 }
 
 export interface ToolPageLayoutProps {
-  // Required sections
   toolSlug: string;
   title: string;
   description: string;
-  badge?: string; // e.g., "AI-Powered Tool", "Free Tool"
+  badge?: string;
   toolComponent: ReactNode;
   educationalContent: ReactNode;
   faqs: FAQItem[];
   relatedToolsCategory: "seo" | "analytics" | "privacy" | "social-media";
-
-  // CTA section
   ctaTitle: string;
   ctaDescription: string;
   ctaEventLocation: string;
   ctaButtonText?: string;
-
-  // Optional metadata for structured data (passed through)
   structuredData?: object;
 }
 
@@ -37,7 +33,7 @@ export function ToolPageLayout({
   toolSlug,
   title,
   description,
-  badge = "Free Tool",
+  badge = "Free tool",
   toolComponent,
   educationalContent,
   faqs,
@@ -54,11 +50,10 @@ export function ToolPageLayout({
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
       )}
 
-      {/* 1. Header — on the rail, matching the marketing interior pages */}
       <section className="border-b border-neutral-200 dark:border-neutral-800">
-        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800 lg:grid lg:grid-cols-12">
-          <GridCrosses />
-          <div className="border-b border-neutral-200 px-5 pb-10 pt-8 dark:border-neutral-800 sm:px-8 lg:col-span-8 lg:border-b-0 lg:border-r lg:px-10 lg:pb-16 lg:pt-10">
+        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
+          <GridCrosses className="hidden sm:block" />
+          <div className="px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
             <nav aria-label="Breadcrumb">
               <ol className="flex flex-wrap items-center gap-1.5 text-sm text-neutral-500 dark:text-neutral-400">
                 <li>
@@ -85,46 +80,62 @@ export function ToolPageLayout({
               </ol>
             </nav>
 
-            <p className="mt-8 flex items-center gap-2.5 text-sm font-semibold tracking-tight text-emerald-700 dark:text-emerald-400">
-              <span
-                aria-hidden="true"
-                className="size-2 rounded-[1px] bg-emerald-600 [animation:kicker-pulse_3.2s_ease-in-out_infinite] dark:bg-emerald-400 motion-reduce:animate-none"
-              />
-              {badge}
-            </p>
-            <h1 className="mt-4 max-w-2xl text-4xl font-semibold leading-[1.02] tracking-[-0.035em] text-neutral-950 text-balance dark:text-neutral-50 md:text-5xl">
-              {title}
-            </h1>
-          </div>
-
-          <div className="flex items-end px-5 py-10 sm:px-8 lg:col-span-4 lg:px-10 lg:py-16">
-            <p className="max-w-md text-base leading-7 text-neutral-600 text-pretty dark:text-neutral-400">
-              {description}
-            </p>
+            <div className="mt-10 grid gap-6 lg:grid-cols-12 lg:items-end">
+              <div className="lg:col-span-8">
+                <p className="flex items-center gap-2 text-sm font-medium text-emerald-700 dark:text-emerald-400">
+                  <span aria-hidden="true" className="size-2 rounded-[1px] bg-emerald-600 dark:bg-emerald-400" />
+                  {badge}
+                </p>
+                <h1 className="mt-3 max-w-3xl text-3xl font-semibold leading-tight tracking-[-0.03em] text-neutral-950 text-balance dark:text-neutral-50 sm:text-4xl">
+                  {title}
+                </h1>
+              </div>
+              <p className="max-w-lg text-base leading-7 text-neutral-600 text-pretty dark:text-neutral-300 lg:col-span-4">
+                {description}
+              </p>
+            </div>
           </div>
         </div>
       </section>
 
-      {/* 2–5. Tool, article, FAQ, related — a readable column on the rail */}
-      <section className="border-b border-neutral-200 dark:border-neutral-800">
+      <section className="border-b border-neutral-200 dark:border-neutral-800" aria-label={`${title} workspace`}>
         <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
-          <GridCrosses />
-          <div className="mx-auto max-w-3xl px-5 py-12 sm:px-8 md:py-16 lg:px-10">
-            {/* 2. The Actual Tool */}
-            <div>{toolComponent}</div>
+          <GridCrosses className="hidden sm:block" />
+          <div className="flex min-h-11 items-center justify-between border-b border-neutral-200 px-5 text-xs font-medium text-neutral-500 dark:border-neutral-800 dark:text-neutral-400 sm:px-8 lg:px-10">
+            <span className="flex items-center gap-2 text-neutral-700 dark:text-neutral-200">
+              <span className="size-1.5 rounded-full bg-emerald-500" aria-hidden="true" />
+              Interactive workspace
+            </span>
+            <span className="hidden sm:inline">Free · no account required</span>
+          </div>
 
-            {/* 3. Educational Content */}
-            <div className="mt-16 prose prose-neutral max-w-none dark:prose-invert prose-headings:tracking-tight prose-a:text-emerald-700 dark:prose-a:text-emerald-400">
+          <div className="grid lg:grid-cols-12">
+            <div className="min-w-0 bg-neutral-50/60 px-5 py-8 dark:bg-neutral-900/20 sm:px-8 lg:col-span-9 lg:border-r lg:border-neutral-200 lg:px-10 lg:py-10 lg:dark:border-neutral-800">
+              <div className={styles.workspace}>{toolComponent}</div>
+            </div>
+            <aside className="min-w-0 border-t border-neutral-200 px-5 py-8 dark:border-neutral-800 sm:px-8 lg:col-span-3 lg:border-t-0 lg:px-6 lg:py-10">
+              <BuiltByRybbit />
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-neutral-200 dark:border-neutral-800">
+        <div className="relative mx-auto grid max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
+          <GridCrosses className="hidden sm:block" />
+          <article className="min-w-0 px-5 py-12 sm:px-8 lg:col-span-8 lg:border-r lg:border-neutral-200 lg:px-10 lg:py-16 lg:dark:border-neutral-800">
+            <div className="prose prose-neutral max-w-[70ch] dark:prose-invert prose-headings:font-semibold prose-headings:tracking-tight prose-a:text-emerald-700 dark:prose-a:text-emerald-400">
               {educationalContent}
             </div>
+          </article>
 
-            {/* 4. FAQ Section */}
-            {faqs.length > 0 && (
-              <div className="mt-16">
-                <h2 className="text-2xl font-semibold tracking-tight text-neutral-950 dark:text-neutral-50">
+          {faqs.length > 0 && (
+            <aside className="min-w-0 border-t border-neutral-200 px-5 py-12 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-t-0 lg:px-8 lg:py-16">
+              <div className="lg:sticky lg:top-24">
+                <h2 className="text-xl font-semibold tracking-tight text-neutral-950 dark:text-neutral-50">
                   Frequently asked questions
                 </h2>
-                <div className="mt-6 border-t border-neutral-200 dark:border-neutral-800">
+                <div className="mt-5 border-t border-neutral-200 dark:border-neutral-800">
                   <Accordion type="single" collapsible className="w-full">
                     {faqs.map((faq, index) => (
                       <AccordionItem
@@ -132,24 +143,27 @@ export function ToolPageLayout({
                         value={`item-${index}`}
                         className="border-b border-neutral-200 px-0 dark:border-neutral-800"
                       >
-                        <AccordionTrigger className="px-0 text-left">{faq.question}</AccordionTrigger>
-                        <AccordionContent className="px-0">{faq.answer}</AccordionContent>
+                        <AccordionTrigger className="px-0 text-left text-sm leading-5">{faq.question}</AccordionTrigger>
+                        <AccordionContent className="px-0 text-sm leading-6 text-neutral-600 dark:text-neutral-300">
+                          {faq.answer}
+                        </AccordionContent>
                       </AccordionItem>
                     ))}
                   </Accordion>
                 </div>
               </div>
-            )}
-
-            {/* 5. Related Tools */}
-            <RelatedTools currentToolHref={`/tools/${toolSlug}`} category={relatedToolsCategory} />
-
-            <BuiltByRybbit />
-          </div>
+            </aside>
+          )}
         </div>
       </section>
 
-      {/* 6. CTA */}
+      <section className="border-b border-neutral-200 dark:border-neutral-800">
+        <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 px-5 py-12 dark:border-neutral-800 sm:px-8 lg:px-10">
+          <GridCrosses className="hidden sm:block" />
+          <RelatedTools currentToolHref={`/tools/${toolSlug}`} category={relatedToolsCategory} />
+        </div>
+      </section>
+
       <ToolCTA
         title={ctaTitle}
         description={ctaDescription}

--- a/docs/src/app/[locale]/(home)/tools/meta-description-generator/MetaDescriptionForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/meta-description-generator/MetaDescriptionForm.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { TrackedButton } from "@/components/TrackedButton";
-import { DEFAULT_EVENT_LIMIT } from "@/lib/const";
 import { CheckCircle, Copy, Loader2 } from "lucide-react";
 import { useState } from "react";
 
@@ -168,27 +166,6 @@ export function MetaDescriptionForm() {
               </div>
             </div>
           )}
-        </div>
-      </div>
-
-      {/* CTA */}
-      <div className="border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-20 -mx-6">
-        <div className="max-w-4xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 dark:text-white mb-4">
-            Optimize your content with Rybbit
-          </h2>
-          <p className="text-lg text-neutral-600 dark:text-neutral-400 mb-8 max-w-2xl mx-auto">
-            Track which pages perform best and refine your meta descriptions based on real visitor data. Get started for
-            free with up to {DEFAULT_EVENT_LIMIT.toLocaleString()} pageviews per month.
-          </p>
-          <TrackedButton
-            href="https://app.rybbit.io/signup"
-            eventName="signup"
-            eventProps={{ location: "meta_description_generator_cta" }}
-            className="inline-block bg-emerald-600 hover:bg-emerald-500 text-white font-semibold px-10 py-4 text-lg rounded-lg shadow-lg shadow-emerald-900/20 transform hover:-translate-y-0.5 transition-all duration-200"
-          >
-            Start tracking for free
-          </TrackedButton>
         </div>
       </div>
     </>

--- a/docs/src/app/[locale]/(home)/tools/page-speed-calculator/PageSpeedForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/page-speed-calculator/PageSpeedForm.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import { TrackedButton } from "@/components/TrackedButton";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import { DEFAULT_EVENT_LIMIT } from "@/lib/const";
-import Link from "next/link";
 import { useState } from "react";
 
 interface CalculateImpactResult {
@@ -317,88 +313,6 @@ export function PageSpeedForm() {
               Clear
             </button>
           </div>
-        </div>
-      </div>
-
-      {/* FAQ Section */}
-      <div className="mb-16">
-        <h2 className="text-2xl font-bold text-neutral-900 dark:text-white mb-6">Frequently Asked Questions</h2>
-        <div className="bg-neutral-100/50 dark:bg-neutral-800/20 backdrop-blur-sm border border-neutral-300/50 dark:border-neutral-800/50 rounded-xl overflow-hidden">
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="item-1">
-              <AccordionTrigger>How much does page speed really matter?</AccordionTrigger>
-              <AccordionContent>
-                Studies show that for every 1 second delay in page load time, conversions decrease by approximately 7%,
-                bounce rate increases by 7%, and customer satisfaction drops by 16%. A 2-second delay can result in
-                abandonment rates up to 87% for e-commerce sites. This makes page speed a critical business metric.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-2">
-              <AccordionTrigger>What are Google Core Web Vitals and why are they important?</AccordionTrigger>
-              <AccordionContent>
-                Google Core Web Vitals are three key metrics that measure user experience: Largest Contentful Paint
-                (LCP, visual loading speed), First Input Delay (FID, responsiveness), and Cumulative Layout Shift (CLS,
-                visual stability). Google uses these metrics as ranking factors in search results, making them essential
-                for SEO. Meeting these thresholds directly impacts your site's visibility and traffic.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-3">
-              <AccordionTrigger>What's a good page load time?</AccordionTrigger>
-              <AccordionContent>
-                Google recommends pages load in under 3 seconds on mobile. However, the faster the better—pages that
-                load in under 1 second see significantly higher engagement. Amazon found that every 100ms improvement in
-                load time increased revenue by 1%. Most successful e-commerce sites target between 1-2 seconds.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-4">
-              <AccordionTrigger>What are the best ways to improve page speed?</AccordionTrigger>
-              <AccordionContent>
-                Key improvements include: optimizing images (compress and use modern formats like WebP), minifying
-                CSS/JS files, enabling browser caching, using a Content Delivery Network (CDN), reducing server response
-                time, eliminating render-blocking resources, lazy-loading below-the-fold content, and choosing
-                lightweight analytics tools like{" "}
-                <Link href="https://app.rybbit.io" className="text-emerald-600 dark:text-emerald-400 hover:underline">
-                  Rybbit
-                </Link>{" "}
-                which adds minimal overhead (just 3KB).
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-5" className="border-b-0">
-              <AccordionTrigger>How can analytics tools affect my page speed?</AccordionTrigger>
-              <AccordionContent>
-                Many analytics tools can significantly impact page performance by loading large scripts synchronously
-                and making blocking network requests. This reduces your page's speed and negatively affects user
-                experience. Tools like Rybbit are designed to minimize this impact with lightweight asynchronous loading
-                (3KB script, loaded after page interactive), ensuring you get the insights you need without compromising
-                performance.
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </div>
-      </div>
-
-      {/* CTA */}
-      <div className="border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-20">
-        <div className="max-w-4xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 dark:text-white mb-4">
-            Lightning-fast analytics that won't slow you down
-          </h2>
-          <p className="text-lg text-neutral-600 dark:text-neutral-400 mb-8 max-w-2xl mx-auto">
-            Rybbit's tiny 3KB script loads asynchronously and won't impact your page speed. Get started for free with up
-            to {DEFAULT_EVENT_LIMIT.toLocaleString()} pageviews per month.
-          </p>
-          <TrackedButton
-            href="https://app.rybbit.io/signup"
-            eventName="signup"
-            eventProps={{ location: "page_speed_calculator_cta" }}
-            className="inline-block bg-emerald-600 hover:bg-emerald-500 text-white font-semibold px-10 py-4 text-lg rounded-lg shadow-lg shadow-emerald-900/20 transform hover:-translate-y-0.5 transition-all duration-200"
-          >
-            Start tracking for free
-          </TrackedButton>
         </div>
       </div>
     </>

--- a/docs/src/app/[locale]/(home)/tools/page.tsx
+++ b/docs/src/app/[locale]/(home)/tools/page.tsx
@@ -342,19 +342,21 @@ function ToolCell({ tool }: { tool: Tool }) {
   return (
     <Link
       href={tool.href}
-      className="group block bg-white px-5 py-8 transition-colors duration-200 hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-emerald-500 dark:bg-neutral-950 dark:hover:bg-neutral-900/60 sm:px-8"
+      className="group grid min-h-20 grid-cols-[2rem_minmax(0,1fr)_auto] items-start gap-3 bg-white px-5 py-5 transition-colors duration-200 hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-emerald-500 dark:bg-neutral-950 dark:hover:bg-neutral-900/60 sm:grid-cols-[2rem_minmax(10rem,0.75fr)_minmax(12rem,1.25fr)_auto] sm:items-center sm:gap-4 sm:px-8"
     >
-      <div className="mb-5 text-neutral-500 dark:text-neutral-400">
-        <Icon className="size-5" aria-hidden="true" />
+      <div className="flex size-8 items-center justify-center rounded-md bg-neutral-100 text-neutral-500 dark:bg-neutral-900 dark:text-neutral-400">
+        <Icon className="size-4" aria-hidden="true" />
       </div>
-      <h3 className="flex items-baseline justify-between gap-3 font-semibold tracking-tight text-neutral-950 dark:text-neutral-50">
+      <h3 className="self-center text-sm font-semibold tracking-tight text-neutral-950 dark:text-neutral-50">
         {tool.title}
-        <ArrowRight
-          className="size-3.5 shrink-0 self-center text-neutral-400 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none dark:text-neutral-600"
-          aria-hidden="true"
-        />
       </h3>
-      <p className="mt-2 max-w-md text-sm leading-6 text-neutral-600 dark:text-neutral-400">{tool.description}</p>
+      <p className="col-start-2 text-sm leading-5 text-neutral-500 dark:text-neutral-400 sm:col-start-auto">
+        {tool.description}
+      </p>
+      <ArrowRight
+        className="row-span-2 size-3.5 self-center text-neutral-400 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none dark:text-neutral-600 sm:row-span-1"
+        aria-hidden="true"
+      />
     </Link>
   );
 }
@@ -373,7 +375,7 @@ function ToolSection({
   return (
     <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby={id}>
       <div className="relative mx-auto grid max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
-        <GridCrosses />
+        <GridCrosses className="hidden sm:block" />
         <div className="border-b border-neutral-200 px-5 py-12 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 lg:py-16">
           <div className="lg:sticky lg:top-24">
             <h2 id={id} className="text-3xl font-semibold tracking-[-0.03em] md:text-4xl">
@@ -382,16 +384,22 @@ function ToolSection({
             <p className="mt-5 max-w-sm text-base leading-7 text-neutral-600 dark:text-neutral-400">{description}</p>
           </div>
         </div>
-        <div className="grid gap-px bg-neutral-200 dark:bg-neutral-800 md:grid-cols-2 lg:col-span-8">
+        <div className="divide-y divide-neutral-200 dark:divide-neutral-800 lg:col-span-8">
           {tools.map(tool => (
             <ToolCell key={tool.href} tool={tool} />
           ))}
-          {tools.length % 2 === 1 && <div aria-hidden="true" className="hidden bg-white dark:bg-neutral-950 md:block" />}
         </div>
       </div>
     </section>
   );
 }
+
+const directoryLinks = [
+  { href: "#calculators-title", label: "Calculators", count: calculators.length },
+  { href: "#ai-tools-title", label: "AI tools", count: aiPoweredTools.length },
+  { href: "#utilities-title", label: "Utilities", count: utilityTools.length },
+  { href: "#social-tools-title", label: "Social media", count: socialToolCount },
+];
 
 export default function ToolsPage() {
   return (
@@ -400,7 +408,27 @@ export default function ToolsPage() {
         title={`${totalToolCount} free marketing tools`}
         description="Calculators, generators, and utilities to help you make data-driven marketing decisions. Every tool is free — no account required."
         eventLocation="tools_hero"
+        primaryAction={null}
+        secondaryAction={null}
+        note="No signup. No usage limits."
       />
+
+      <nav aria-label="Tool categories" className="border-b border-neutral-200 dark:border-neutral-800">
+        <div className="mx-auto grid max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800 sm:grid-cols-2 lg:grid-cols-4">
+          {directoryLinks.map((item, index) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`group flex min-h-14 items-center justify-between gap-4 border-neutral-200 px-5 text-sm font-medium text-neutral-700 transition-colors hover:bg-neutral-50 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-emerald-500 dark:border-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-900/60 dark:hover:text-neutral-50 ${
+                index < directoryLinks.length - 1 ? "border-b sm:border-b-0 sm:odd:border-r lg:border-r" : ""
+              }`}
+            >
+              <span>{item.label}</span>
+              <span className="tabular-nums text-neutral-400 dark:text-neutral-500">{item.count}</span>
+            </Link>
+          ))}
+        </div>
+      </nav>
 
       <ToolSection
         id="calculators-title"
@@ -425,7 +453,7 @@ export default function ToolsPage() {
 
       <section className="border-b border-neutral-200 dark:border-neutral-800" aria-labelledby="social-tools-title">
         <div className="relative mx-auto grid max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
-          <GridCrosses />
+          <GridCrosses className="hidden sm:block" />
           <div className="border-b border-neutral-200 px-5 py-12 dark:border-neutral-800 sm:px-8 lg:col-span-4 lg:border-b-0 lg:border-r lg:px-10 lg:py-16">
             <div className="lg:sticky lg:top-24">
               <h2 id="social-tools-title" className="text-3xl font-semibold tracking-[-0.03em] md:text-4xl">

--- a/docs/src/app/[locale]/(home)/tools/privacy-policy-builder/PrivacyPolicyBuilderForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/privacy-policy-builder/PrivacyPolicyBuilderForm.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { TrackedButton } from "@/components/TrackedButton";
 import { CheckCircle, Copy } from "lucide-react";
 import { useState } from "react";
 
@@ -308,26 +307,6 @@ If you have any questions about this Privacy Policy, please contact us at:
           >
             Clear
           </button>
-        </div>
-      </div>
-
-      {/* CTA */}
-      <div className="border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-20 -mx-6 mt-16">
-        <div className="max-w-4xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 dark:text-white mb-4">
-            Privacy-first analytics with Rybbit
-          </h2>
-          <p className="text-lg text-neutral-600 dark:text-neutral-400 mb-8 max-w-2xl mx-auto">
-            No cookies, no tracking, full GDPR compliance. Get powerful analytics without compromising your users' privacy.
-          </p>
-          <TrackedButton
-            href="https://app.rybbit.io/signup"
-            eventName="signup"
-            eventProps={{ location: "privacy_policy_builder_cta" }}
-            className="inline-block bg-emerald-600 hover:bg-emerald-500 text-white font-semibold px-10 py-4 text-lg rounded-lg shadow-lg shadow-emerald-900/20 transform hover:-translate-y-0.5 transition-all duration-200"
-          >
-            Start tracking for free
-          </TrackedButton>
         </div>
       </div>
     </div>

--- a/docs/src/app/[locale]/(home)/tools/seo-title-generator/SEOTitleForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/seo-title-generator/SEOTitleForm.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import { TrackedButton } from "@/components/TrackedButton";
-import { DEFAULT_EVENT_LIMIT } from "@/lib/const";
 import { CheckCircle, Copy, Loader2 } from "lucide-react";
-import Link from "next/link";
 import { useState } from "react";
 
 interface TitleOption {
@@ -169,27 +166,6 @@ export function SEOTitleForm() {
               </div>
             </div>
           )}
-        </div>
-      </div>
-
-      {/* CTA */}
-      <div className="border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-20 -mx-6">
-        <div className="max-w-4xl mx-auto px-6 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 dark:text-white mb-4">
-            Track your SEO performance with Rybbit
-          </h2>
-          <p className="text-lg text-neutral-600 dark:text-neutral-400 mb-8 max-w-2xl mx-auto">
-            See which pages drive organic traffic and optimize your titles based on real data. Get started for free with
-            up to {DEFAULT_EVENT_LIMIT.toLocaleString()} pageviews per month.
-          </p>
-          <TrackedButton
-            href="https://app.rybbit.io/signup"
-            eventName="signup"
-            eventProps={{ location: "seo_title_generator_cta" }}
-            className="inline-block bg-emerald-600 hover:bg-emerald-500 text-white font-semibold px-10 py-4 text-lg rounded-lg shadow-lg shadow-emerald-900/20 transform hover:-translate-y-0.5 transition-all duration-200"
-          >
-            Start tracking for free
-          </TrackedButton>
         </div>
       </div>
     </>

--- a/docs/src/app/[locale]/(home)/tools/traffic-value-calculator/TrafficValueForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/traffic-value-calculator/TrafficValueForm.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import Link from "next/link";
 import { useState } from "react";
 
 export function TrafficValueForm() {
@@ -222,53 +220,6 @@ export function TrafficValueForm() {
               Clear
             </button>
           </div>
-        </div>
-      </div>
-
-      {/* FAQ Section */}
-      <div className="mb-12">
-        <h2 className="text-2xl font-bold text-neutral-900 dark:text-white mb-6">Frequently Asked Questions</h2>
-        <div className="bg-neutral-100/50 dark:bg-neutral-800/20 backdrop-blur-sm border border-neutral-300/50 dark:border-neutral-800/50 rounded-xl overflow-hidden">
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="item-1">
-              <AccordionTrigger>Why is knowing visitor value important?</AccordionTrigger>
-              <AccordionContent>
-                Understanding visitor value helps you make informed decisions about marketing spend, SEO investments, and website optimization. If each visitor is worth $2, you can confidently spend up to $2 per visitor on advertising while breaking even, and anything less is profitable.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-2">
-              <AccordionTrigger>How can I increase visitor value?</AccordionTrigger>
-              <AccordionContent>
-                You can increase visitor value by: improving conversion rate (better UX, faster site, clearer CTAs), increasing average order value (upsells, cross-sells, bundles), improving profit margins (better pricing, lower costs), or attracting higher-intent traffic (better targeting, SEO for buyer keywords).
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-3">
-              <AccordionTrigger>Should I include customer lifetime value?</AccordionTrigger>
-              <AccordionContent>
-                This calculator shows immediate value per visitor. For businesses with repeat customers, your actual visitor value is higher when including lifetime value (LTV). Track customer behavior over time with{" "}
-                <Link href="https://app.rybbit.io" className="text-emerald-600 dark:text-emerald-400 hover:underline">
-                  Rybbit Analytics
-                </Link>{" "}
-                to understand true LTV.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-4">
-              <AccordionTrigger>How do I calculate traffic value?</AccordionTrigger>
-              <AccordionContent>
-                Traffic value = (Monthly Visitors × Conversion Rate × Average Order Value × Profit Margin). This shows what each visitor is worth in profit. Our calculator does this automatically, but understanding the formula helps you see how each metric impacts your total value.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-5" className="border-b-0">
-              <AccordionTrigger>What profit margin should I use?</AccordionTrigger>
-              <AccordionContent>
-                Use your net profit margin (profit after all costs including COGS, wages, overhead, taxes). If you're not sure, calculate it as: (Total Profit / Total Revenue) × 100. Using an accurate margin ensures your visitor value calculations reflect real profitability, not just revenue.
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
         </div>
       </div>
     </>

--- a/docs/src/app/[locale]/(home)/tools/utm-builder/UTMBuilderForm.tsx
+++ b/docs/src/app/[locale]/(home)/tools/utm-builder/UTMBuilderForm.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { CheckCircle, Copy } from "lucide-react";
-import Link from "next/link";
 import { useMemo, useState } from "react";
 
 export function UTMBuilderForm() {
@@ -147,7 +145,7 @@ export function UTMBuilderForm() {
                   type="text"
                   value={utmUrl}
                   readOnly
-                  className="flex-1 px-4 py-3 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-neutral-900 dark:text-white font-mono text-sm"
+                  className="flex-1 px-4 py-3 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-300 dark:border-emerald-800 rounded-lg text-emerald-950 dark:text-emerald-100 font-mono text-sm"
                 />
                 <button
                   onClick={copyToClipboard}
@@ -169,53 +167,6 @@ export function UTMBuilderForm() {
               Clear
             </button>
           </div>
-        </div>
-      </div>
-
-      {/* FAQ Section */}
-      <div className="mb-12">
-        <h2 className="text-2xl font-bold text-neutral-900 dark:text-white mb-6">Frequently Asked Questions</h2>
-        <div className="bg-neutral-100/50 dark:bg-neutral-800/20 backdrop-blur-sm border border-neutral-300/50 dark:border-neutral-800/50 rounded-xl overflow-hidden">
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="item-1">
-              <AccordionTrigger>What is UTM tracking?</AccordionTrigger>
-              <AccordionContent>
-                UTM (Urchin Tracking Module) parameters are tags added to URLs that help you track the effectiveness of your marketing campaigns in analytics tools like Rybbit, Google Analytics, and others. They tell you exactly where your traffic is coming from and how your campaigns perform.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-2">
-              <AccordionTrigger>What are the required UTM parameters?</AccordionTrigger>
-              <AccordionContent>
-                The three required parameters are: <strong>utm_source</strong> (identifies the source like google or newsletter), <strong>utm_medium</strong> (identifies the medium like cpc or email), and <strong>utm_campaign</strong> (identifies the specific campaign like summer_sale).
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-3">
-              <AccordionTrigger>How do I track UTM links with Rybbit?</AccordionTrigger>
-              <AccordionContent>
-                Once you have Rybbit installed on your website, UTM parameters are automatically tracked. You can view your campaign performance in your{" "}
-                <Link href="https://app.rybbit.io" className="text-emerald-600 dark:text-emerald-400 hover:underline">
-                  Rybbit dashboard
-                </Link>{" "}
-                under the UTM section.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-4">
-              <AccordionTrigger>What are optional UTM parameters?</AccordionTrigger>
-              <AccordionContent>
-                <strong>utm_term</strong> is used for tracking paid search keywords, while <strong>utm_content</strong> helps differentiate between different ads or links within the same campaign. These are optional but useful for deeper campaign analysis and A/B testing.
-              </AccordionContent>
-            </AccordionItem>
-
-            <AccordionItem value="item-5" className="border-b-0">
-              <AccordionTrigger>What naming conventions should I follow?</AccordionTrigger>
-              <AccordionContent>
-                Use lowercase letters and underscores instead of spaces (e.g., summer_sale, not Summer Sale). Be consistent across campaigns so data is properly grouped in analytics. Avoid special characters and keep names descriptive but concise.
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
         </div>
       </div>
     </>

--- a/docs/src/components/Footer.tsx
+++ b/docs/src/components/Footer.tsx
@@ -85,7 +85,7 @@ export function Footer() {
   return (
     <footer className="border-t border-neutral-200 dark:border-neutral-800">
       <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
-        <GridCrosses />
+        <GridCrosses className="hidden sm:block" />
         <div className="grid border-b border-neutral-200 dark:border-neutral-800 lg:grid-cols-12">
           <div className="border-b border-neutral-200 px-5 py-10 dark:border-neutral-800 sm:px-8 lg:col-span-3 lg:border-b-0 lg:border-r lg:py-14">
             <div className="flex h-full flex-col">

--- a/docs/src/components/RelatedTools.tsx
+++ b/docs/src/components/RelatedTools.tsx
@@ -1370,34 +1370,40 @@ export function RelatedTools({ currentToolHref, category, maxTools = 6 }: Relate
   }
 
   return (
-    <div className="mt-20 pt-16 border-t border-neutral-200 dark:border-neutral-800">
-      <div className="mb-6">
-        <h2 className="text-xl font-semibold text-neutral-900 dark:text-white mb-4">Related Tools</h2>
-        <ul className="space-y-3">
-          {relatedTools.map(tool => (
-            <li key={tool.href}>
-              <Link
-                href={tool.href}
-                className="group flex items-center gap-2 text-neutral-700 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors"
-              >
-                <ArrowRight className="w-4 h-4 flex-shrink-0 group-hover:translate-x-1 transition-transform" />
-                <span className="font-medium">{tool.name}</span>
-                <span className="text-sm text-neutral-500 dark:text-neutral-500">— {tool.description}</span>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </div>
-
-      <div className="mt-6">
+    <div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight text-neutral-950 dark:text-neutral-50">Related tools</h2>
+          <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">Keep working with a nearby calculator or utility.</p>
+        </div>
         <Link
           href="/tools"
-          className="inline-flex items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-neutral-100 font-medium transition-colors"
+          className="inline-flex min-h-9 items-center gap-2 rounded-md text-sm font-medium text-neutral-700 transition-colors hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 dark:text-neutral-300 dark:hover:text-neutral-50"
         >
           View all tools
-          <ArrowRight className="w-4 h-4" />
+          <ArrowRight className="size-4" aria-hidden="true" />
         </Link>
       </div>
+
+      <ul className="mt-6 grid border-x border-t border-neutral-200 dark:border-neutral-800 sm:grid-cols-2 lg:grid-cols-3">
+        {relatedTools.map(tool => (
+          <li key={tool.href} className="border-b border-neutral-200 dark:border-neutral-800 sm:odd:border-r lg:border-r lg:nth-[3n]:border-r-0">
+            <Link
+              href={tool.href}
+              className="group flex h-full min-h-28 flex-col justify-between gap-4 px-4 py-4 transition-colors hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-500 dark:hover:bg-neutral-900/50"
+            >
+              <span>
+                <span className="block text-sm font-semibold text-neutral-900 dark:text-neutral-100">{tool.name}</span>
+                <span className="mt-1 block text-sm leading-5 text-neutral-500 dark:text-neutral-400">{tool.description}</span>
+              </span>
+              <ArrowRight
+                className="size-3.5 text-neutral-400 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none dark:text-neutral-600"
+                aria-hidden="true"
+              />
+            </Link>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- turn every free-tool page into a compact, app-style workspace with shared control density, an instrument-panel rail, and responsive guide/FAQ columns
- replace the tools catalog card wall with category navigation and dense directory rows
- consolidate repeated FAQs and conversion banners into the shared page layout, and tighten related-tool and Rybbit provenance sections
- remove mobile rail-cross overflow and preserve 44px touch targets on coarse-pointer devices

## Verification
- `cd docs && tsc --noEmit`
- `cd docs && npm run build` (Node 24; 4,709 static pages)
- Impeccable layout detector: clean
- Impeccable full detector on changed shared surfaces: clean
- visual checks at 1440px and emulated 390px across the tools directory, CTR calculator, and LinkedIn character counter
- live CTR interaction/result-state check; mobile `scrollWidth === clientWidth`

## Assessment
Ran the Impeccable layout workflow with two isolated parallel assessments: qualitative layout review and mechanical pre-scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added category navigation with tool counts to the tools directory.
  * Introduced a redesigned tool workspace layout with responsive form styling.
  * Added a refreshed “Built by Rybbit” information panel and related-tools card grid.

* **Improvements**
  * Updated tool cards, CTA sections, spacing, typography, and responsive visuals.
  * Simplified several tool pages by removing embedded FAQs and promotional CTAs.
  * Improved mobile and accessibility behavior across tool pages and decorative elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->