### PR TITLE
fix(readme): restore the star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ See how Rybbit compares to other analytics solutions:
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rybbit-io/rybbit&type=Date)](https://www.star-history.com/#rybbit-io/rybbit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rybbit-io/rybbit&type=Date)](https://star-history.dera.page/#rybbit-io/rybbit&Date)


### PR DESCRIPTION
The star history badge in the README is currently broken: the chart fails to render because the provider behind star-history.com can no longer fetch stargazer data from GitHub's API. This change switches the chart over to a working alternative that uses a different data source and serves both the chart and the site from a single domain. The image URL becomes https://star-history.dera.page/svg and the surrounding link now uses the matching hash-based URL, while the badge retains the original repo and Date parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Star History chart link and image source to use the new hosting domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->