### PR TITLE
fix(events): don't pass display labels to t()

### DIFF
--- a/client/src/app/[site]/events/components/EventLog/EventDetailsSheet.tsx
+++ b/client/src/app/[site]/events/components/EventLog/EventDetailsSheet.tsx
@@ -61,7 +61,7 @@ export function EventDetailsSheet({ open, onOpenChange, event, site }: EventDeta
           <SheetTitle>
             <div className="flex items-center gap-2">
               <EventTypeIcon type={event?.type || ""} className="w-5 h-5" />
-              <span className="font-medium">{getEventTypeLabel(event?.type || "", t)}</span>
+              <span className="font-medium">{getEventTypeLabel(event?.type || "")}</span>
             </div>
           </SheetTitle>
         </SheetHeader>

--- a/client/src/app/[site]/events/components/EventLog/EventRow.tsx
+++ b/client/src/app/[site]/events/components/EventLog/EventRow.tsx
@@ -34,7 +34,7 @@ export function EventRow({ event, site, onClick }: EventRowProps) {
   const pagePath = buildEventPath(event);
   const pageUrl = `https://${event.hostname}${pagePath}`;
   const isPageview = event.type === "pageview";
-  const eventData = isPageview ? null : getMainData(event, eventProperties, getEventDisplayName, t);
+  const eventData = isPageview ? null : getMainData(event, eventProperties, getEventDisplayName);
   const userProfileId = event.identified_user_id || event.user_id;
   const displayName = getUserDisplayName({
     identified_user_id: event.identified_user_id || undefined,
@@ -55,7 +55,7 @@ export function EventRow({ event, site, onClick }: EventRowProps) {
             </div>
           </TooltipTrigger>
           <TooltipContent>
-            <span>{getEventTypeLabel(event.type, t)}</span>
+            <span>{getEventTypeLabel(event.type)}</span>
           </TooltipContent>
         </Tooltip>
       </div>

--- a/client/src/app/[site]/events/components/EventLog/eventLogUtils.tsx
+++ b/client/src/app/[site]/events/components/EventLog/eventLogUtils.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Event } from "../../../../../api/analytics/endpoints";
-import { EVENT_TYPE_CONFIG, EventDisplayNameFormatter, TranslationFunction } from "../../../../../lib/events";
+import { EVENT_TYPE_CONFIG, EventDisplayNameFormatter } from "../../../../../lib/events";
 
 export function getEventKey(event: Event) {
   return `${event.timestamp}-${event.session_id}-${event.user_id}-${event.type}-${event.event_name ?? ""}-${event.pathname}`;
@@ -18,9 +18,11 @@ export function parseEventProperties(event: Event): Record<string, any> {
   return {};
 }
 
-export function getEventTypeLabel(type: string, t?: TranslationFunction) {
-  const label = EVENT_TYPE_CONFIG.find(item => item.value === type)?.label ?? "Event";
-  return t ? t(label) : label;
+// EVENT_TYPE_CONFIG labels are display strings ("Pageview", "Input Change"), not
+// message keys, so they must not be passed to t() — doing so throws MISSING_MESSAGE
+// and breaks the events page. Return them as-is.
+export function getEventTypeLabel(type: string) {
+  return EVENT_TYPE_CONFIG.find(item => item.value === type)?.label ?? "Event";
 }
 
 export function buildEventPath(event: Event) {
@@ -30,8 +32,7 @@ export function buildEventPath(event: Event) {
 export function getMainData(
   event: Event,
   props: Record<string, any>,
-  getEventDisplayName: EventDisplayNameFormatter,
-  t?: TranslationFunction
+  getEventDisplayName: EventDisplayNameFormatter
 ) {
   const isPageview = event.type === "pageview";
   const isOutbound = event.type === "outbound";
@@ -61,6 +62,6 @@ export function getMainData(
   }
 
   return {
-    label: event.event_name || (t ? t("Event") : "Event"),
+    label: event.event_name || "Event",
   };
 }


### PR DESCRIPTION
## Summary

The events page throws `MISSING_MESSAGE` on every render — server-side and in the browser, where it breaks the page rather than just mislabelling it.

`getEventTypeLabel` looks up `EVENT_TYPE_CONFIG` and passes the result to `t()`:

```ts
const label = EVENT_TYPE_CONFIG.find(item => item.value === type)?.label ?? "Event";
return t ? t(label) : label;
```

But those labels are display strings (`"Pageview"`, `"Input Change"`, `"Button Click"`), not message keys — the catalogs are keyed by hashed ids (`cQyKR1`, `zSOvI0`, …). So no lookup can ever resolve, for any event type. `getMainData` has the same problem with a literal `t("Event")`.

This is exactly the case `client/CLAUDE.md` already warns about:

> only pass real message keys to `t(...)`. Passing an arbitrary string (e.g. a display label like `"Input Change"`) throws `MISSING_MESSAGE: Could not resolve …`. If a value isn't a key in `messages/`, return it as-is instead of running it through `t`.

Both helpers now return their labels as-is. The unused `t` parameters and the now-unused `TranslationFunction` import are dropped, and the two call sites updated.

## Reproduction

Self-hosted 2.7.0, locale `en`, open `/{site}/events`:

```
Error: MISSING_MESSAGE: Event (en)
    at H (.next/server/chunks/ssr/src_app_[site]_events_page_tsx_0tib3am._.js:1:832)
    at J (.next/server/chunks/ssr/src_app_[site]_events_page_tsx_0tib3am._.js:1:1830) {
  code: 'MISSING_MESSAGE',
  originalMessage: 'Event (en)'
}
```

The same error repeats in the browser console and the page fails to render its content.

## Validation

- `tsc --noEmit` clean in `client/` (with `shared/` built).
- Built and deployed to a self-hosted 2.7.0 instance: the errors are gone and the events page renders.

## Note

This drops translation of these labels rather than adding catalog entries, which matches the documented convention. If they should be translated, the fix would instead be to store message ids in `EVENT_TYPE_CONFIG` — happy to redo it that way if you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event log label handling for more consistent event type and event name display.
  - Preserved event-specific details while providing clearer fallback labels for unidentified events.
  - Maintained existing translations for browser, operating system, and device information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->