### PR TITLE
Fix widget API routing and hex site ID resolution

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -22,6 +22,17 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_LITE_DASHBOARD: process.env.NEXT_PUBLIC_LITE_DASHBOARD,
     NEXT_PUBLIC_APP_VERSION: process.env.npm_package_version,
   },
+  // next dev only: /api is same-origin in real deploys (Caddy/nginx → backend).
+  // Do not key this off NEXT_PUBLIC_BACKEND_URL — that env is optional.
+  async rewrites() {
+    if (process.env.NODE_ENV === "production") return [];
+    return [
+      {
+        source: "/api/:path*",
+        destination: "http://localhost:3001/api/:path*",
+      },
+    ];
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/client/src/app/widget/[siteId]/route.ts
+++ b/client/src/app/widget/[siteId]/route.ts
@@ -8,11 +8,6 @@ const MINUTES_LABEL: Record<number, string> = {
   10080: "LAST 7 DAYS",
 };
 
-function getBackendUrl() {
-  const raw = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:3001";
-  return raw === "http://localhost:3001" ? "http://localhost:3001/api" : `${raw}/api`;
-}
-
 interface Config {
   siteId: string;
   minutes: number;
@@ -21,7 +16,6 @@ interface Config {
   theme: "dark" | "light";
   accent: string;
   variant: "card" | "inline";
-  backendUrl: string;
   windowLabel: string;
 }
 
@@ -154,7 +148,6 @@ function renderHTML(c: Config) {
     minutes: c.minutes,
     chart: c.chart,
     countries: c.countries,
-    backendUrl: c.backendUrl,
   });
   const accentColor = c.theme === "dark" ? c.accent : c.accent;
 
@@ -271,7 +264,7 @@ ${body}
   }
 
   function fetchData() {
-    var url = cfg.backendUrl + "/sites/" + encodeURIComponent(cfg.siteId) +
+    var url = window.location.origin + "/api/sites/" + encodeURIComponent(cfg.siteId) +
       "/embed-stats?minutes=" + cfg.minutes +
       "&chart=" + cfg.chart +
       "&countries=" + cfg.countries;
@@ -320,7 +313,6 @@ export async function GET(
     theme,
     accent,
     variant,
-    backendUrl: getBackendUrl(),
     windowLabel: MINUTES_LABEL[minutes],
   });
 

--- a/server/src/api/sites/getEmbedStats.ts
+++ b/server/src/api/sites/getEmbedStats.ts
@@ -39,15 +39,14 @@ export async function getEmbedStats(
   if (!config) return res.status(404).send({ error: "Site not found" });
   if (!config.embedEnabled) return res.status(403).send({ error: "Embed widget is not enabled for this site" });
 
-  const cacheKey = `${siteId}:${minutesNum}:${includeChart}:${includeCountries}`;
+  const numericId = config.siteId;
+  const cacheKey = `${numericId}:${minutesNum}:${includeChart}:${includeCountries}`;
   const now = Date.now();
   const cached = cache.get(cacheKey);
   if (cached && cached.expiresAt > now) {
     res.header("Cache-Control", "public, max-age=60");
     return res.send(cached.data);
   }
-
-  const numericId = Number(siteId);
 
   const countResult = await clickhouse.query({
     query: `SELECT COUNT(DISTINCT(session_id)) AS count FROM events


### PR DESCRIPTION
https://github.com/rybbit-io/rybbit/issues/994

No reliance on NEXT_PUBLIC_BACKEND_URL which is optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seamless local routing for API requests during development.
  * Embedded widgets now automatically use the current application address to retrieve statistics.
* **Bug Fixes**
  * Improved embedded statistics retrieval by consistently identifying sites, helping ensure cached and newly fetched results match the correct site.
  * Removed the need to configure a separate backend address for embedded widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->