### PR TITLE
Modify custom Nginx config for OIDC Discovery support

### DIFF
--- a/docs/content/docs/(docs)/self-hosting-guides/custom-nginx.mdx
+++ b/docs/content/docs/(docs)/self-hosting-guides/custom-nginx.mdx
@@ -70,6 +70,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
 
     # Backend service
+    # the `.well-known` path is for OIDC Discovery
     location ~ ^/(api|\.well-known)/.*$ {
         proxy_pass http://localhost:3001;
         proxy_set_header Host $host;
@@ -198,7 +199,7 @@ If you need to use custom ports for Rybbit:
 Update your Nginx configuration accordingly:
 
 ```nginx
-location /api/ {
+location ~ ^/(api|\.well-known)/.*$ {
     proxy_pass http://localhost:8080;  # Custom backend port
     # ... rest of config
 }

--- a/docs/content/docs/(docs)/self-hosting-guides/custom-nginx.mdx
+++ b/docs/content/docs/(docs)/self-hosting-guides/custom-nginx.mdx
@@ -70,7 +70,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
 
     # Backend service
-    # the `.well-known` path is for OIDC Discovery
+    # The /.well-known/ path is for OIDC discovery
     location ~ ^/(api|\.well-known)/.*$ {
         proxy_pass http://localhost:3001;
         proxy_set_header Host $host;


### PR DESCRIPTION
#1107 has added some but missed another nginx configuration item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the `.well-known` route supports OIDC Discovery.
  * Updated custom Nginx configuration guidance to route both API and `.well-known` requests to the backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->