### PR TITLE
fix: truncate long urls from hiding the timestamp

### DIFF
--- a/client/src/components/Sessions/SessionDetails/PageviewItem.tsx
+++ b/client/src/components/Sessions/SessionDetails/PageviewItem.tsx
@@ -220,7 +220,7 @@ export function PageviewItem({
         </div>
       </div>
 
-      <div className="flex flex-col ml-3 flex-1">
+      <div className="flex flex-col ml-3 flex-1 min-w-0">
         <div className="flex items-center flex-1 py-1">
           <div className="shrink-0 mr-3">
             <EventTypeIcon type={item.type} />
@@ -236,9 +236,6 @@ export function PageviewItem({
                 <div
                   className="text-sm truncate hover:underline "
                   title={item.pathname}
-                  style={{
-                    maxWidth: "calc(min(100vw, 1150px) - 250px)",
-                  }}
                 >
                   {showHostname && item.hostname}
                   {item.pathname}
@@ -258,9 +255,6 @@ export function PageviewItem({
                 <div
                   className="text-sm truncate hover:underline"
                   title={String(item.props.url)}
-                  style={{
-                    maxWidth: "calc(min(100vw, 1150px) - 250px)",
-                  }}
                 >
                   {String(item.props.url)}
                 </div>


### PR DESCRIPTION
Closes #1099 

After the fix:

<img width="1712" height="562" alt="after-width-fix" src="https://github.com/user-attachments/assets/2f9bd9cb-aed1-4ee7-ac0b-4b0f42cb5f76" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text overflow handling in session details, ensuring long page paths and outbound URLs display cleanly without disrupting the layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->