### PR TITLE
fix(tracker): fall back custom UTM traffic without HTTP referrer to Referral instead of Unknown

### DIFF
--- a/server/src/services/tracker/getChannel.test.ts
+++ b/server/src/services/tracker/getChannel.test.ts
@@ -6,6 +6,7 @@ describe("getChannel - UTM parameter fallback", () => {
     expect(getChannel("", "utm_source=my_app&utm_medium=custom")).toBe("Referral");
     expect(getChannel("", "utm_source=gsuite_extension")).toBe("Referral");
     expect(getChannel("", "utm_medium=custom_link")).toBe("Referral");
+    expect(getChannel("", "utm_campaign=custom_campaign")).toBe("Referral");
   });
 
   it("retains Direct classification when no referrer and no UTM parameters exist", () => {
@@ -14,5 +15,8 @@ describe("getChannel - UTM parameter fallback", () => {
 
   it("retains Referral classification for external referring domains", () => {
     expect(getChannel("https://external-site.com/blog", "")).toBe("Referral");
+    expect(
+      getChannel("https://example.com/page", "utm_source=custom_source", "example.com"),
+    ).not.toBe("Referral");    
   });
 });

--- a/server/src/services/tracker/getChannel.test.ts
+++ b/server/src/services/tracker/getChannel.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getChannel } from "./getChannel.js";
+
+describe("getChannel - UTM parameter fallback", () => {
+  it("classifies traffic with custom UTM parameters as Referral when no HTTP referrer is present", () => {
+    expect(getChannel("", "utm_source=my_app&utm_medium=custom")).toBe("Referral");
+    expect(getChannel("", "utm_source=gsuite_extension")).toBe("Referral");
+    expect(getChannel("", "utm_medium=custom_link")).toBe("Referral");
+  });
+
+  it("retains Direct classification when no referrer and no UTM parameters exist", () => {
+    expect(getChannel("", "")).toBe("Direct");
+  });
+
+  it("retains Referral classification for external referring domains", () => {
+    expect(getChannel("https://external-site.com/blog", "")).toBe("Referral");
+  });
+});

--- a/server/src/services/tracker/getChannel.ts
+++ b/server/src/services/tracker/getChannel.ts
@@ -287,9 +287,11 @@ export function getChannel(referrer: string, querystring: string, hostname?: str
   if (/event|conference|webinar/.test(utmCampaign)) return "Event";
   if (/social|facebook|twitter|instagram|linkedin/.test(utmCampaign)) return "Organic Social";
 
-  // If referring domain exists but we couldn't categorize it
-  // Don't mark as referral if it's a self-referral
-  if (referringDomain && referringDomain !== "$direct" && !selfReferral) return "Referral";
+  // If referring domain or UTM parameters exist but couldn't be categorized into a specific channel,
+  // classify as Referral (unless it's a self-referral)
+  if ((utmSource || utmMedium || utmCampaign || (referringDomain && referringDomain !== "$direct")) && !selfReferral) {
+    return "Referral";
+  }
 
   // Default fallback
   return "Unknown";

--- a/server/src/services/tracker/getChannel.ts
+++ b/server/src/services/tracker/getChannel.ts
@@ -187,6 +187,7 @@ export function getChannel(referrer: string, querystring: string, hostname?: str
   if (
     (referringDomain === "$direct" || (!referrer && !selfReferral)) &&
     !utmMedium &&
+    !utmCampaign &&
     (!utmSource || utmSource === "direct" || utmSource === "(direct)")
   ) {
     return "Direct";


### PR DESCRIPTION
Fixes an issue in `getChannel()` where incoming traffic carrying explicit `utm_source`, `utm_medium`, or `utm_campaign` parameters is categorized as `"Unknown"` if the HTTP `Referrer` header is missing or suppressed (e.g., mobile app links, Android WebViews, QR codes, cross-protocol navigation, or `rel="noreferrer"` links).

## Problem
In `server/src/services/tracker/getChannel.ts`, custom UTM parameters that do not match hardcoded search/social/AI lists fall through to the final referral check:

```ts
if (referringDomain && referringDomain !== "$direct" && !selfReferral) return "Referral";
```

When an HTTP Referrer header is absent (which is standard behavior on mobile app links and WebViews), referringDomain evaluates to "$direct". This causes the check to fail and returns "Unknown" for channel.

## Fix

Updated the fallback condition in getChannel.ts so that non-self-referral traffic carrying any UTM parameters (utmSource, utmMedium, or utmCampaign) falls back to "Referral" instead of "Unknown".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved traffic-source classification for visits with custom UTM parameters, even when no HTTP referrer is available.
  - External referrals continue to be identified correctly, while direct visits remain classified as Direct.
  - Prevented self-referrals from being incorrectly classified as Referral.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->