### PR TITLE
Fix embed widget to use hex site ids and load under /widget/<hexId>.

### DIFF
--- a/client/src/app/[site]/components/Header/NoData.tsx
+++ b/client/src/app/[site]/components/Header/NoData.tsx
@@ -123,7 +123,9 @@ export function NoData() {
   const { data: siteHasData, isLoading } = useSiteHasData(site);
   const { data: siteMetadata, isLoading: isLoadingSiteMetadata } = useGetSite(site);
 
-  if (siteHasData || isLoading || isLoadingSiteMetadata) {
+  const siteId = siteMetadata?.id ?? siteMetadata?.siteId ?? (site || undefined);
+
+  if (siteHasData || isLoading || isLoadingSiteMetadata || !siteId) {
     return null;
   }
 
@@ -131,7 +133,6 @@ export function NoData() {
   const hiddenCount = PLATFORM_GUIDES.length - VISIBLE_PLATFORM_COUNT;
 
   const isMobileSite = siteMetadata?.type === "mobile";
-  const siteId = siteMetadata?.id ?? siteMetadata?.siteId;
   const scriptUrl = `${globalThis.location.origin}/api/script.js`;
 
   const htmlSnippet = `<script\n    src="${scriptUrl}"\n    data-site-id="${siteId}"\n    defer\n></script>`;

--- a/client/src/components/SiteSettings/EmbedTab.tsx
+++ b/client/src/components/SiteSettings/EmbedTab.tsx
@@ -60,7 +60,7 @@ export function EmbedTab({ siteMetadata, embedEnabled }: EmbedTabProps) {
   const [accent, setAccent] = useState<string>(DEFAULT_ACCENT);
   const [widgetOutputTab, setWidgetOutputTab] = useState<OutputTab>("preview");
 
-  const siteId = siteMetadata.siteId;
+  const siteId = siteMetadata.id ?? String(siteMetadata.siteId);
   const origin = typeof window !== "undefined" ? window.location.origin : "";
 
   const widgetUrl = new URL(`${origin}/widget/${siteId}`);

--- a/client/src/proxy.ts
+++ b/client/src/proxy.ts
@@ -10,6 +10,12 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // Embed widget routes — hex public site ids are 12 chars and would otherwise
+  // match the private-key pattern below (/widget/<hexId>).
+  if (path.startsWith("/widget/")) {
+    return NextResponse.next();
+  }
+
   // Handle GitHub OAuth callback redirect
   if (path.includes("/auth/callback/github") || path.includes("/auth/callback/google")) {
     const redirectUrl = new URL(`/api${path}${request.nextUrl.search}`, request.url);


### PR DESCRIPTION
Fixes https://github.com/rybbit-io/rybbit/issues/994


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site identification when displaying empty-state content and embedded widgets.
  * Prevented widget pages from being incorrectly redirected or rewritten.
  * Ensured widget embeds use the correct site destination when metadata varies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->