### PR TITLE
fix(sessions): guard useGetSessionsInfinite on site

### DIFF
--- a/client/src/api/analytics/hooks/useGetUserSessions.ts
+++ b/client/src/api/analytics/hooks/useGetUserSessions.ts
@@ -89,6 +89,10 @@ export function useGetSessionsInfinite({
     },
     staleTime: Infinity,
     refetchInterval,
+    // Without this the hook fires while the store's site is still empty, requesting
+    // /api/sites//sessions (400). LiveUserCount renders on every [site] page, so
+    // this ran on every page load.
+    enabled: !!site,
   });
 }
 


### PR DESCRIPTION
## Summary

`useGetSessionsInfinite` is a bare `useInfiniteQuery` with no `enabled` guard, so it fires before the store's `site` has hydrated and requests `/api/sites//sessions` (note the empty segment), which the backend rejects with 400.

`LiveUserCount` lives in `SubHeader`, so it renders on every `[site]` page — this fires on every page load, and re-fires on its 10s `refetchInterval` until `site` resolves.

Adding `enabled: !!site` brings it in line with the rest of the codebase:

- every sibling hook in the same file already guards (`enabled: !!sessionId && !!site`, `enabled: !!site && !!userId`)
- `useAnalyticsQuery` / `useAnalyticsInfiniteQuery` do the same via `enabled: (options.enabled ?? true) && !!site`

Same class of bug as #1037.

## Reproduction

Open any `/{site}/…` page on a self-hosted instance and watch the network tab on first paint:

```
GET /api/sites//sessions?time_zone=Europe/Vienna&past_minutes_start=5&past_minutes_end=0&page=1&limit=25
→ 400
```

## Validation

- `tsc --noEmit` clean in `client/` (with `shared/` built).
- Built and deployed to a self-hosted 2.7.0 instance; the empty-site requests no longer occur and live user count still populates normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented session data requests from running when no site is selected.
  * Avoided invalid requests and repeated rendering on site-related pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->