### PR TITLE
Fix event name filtering in Events table

### DIFF
--- a/server/src/api/analytics/events/getEvents.test.ts
+++ b/server/src/api/analytics/events/getEvents.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../db/clickhouse/clickhouse.js", () => ({
+  clickhouse: { query: vi.fn() },
+}));
+vi.mock("../../../db/postgres/postgres.js", () => ({
+  db: {},
+}));
+
+import { buildEventsQuery } from "./getEvents.js";
+
+const SITE_ID = 1;
+
+const baseQuery = (overrides: Partial<Record<string, unknown>> = {}) =>
+  ({
+    start_date: "",
+    end_date: "",
+    time_zone: "UTC",
+    filters: "",
+    page_size: "50",
+    ...overrides,
+  }) as Parameters<typeof buildEventsQuery>[0];
+
+describe("buildEventsQuery filters", () => {
+  it("filters event names at the event-row level", () => {
+    const filters = JSON.stringify([{ parameter: "event_name", type: "equals", value: ["att_prompt_shown"] }]);
+    const { query } = buildEventsQuery(baseQuery({ filters }), SITE_ID);
+
+    expect(query).toContain("AND event_name = 'att_prompt_shown'");
+    expect(query).not.toContain("SELECT DISTINCT session_id");
+  });
+
+  it("keeps channel filters at the session level", () => {
+    const filters = JSON.stringify([{ parameter: "channel", type: "equals", value: ["Direct"] }]);
+    const { query } = buildEventsQuery(baseQuery({ filters }), SITE_ID);
+
+    expect(query).toContain("session_id IN");
+    expect(query).toContain("session_channel = 'Direct'");
+  });
+
+  it("does not add a filter clause when filters are empty", () => {
+    const { query, params } = buildEventsQuery(baseQuery(), SITE_ID);
+
+    expect(query).not.toContain("session_id IN");
+    expect(params).toEqual({ siteId: SITE_ID, limit: 50 });
+  });
+});

--- a/server/src/api/analytics/events/getEvents.ts
+++ b/server/src/api/analytics/events/getEvents.ts
@@ -77,7 +77,10 @@ export const buildEventsQuery = (query: GetEventsRequest["Querystring"], siteId:
   const { since_timestamp, before_timestamp, page_size: pageSize = "50", filters } = query;
 
   const limit = parseInt(pageSize, 10);
-  const filterStatement = filters ? getFilterStatement(filters, siteId) : "";
+  // The event log filters individual rows; only channel remains session-attributed.
+  const filterStatement = filters
+    ? getFilterStatement(filters, siteId, undefined, { sessionLevelParams: ["channel"] })
+    : "";
 
   // Mode A: Poll for new events since a timestamp (Realtime polling)
   if (since_timestamp) {


### PR DESCRIPTION
## Summary

- filter `event_name` directly against rows in the Events table
- keep `channel` filters session-attributed
- add query-level regression tests for event names, channels, and empty filters

## Root cause

The shared filter builder treats both `event_name` and `channel` as session-level filters by default. The Events endpoint inherited that default, so selecting an event name returned every event from matching sessions instead of only matching event rows.

## Validation

- `npm run build`
- `npx vitest run src/api/analytics/events/getEvents.test.ts` (3 tests)
- `npx vitest run --exclude src/mcp/mcp.test.ts` (1,071 tests)
- `npx prettier --check src/api/analytics/events/getEvents.ts src/api/analytics/events/getEvents.test.ts`

The full test command completed 1,102 passing assertions locally, but Vitest exited non-zero on Windows because `src/mcp/mcp.test.ts` emitted three unrelated `socket.destroySoon` teardown errors.

## AI assistance

OpenAI Codex assisted with implementation, tests, and validation. The final diff and generated queries were reviewed locally.

Fixes #1090


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics event filtering so event-name filters apply directly to event records.
  * Preserved session-level filtering for channel-based queries.
  * Ensured unfiltered event queries avoid unnecessary session filtering.

* **Tests**
  * Added coverage for event-name, channel, and no-filter query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->