### PR TITLE
Allow Shopify pixels to send events from sandboxed contexts

### DIFF
--- a/server/src/lib/cors.test.ts
+++ b/server/src/lib/cors.test.ts
@@ -122,6 +122,41 @@ describe("CORS policy", () => {
     }
   });
 
+  it("allows opaque origins on public tracking endpoints without credentials", async () => {
+    const app = await buildCorsTestApp({
+      NODE_ENV: "production",
+      BASE_URL: "https://rybbit.example.com",
+    });
+
+    try {
+      const preflight = await app.inject({
+        method: "OPTIONS",
+        url: "/api/track",
+        headers: {
+          origin: "null",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "content-type",
+        },
+      });
+
+      expect(preflight.statusCode).toBe(204);
+      expect(preflight.headers["access-control-allow-origin"]).toBe("null");
+      expect(preflight.headers["access-control-allow-credentials"]).toBeUndefined();
+
+      const actual = await app.inject({
+        method: "POST",
+        url: "/api/track",
+        headers: { origin: "null" },
+      });
+
+      expect(actual.statusCode).toBe(200);
+      expect(actual.headers["access-control-allow-origin"]).toBe("null");
+      expect(actual.headers["access-control-allow-credentials"]).toBeUndefined();
+    } finally {
+      await app.close();
+    }
+  });
+
   it("allows public version checks without credentials", async () => {
     const app = await buildCorsTestApp({
       NODE_ENV: "production",

--- a/server/src/lib/cors.ts
+++ b/server/src/lib/cors.ts
@@ -106,6 +106,19 @@ export function isPublicCorsPath(path: string): boolean {
 }
 
 export function getCorsOptionsForRequest(request: FastifyRequest, env: NodeJS.ProcessEnv = process.env): CorsOptions {
+  const path = getRequestPath(request);
+  // Sandboxed browser contexts, including Shopify custom pixels, serialize
+  // their opaque origin as the literal string "null". Public ingestion routes
+  // are intentionally reachable from any origin, so reflect opaque origins
+  // without credentials while keeping management routes restricted.
+  if (request.headers.origin === "null" && isPublicCorsPath(path)) {
+    return {
+      ...commonCorsOptions,
+      origin: true,
+      credentials: false,
+    };
+  }
+
   const requestOrigin = normalizeCorsOrigin(request.headers.origin);
   if (!requestOrigin) {
     return {
@@ -115,7 +128,7 @@ export function getCorsOptionsForRequest(request: FastifyRequest, env: NodeJS.Pr
     };
   }
 
-  if (isPublicCorsPath(getRequestPath(request))) {
+  if (isPublicCorsPath(path)) {
     // These paths are reachable from any origin (e.g. embedded widgets), but they
     // are also hit by the authenticated dashboard, which sends cookies. Reflect any
     // origin, but only allow credentials for trusted origins so the dashboard's


### PR DESCRIPTION
Shopify custom pixels run in sandboxed iframes, which send `Origin: null`. The current CORS normalization rejects that origin, so `/api/track` preflights return 404 and the events are never sent.

This keeps the existing restrictions for authenticated routes while allowing opaque origins on public endpoints without credentials. It also adds coverage for the preflight and POST response headers.

Tested with:

- `npm run build`
- `npm run test:run -- src/lib/cors.test.ts`
- A live Shopify custom pixel against a self-hosted v2.8 instance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Public tracking endpoints now accept requests from opaque `"null"` origins.
  * Preflight and actual requests correctly return the appropriate CORS response without enabling credentials.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->