### PR TITLE
fix(self-host): link Pages and Bots in the sidebar on self-hosted installs

### DIFF
--- a/client/src/app/[site]/components/Sidebar/Sidebar.tsx
+++ b/client/src/app/[site]/components/Sidebar/Sidebar.tsx
@@ -90,14 +90,12 @@ function SidebarContent() {
           href={getTabPath("globe")}
           icon={<Globe2 className="w-4 h-4" />}
         />
-        {IS_CLOUD && (
-          <SidebarComponents.Item
-            label={t("Pages")}
-            active={isActiveTab("pages")}
-            href={getTabPath("pages")}
-            icon={<File className="w-4 h-4" />}
-          />
-        )}
+        <SidebarComponents.Item
+          label={t("Pages")}
+          active={isActiveTab("pages")}
+          href={getTabPath("pages")}
+          icon={<File className="w-4 h-4" />}
+        />
         {IS_CLOUD && !isMobileSite && (
           <SidebarComponents.Item
             label={t("Performance")}
@@ -106,14 +104,12 @@ function SidebarContent() {
             icon={<Gauge className="w-4 h-4" />}
           />
         )}
-        {IS_CLOUD && (
-          <SidebarComponents.Item
-            label={t("Bots")}
-            active={isActiveTab("bots")}
-            href={getTabPath("bots")}
-            icon={<Bot className="w-4 h-4" />}
-          />
-        )}
+        <SidebarComponents.Item
+          label={t("Bots")}
+          active={isActiveTab("bots")}
+          href={getTabPath("bots")}
+          icon={<Bot className="w-4 h-4" />}
+        />
         <SidebarComponents.Item
           label={t("Goals")}
           active={isActiveTab("goals")}


### PR DESCRIPTION
The Pages and Bots views already work on self-hosted installs. Their page components have no cloud check, the bot endpoints in `index.ts` register unconditionally alongside every other analytics route, and `DisabledOverlay` returns `disabled = false` whenever `IS_CLOUD` is unset. The only thing missing is the sidebar link, so today you can reach both by typing `/<siteId>/pages` or `/<siteId>/bots` and no other way. That seemed more like an oversight than a deliberate paywall, since a paywalled feature would normally be blocked rather than merely unlinked.

Only touches the two sidebar entries. Performance and the `!IS_CLOUD` Query block are untouched, so the import stays and this doesn't overlap #1104.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pages and Bots are now available in the sidebar across all deployment environments.
  * Existing navigation routes, labels, icons, and active-state behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->