### PR TITLE
fix(self-host): show Web Vitals and Search Console on self-hosted installs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,11 @@ POSTGRES_PASSWORD=frog
 
 # External Service Tokens (optional)
 MAPBOX_TOKEN=
+
+# Google Search Console integration (optional)
+# Create an OAuth 2.0 Client ID at https://console.cloud.google.com/apis/credentials
+# and enable the Google Search Console API for the project. The authorized
+# redirect URI must exactly match GOOGLE_REDIRECT_URI below.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI="${BASE_URL}/api/gsc/callback"

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ See how Rybbit compares to other analytics solutions:
 
 <img width="1299" height="797" alt="Screenshot 2025-10-16 at 7 34 20 PM" src="https://github.com/user-attachments/assets/c56a31ac-7af5-419b-82a5-d3aedb68debc" />
 
-### Web Vitals (Cloud only)
+### Web Vitals
 
 <img width="1299" height="797" alt="Screenshot 2025-10-16 at 7 28 01 PM" src="https://github.com/user-attachments/assets/d88b8be0-cd30-4dd6-a0e5-5446c890c0f9" />
 

--- a/client/src/app/[site]/components/Sidebar/Sidebar.tsx
+++ b/client/src/app/[site]/components/Sidebar/Sidebar.tsx
@@ -98,7 +98,7 @@ function SidebarContent() {
             icon={<File className="w-4 h-4" />}
           />
         )}
