### PR TITLE
Forward /.well-known/ to backend in custom Nginx configuration

### DIFF
--- a/docs/content/docs/(docs)/self-hosting-guides/custom-nginx.mdx
+++ b/docs/content/docs/(docs)/self-hosting-guides/custom-nginx.mdx
@@ -69,8 +69,8 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    # API requests
-    location /api/ {
+    # Backend service
+    location ~ ^/(api|\.well-known)/.*$ {
         proxy_pass http://localhost:3001;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -84,7 +84,7 @@ server {
         proxy_read_timeout 60s;
     }
 
-    # Client app
+    # Client service
     location / {
         proxy_pass http://localhost:3002;
         proxy_set_header Host $host;


### PR DESCRIPTION
MCP client depends on this path for OAuth auto-discovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the custom Nginx self-hosting guide to proxy API and well-known paths correctly.
  * Clarified backend and client service configuration comments.
  * Fixed formatting in the log command example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->