-        {IS_CLOUD && !isMobileSite && (
+        {!isMobileSite && (
           <SidebarComponents.Item
             label={t("Performance")}
             active={isActiveTab("performance")}

--- a/client/src/app/[site]/main/page.tsx
+++ b/client/src/app/[site]/main/page.tsx
@@ -3,7 +3,8 @@ import { ReactNode } from "react";
 import { useGetLiveUserCount } from "../../../api/analytics/hooks/useGetLiveUserCount";
 import { useInView } from "../../../hooks/useInView";
 import { useSetPageTitle } from "../../../hooks/useSetPageTitle";
-import { IS_CLOUD, LITE_DASHBOARD } from "../../../lib/const";
+import { useConfigs } from "../../../lib/configs";
+import { LITE_DASHBOARD } from "../../../lib/const";
 import { useStore } from "../../../lib/store";
 import { SubHeader } from "../components/SubHeader/SubHeader";
 import { MainSection } from "./components/MainSection/MainSection";
@@ -40,6 +41,7 @@ export default function MainPage() {
 
 function MainPageContent() {
   const { data } = useGetLiveUserCount(5);
+  const { configs } = useConfigs();
 
   useSetPageTitle(`${data?.count ?? "…"} user${data?.count === 1 ? "" : "s"} online`);
 
@@ -89,7 +91,7 @@ function MainPageContent() {
         <LazySection>
           <Weekdays />
         </LazySection>
-        {IS_CLOUD && (
+        {configs?.gscEnabled && (
           <LazySection>
             <SearchConsole />
           </LazySection>

--- a/client/src/components/SiteSettings/SiteSettings.tsx
+++ b/client/src/components/SiteSettings/SiteSettings.tsx
@@ -35,7 +35,7 @@ import { useGetSite } from "../../api/admin/hooks/useSites";
 import { useUserOrganizations } from "../../api/admin/hooks/useOrganizations";
 import { useGetSitesFromOrg } from "../../api/admin/hooks/useSites";
 import { SiteResponse, updateSiteConfig } from "../../api/admin/endpoints";
-import { IS_CLOUD } from "../../lib/const";
+import { useConfigs } from "../../lib/configs";
 
 export function SiteSettings({ siteId, trigger }: { siteId: number; trigger?: React.ReactNode }) {
   const { data: siteMetadata, isLoading, error } = useGetSite(siteId);
@@ -60,6 +60,7 @@ type TabKey =
 
 function SiteSettingsInner({ siteMetadata, trigger }: { siteMetadata: SiteResponse; trigger?: React.ReactNode }) {
   const t = useExtracted();
+  const { configs } = useConfigs();
   const { data: session } = authClient.useSession();
   const { data: userOrganizationsData } = useUserOrganizations();
   const siteOrgMembership = userOrganizationsData?.find(org => org.id === siteMetadata.organizationId);
@@ -106,7 +107,7 @@ function SiteSettingsInner({ siteMetadata, trigger }: { siteMetadata: SiteRespon
     { key: "general", label: t("General"), icon: Settings },
     { key: "tracking", label: t("Tracking"), icon: SlidersHorizontal },
     { key: "exclusions", label: t("Exclusions"), icon: Ban },
-    { key: "integrations", label: t("Integrations"), icon: Plug, hidden: !IS_CLOUD },
+    { key: "integrations", label: t("Integrations"), icon: Plug, hidden: !configs?.gscEnabled },
     { key: "script", label: isMobileSite ? t("React Native SDK") : t("Tracking Script"), icon: Code },
     { key: "widget-embeds", label: t("Widget Embeds"), icon: LayoutTemplate },
     { key: "dashboard-embed", label: t("Dashboard Embed"), icon: LayoutDashboard },
@@ -183,7 +184,7 @@ function SiteSettingsInner({ siteMetadata, trigger }: { siteMetadata: SiteRespon
               )}
               {activeTab === "tracking" && <TrackingTab siteMetadata={currentSiteMetadata} disabled={disabled} />}
               {activeTab === "exclusions" && <ExclusionsTab siteId={siteMetadata.siteId} disabled={disabled} />}
-              {activeTab === "integrations" && IS_CLOUD && <IntegrationsTab disabled={disabled} />}
+              {activeTab === "integrations" && configs?.gscEnabled && <IntegrationsTab disabled={disabled} />}
               {activeTab === "script" && (
                 <ScriptBuilder
                   siteId={siteMetadata.id ?? String(siteMetadata.siteId)}

--- a/client/src/components/SiteSettings/TrackingTab.tsx
+++ b/client/src/components/SiteSettings/TrackingTab.tsx
@@ -114,7 +114,7 @@ export function TrackingTab({ siteMetadata, disabled = false }: TrackingTabProps
           } as ToggleConfig,
         ]
       : []),
-    ...(IS_CLOUD && !isMobileSite
+    ...(!isMobileSite
       ? [
           {
             id: "webVitals",

--- a/client/src/lib/configs.ts
+++ b/client/src/lib/configs.ts
@@ -5,6 +5,7 @@ interface Configs {
   disableSignup: boolean;
   mapboxToken: string;
   liteDashboard: boolean;
+  gscEnabled: boolean;
 }
 
 export function useConfigs() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,9 @@ services:
       - LITE_DASHBOARD=${LITE_DASHBOARD}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
       - OPENROUTER_MODEL=${OPENROUTER_MODEL}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      - GOOGLE_REDIRECT_URI=${GOOGLE_REDIRECT_URI}
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/docs/content/docs/(docs)/self-hosting-guides/self-hosting-manual.mdx
+++ b/docs/content/docs/(docs)/self-hosting-guides/self-hosting-manual.mdx
@@ -47,6 +47,11 @@ DISABLE_SIGNUP=false
 # Optional but recommended: Mapbox token for globe visualizations
 MAPBOX_TOKEN=your_mapbox_token
 
+# Optional: enables the Google Search Console integration
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+GOOGLE_REDIRECT_URI=https://your.domain.com/api/gsc/callback
+
 # Optional: Custom ports (only needed if you want different ports)
 # HOST_BACKEND_PORT="3001:3001"
 # HOST_CLIENT_PORT="3002:3002"
@@ -236,6 +241,30 @@ HOST_BACKEND_PORT="8080:3001"
 HOST_CLIENT_PORT="8081:3002"
 ```
 
+### Google Search Console
+
+The Search Console integration appears in Site Settings → Integrations once the
+backend has Google OAuth credentials. No client rebuild is needed — the setting is
+served at runtime from `/api/config`.
+
+1. In the [Google Cloud console](https://console.cloud.google.com/apis/credentials),
+   create an OAuth 2.0 Client ID of type "Web application" and enable the
+   Google Search Console API for the project.
+2. Add `https://your.domain.com/api/gsc/callback` as an authorized redirect URI.
+   It must match `GOOGLE_REDIRECT_URI` exactly.
+3. Set `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` and `GOOGLE_REDIRECT_URI` in your
+   `.env`, then restart the backend:
+
+   ```bash
+   docker compose up -d backend
+   ```
+
+4. Open Site Settings → Integrations and click Connect.
+
+The Google account you authorize must already have access to the Search Console
+property. Note that if you also enable Public Analytics for a site, its Search
+Console data becomes readable by anonymous visitors to that dashboard.
+
 ### Using with Coolify
 
 Since Coolify uses Traefik instead of Caddy as proxy, some modifications have to be made in a `docker-compose.yaml` file to avoid conflicts. Specifically, you need to:
@@ -349,6 +378,9 @@ services:
       - DISABLE_SIGNUP=${DISABLE_SIGNUP}
       - DISABLE_TELEMETRY=${DISABLE_TELEMETRY}
       - MAPBOX_TOKEN=${MAPBOX_TOKEN}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      - GOOGLE_REDIRECT_URI=${GOOGLE_REDIRECT_URI}
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/server/src/api/getConfig.test.ts
+++ b/server/src/api/getConfig.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted above every top-level statement, so the factory cannot
+// close over a plain `const`. vi.hoisted lifts the fixture with it.
+const mockConst = vi.hoisted(() => ({
+  DISABLE_SIGNUP: false,
+  MAPBOX_TOKEN: "mapbox-token",
+  LITE_DASHBOARD: false,
+  GOOGLE_CLIENT_ID: undefined as string | undefined,
+  GOOGLE_CLIENT_SECRET: undefined as string | undefined,
+}));
+
+vi.mock("../lib/const.js", () => mockConst);
+
+// Distinctive values so the leak assertion cannot pass by coincidence.
+const CLIENT_ID_SENTINEL = "google-client-id-sentinel";
+const CLIENT_SECRET_SENTINEL = "google-client-secret-sentinel";
+
+const { getConfig } = await import("./getConfig.js");
+
+function makeReply() {
+  const reply = {
+    payload: undefined as unknown,
+    send(body: unknown) {
+      reply.payload = body;
+      return reply;
+    },
+  };
+  return reply;
+}
+
+async function callGetConfig() {
+  const reply = makeReply();
+  await getConfig({} as never, reply as never);
+  return reply.payload as Record<string, unknown>;
+}
+
+describe("getConfig", () => {
+  beforeEach(() => {
+    mockConst.GOOGLE_CLIENT_ID = undefined;
+    mockConst.GOOGLE_CLIENT_SECRET = undefined;
+  });
+
+  it("reports gscEnabled false when no Google OAuth credentials are set", async () => {
+    expect(await callGetConfig()).toMatchObject({ gscEnabled: false });
+  });
+
+  it("reports gscEnabled false when only the client id is set", async () => {
+    mockConst.GOOGLE_CLIENT_ID = CLIENT_ID_SENTINEL;
+    expect(await callGetConfig()).toMatchObject({ gscEnabled: false });
+  });
+
+  it("reports gscEnabled false when only the client secret is set", async () => {
+    mockConst.GOOGLE_CLIENT_SECRET = CLIENT_SECRET_SENTINEL;
+    expect(await callGetConfig()).toMatchObject({ gscEnabled: false });
+  });
+
+  it("reports gscEnabled true when both credentials are set", async () => {
+    mockConst.GOOGLE_CLIENT_ID = CLIENT_ID_SENTINEL;
+    mockConst.GOOGLE_CLIENT_SECRET = CLIENT_SECRET_SENTINEL;
+    expect(await callGetConfig()).toMatchObject({ gscEnabled: true });
+  });
+
+  it("never leaks the Google credentials themselves", async () => {
+    mockConst.GOOGLE_CLIENT_ID = CLIENT_ID_SENTINEL;
+    mockConst.GOOGLE_CLIENT_SECRET = CLIENT_SECRET_SENTINEL;
+    const serialized = JSON.stringify(await callGetConfig());
+    expect(serialized).not.toContain(CLIENT_ID_SENTINEL);
+    expect(serialized).not.toContain(CLIENT_SECRET_SENTINEL);
+  });
+
+  it("still returns the pre-existing config fields", async () => {
+    expect(await callGetConfig()).toMatchObject({
+      disableSignup: false,
+      mapboxToken: "mapbox-token",
+      liteDashboard: false,
+    });
+  });
+});

--- a/server/src/api/getConfig.ts
+++ b/server/src/api/getConfig.ts
@@ -1,6 +1,12 @@
 import { FastifyRequest, FastifyReply } from "fastify";
 import { createRequire } from "module";
-import { DISABLE_SIGNUP, LITE_DASHBOARD, MAPBOX_TOKEN } from "../lib/const.js";
+import {
+  DISABLE_SIGNUP,
+  GOOGLE_CLIENT_ID,
+  GOOGLE_CLIENT_SECRET,
+  LITE_DASHBOARD,
+  MAPBOX_TOKEN,
+} from "../lib/const.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../../package.json");
@@ -10,6 +16,11 @@ export async function getConfig(_: FastifyRequest, reply: FastifyReply) {
     disableSignup: DISABLE_SIGNUP,
     mapboxToken: MAPBOX_TOKEN,
     liteDashboard: LITE_DASHBOARD,
+    // Google Search Console is available whenever OAuth credentials are
+    // configured. Self-hosters get it by setting GOOGLE_CLIENT_ID and
+    // GOOGLE_CLIENT_SECRET, exactly as self-host-vs-cloud.mdx documents.
+    // Only the boolean is exposed — /api/config is public.
+    gscEnabled: Boolean(GOOGLE_CLIENT_ID && GOOGLE_CLIENT_SECRET),
   });
 }
 

--- a/server/src/api/getConfig.ts
+++ b/server/src/api/getConfig.ts
@@ -16,10 +16,7 @@ export async function getConfig(_: FastifyRequest, reply: FastifyReply) {
     disableSignup: DISABLE_SIGNUP,
     mapboxToken: MAPBOX_TOKEN,
     liteDashboard: LITE_DASHBOARD,
-    // Google Search Console is available whenever OAuth credentials are
-    // configured. Self-hosters get it by setting GOOGLE_CLIENT_ID and
-    // GOOGLE_CLIENT_SECRET, exactly as self-host-vs-cloud.mdx documents.
-    // Only the boolean is exposed — /api/config is public.
+    // Boolean only: /api/config is public, so the credentials must not leak.
     gscEnabled: Boolean(GOOGLE_CLIENT_ID && GOOGLE_CLIENT_SECRET),
   });
 }

--- a/server/src/api/gsc/callback.ts
+++ b/server/src/api/gsc/callback.ts
@@ -60,7 +60,7 @@ export async function gscCallback(req: FastifyRequest<GSCCallbackRequest>, res: 
 
     const clientId = process.env.GOOGLE_CLIENT_ID;
     const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
-    const redirectUri = process.env.GOOGLE_REDIRECT_URI || `${process.env.SERVER_URL}/api/gsc/callback`;
+    const redirectUri = process.env.GOOGLE_REDIRECT_URI || `${process.env.BASE_URL}/api/gsc/callback`;
 
     if (!clientId || !clientSecret) {
       return res.status(500).send({ error: "Google OAuth not configured" });

--- a/server/src/api/gsc/connect.ts
+++ b/server/src/api/gsc/connect.ts
@@ -30,7 +30,7 @@ export async function connectGSC(req: FastifyRequest<ConnectGSCRequest>, res: Fa
     }
 
     const clientId = process.env.GOOGLE_CLIENT_ID;
-    const redirectUri = process.env.GOOGLE_REDIRECT_URI || `${process.env.SERVER_URL}/api/gsc/callback`;
+    const redirectUri = process.env.GOOGLE_REDIRECT_URI || `${process.env.BASE_URL}/api/gsc/callback`;
 
     if (!clientId) {
       return res.status(500).send({ error: "Google OAuth not configured" });

--- a/server/src/lib/const.ts
+++ b/server/src/lib/const.ts
@@ -9,6 +9,8 @@ export const DISABLE_TELEMETRY = process.env.DISABLE_TELEMETRY === "true";
 export const LITE_DASHBOARD = process.env.LITE_DASHBOARD === "true";
 export const SECRET = process.env.BETTER_AUTH_SECRET;
 export const MAPBOX_TOKEN = process.env.MAPBOX_TOKEN;
+export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
+export const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
 
 // Trial constants (commented out as we're replacing with free tier)
 // export const TRIAL_DURATION_DAYS = 14;


### PR DESCRIPTION
Picks up #1091, which got closed as completed, but the Web Vitals and Search Console gates are still there. (The Query part of it did get fixed.)

`self-host-vs-cloud.mdx` says self-hosted gets Web Vitals, and Search Console "(Requires Google OAuth env vars)". Neither is reachable, since both sit behind `IS_CLOUD`. Pages View and Email reports are behind the same flag, but the docs list those as cloud only, so I left them alone.

None of it was gated server side. The GSC routes register unconditionally, the only `IS_CLOUD` check in `index.ts` is Stripe, and the web vitals columns get added on ClickHouse init. It was just the UI, plus `docker-compose.yml` never passing the Google credentials through.

So `/api/config` now returns a `gscEnabled` boolean based on whether `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set. `useConfigs()` already hits that endpoint for `disableSignup` and `mapboxToken`, so there's nothing new to wire up and it works without rebuilding the client. Only the boolean, since `/api/config` is public.

The Integrations tab and the dashboard card use that flag. I kept the card gated rather than always showing it, because the Connect button 500s when there are no credentials. Web Vitals just loses the guard, since the docs put no condition on it.

Compose forwards `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` and `GOOGLE_REDIRECT_URI` now, the same way it already does for OpenRouter. All three are documented in `.env.example` and in the self-hosting guide, along with a short section on creating the OAuth client and the redirect URI it needs.

One other thing worth flagging: `SERVER_URL` isn't set anywhere in the repo, but both `connect.ts` and `callback.ts` fall back to it, so leaving `GOOGLE_REDIRECT_URI` unset produced a literal `undefined/api/gsc/callback`. It falls back to `BASE_URL` now.

If these are meant to stay cloud only, feel free to close this. The docs would be the thing to fix then, since they currently promise both to self-hosters.

Tested on my own self-hosted instance: `gscEnabled` flips correctly, the credentials don't leak into the response, and Integrations and Performance show up. Ran the full OAuth flow end to end, including property selection, and the connection completes. Added a small test for `getConfig`. Server suite and typecheck are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Google Search Console integration can be enabled through deployment configuration.
  - Performance and Web Vitals options are available for all non-mobile sites, including self-hosted deployments.
  - OAuth connections use the application’s base URL for more reliable redirects.

- **Documentation**
  - Added self-hosting instructions for Google Search Console setup, OAuth credentials, redirect configuration, and access requirements.
  - Updated the Dashboard Preview label to “Web Vitals.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->