### PR TITLE
Keep the frog avatar reading as a round disc

### DIFF
--- a/client/src/components/FrogAvatar.tsx
+++ b/client/src/components/FrogAvatar.tsx
@@ -8,7 +8,7 @@ export function FrogAvatar({ id, size = 20 }: { id: string; size?: number }) {
       viewBox="0 0 100 100"
       role="img"
       xmlns="http://www.w3.org/2000/svg"
-      style={{ display: "block" }}
+      style={{ display: "block", borderRadius: "50%" }}
       dangerouslySetInnerHTML={{ __html: frogAvatarMarkup(id) }}
     />
   );

--- a/client/src/lib/frogAvatar.ts
+++ b/client/src/lib/frogAvatar.ts
@@ -216,6 +216,28 @@ function frogFeatures(r: Rng): FrogFeatures {
   };
 }
 
+/**
+ * The disc has to stay visible against whatever it sits on. The app's dark
+ * background is 8% lightness and its light background is 97%, so a ground
+ * outside this band merges with the page and the icon stops reading as a
+ * circle — what is left is a frog-shaped silhouette.
+ */
+const GROUND_MIN_L = 28;
+const GROUND_MAX_L = 80;
+
+/** A ground lightness inside that band, still a clear step away from the frog. */
+function groundLightness(preferred: number, frogL: number): number {
+  const bg = clamp(preferred, GROUND_MIN_L, GROUND_MAX_L);
+  if (Math.abs(bg - frogL) >= 24) return bg;
+  // Keep the ground on the side it was already heading for, unless the band
+  // leaves no room there.
+  const darker = clamp(frogL - 34, GROUND_MIN_L, GROUND_MAX_L);
+  const lighter = clamp(frogL + 34, GROUND_MIN_L, GROUND_MAX_L);
+  const preferredSide = bg < frogL ? darker : lighter;
+  const otherSide = bg < frogL ? lighter : darker;
+  return Math.abs(preferredSide - frogL) >= 24 ? preferredSide : otherSide;
+}
+
 function frogPalette(f: FrogFeatures): FrogPalette {
   const h = f.species.h;
   let s = f.species.s;
@@ -238,18 +260,18 @@ function frogPalette(f: FrogFeatures): FrogPalette {
   if (f.ground === "pale") {
     bgH = h + 6;
     bgS = 36 + f.jitter[1] * 26;
-    bgL = 83 + f.jitter[2] * 7;
+    bgL = 69 + f.jitter[2] * 11;
   } else if (f.ground === "contrast") {
     bgH = h + 152 + f.jitter[1] * 30;
     bgS = 26 + f.jitter[1] * 22;
-    bgL = 15 + f.jitter[2] * 13;
+    bgL = 31 + f.jitter[2] * 13;
   } else {
     bgH = h + 20;
     bgS = 20 + f.jitter[1] * 18;
-    bgL = 12 + f.jitter[2] * 12;
+    bgL = 29 + f.jitter[2] * 10;
   }
   // The frog and the ground it sits on never share a value.
-  if (Math.abs(bgL - l) < 24) bgL = l > 50 ? clamp(l - 34, 7, 93) : clamp(l + 34, 7, 93);
+  bgL = groundLightness(bgL, l);
 
   const bright = hsl(h, Math.min(s + 18, 94), 64);
   const deep = hsl(h + 8, Math.min(s * 0.85, 74), clamp(l - 32, 8, 40));
@@ -262,7 +284,7 @@ function frogPalette(f: FrogFeatures): FrogPalette {
     line: f.morph === "dart" ? bright : deep,
     mark: f.morph === "dart" ? bright : hsl(h + 4, s * 0.95, clamp(l > 66 ? l - 26 : l - 22, 6, 92)),
     bg: hsl(bgH, bgS, bgL),
-    bgAlt: hsl(bgH + 20, bgS + 10, clamp(bgL > 60 ? bgL - 16 : bgL + 21, 6, 95)),
+    bgAlt: hsl(bgH + 20, bgS + 10, clamp(bgL > 60 ? bgL - 16 : bgL + 21, GROUND_MIN_L, GROUND_MAX_L)),
     cream: hsl(h - 12, 38, 88),
     contrast: hsl(h + 148, 42, 72),
     bright,
@@ -412,6 +434,6 @@ export function frogAvatarMarkup(id: string): string {
 export function frogAvatarSVG(id: string, size: number): string {
   return (
     `<svg width="${size}" height="${size}" viewBox="0 0 100 100" role="img"` +
-    ` xmlns="http://www.w3.org/2000/svg" style="display:block">${frogAvatarMarkup(id)}</svg>`
+    ` xmlns="http://www.w3.org/2000/svg" style="display:block;border-radius:50%">${frogAvatarMarkup(id)}</svg>`
   );
 }

--- a/docs/src/components/Avatar.tsx
+++ b/docs/src/components/Avatar.tsx
@@ -8,7 +8,7 @@ export function Avatar({ id, size = 20 }: { id: string; size?: number }) {
       viewBox="0 0 100 100"
       role="img"
       xmlns="http://www.w3.org/2000/svg"
-      style={{ display: "block" }}
+      style={{ display: "block", borderRadius: "50%" }}
       dangerouslySetInnerHTML={{ __html: frogAvatarMarkup(id) }}
     />
   );

--- a/docs/src/lib/frogAvatar.ts
+++ b/docs/src/lib/frogAvatar.ts
@@ -216,6 +216,28 @@ function frogFeatures(r: Rng): FrogFeatures {
   };
 }
 
+/**
+ * The disc has to stay visible against whatever it sits on. The app's dark
+ * background is 8% lightness and its light background is 97%, so a ground
+ * outside this band merges with the page and the icon stops reading as a
+ * circle — what is left is a frog-shaped silhouette.
+ */
+const GROUND_MIN_L = 28;
+const GROUND_MAX_L = 80;
+
+/** A ground lightness inside that band, still a clear step away from the frog. */
+function groundLightness(preferred: number, frogL: number): number {
+  const bg = clamp(preferred, GROUND_MIN_L, GROUND_MAX_L);
+  if (Math.abs(bg - frogL) >= 24) return bg;
+  // Keep the ground on the side it was already heading for, unless the band
+  // leaves no room there.
+  const darker = clamp(frogL - 34, GROUND_MIN_L, GROUND_MAX_L);
+  const lighter = clamp(frogL + 34, GROUND_MIN_L, GROUND_MAX_L);
+  const preferredSide = bg < frogL ? darker : lighter;
+  const otherSide = bg < frogL ? lighter : darker;
+  return Math.abs(preferredSide - frogL) >= 24 ? preferredSide : otherSide;
+}
+
 function frogPalette(f: FrogFeatures): FrogPalette {
   const h = f.species.h;
   let s = f.species.s;
@@ -238,18 +260,18 @@ function frogPalette(f: FrogFeatures): FrogPalette {
   if (f.ground === "pale") {
     bgH = h + 6;
     bgS = 36 + f.jitter[1] * 26;
-    bgL = 83 + f.jitter[2] * 7;
+    bgL = 69 + f.jitter[2] * 11;
   } else if (f.ground === "contrast") {
     bgH = h + 152 + f.jitter[1] * 30;
     bgS = 26 + f.jitter[1] * 22;
-    bgL = 15 + f.jitter[2] * 13;
+    bgL = 31 + f.jitter[2] * 13;
   } else {
     bgH = h + 20;
     bgS = 20 + f.jitter[1] * 18;
-    bgL = 12 + f.jitter[2] * 12;
+    bgL = 29 + f.jitter[2] * 10;
   }
   // The frog and the ground it sits on never share a value.
-  if (Math.abs(bgL - l) < 24) bgL = l > 50 ? clamp(l - 34, 7, 93) : clamp(l + 34, 7, 93);
+  bgL = groundLightness(bgL, l);
 
   const bright = hsl(h, Math.min(s + 18, 94), 64);
   const deep = hsl(h + 8, Math.min(s * 0.85, 74), clamp(l - 32, 8, 40));
@@ -262,7 +284,7 @@ function frogPalette(f: FrogFeatures): FrogPalette {
     line: f.morph === "dart" ? bright : deep,
     mark: f.morph === "dart" ? bright : hsl(h + 4, s * 0.95, clamp(l > 66 ? l - 26 : l - 22, 6, 92)),
     bg: hsl(bgH, bgS, bgL),
-    bgAlt: hsl(bgH + 20, bgS + 10, clamp(bgL > 60 ? bgL - 16 : bgL + 21, 6, 95)),
+    bgAlt: hsl(bgH + 20, bgS + 10, clamp(bgL > 60 ? bgL - 16 : bgL + 21, GROUND_MIN_L, GROUND_MAX_L)),
     cream: hsl(h - 12, 38, 88),
     contrast: hsl(h + 148, 42, 72),
     bright,
@@ -412,6 +434,6 @@ export function frogAvatarMarkup(id: string): string {
 export function frogAvatarSVG(id: string, size: number): string {
   return (
     `<svg width="${size}" height="${size}" viewBox="0 0 100 100" role="img"` +
-    ` xmlns="http://www.w3.org/2000/svg" style="display:block">${frogAvatarMarkup(id)}</svg>`
+    ` xmlns="http://www.w3.org/2000/svg" style="display:block;border-radius:50%">${frogAvatarMarkup(id)}</svg>`
   );
 }


### PR DESCRIPTION
Follow-up to #1127.

## The problem

The avatar is geometrically a circle already — the whole composition is clipped to `circle(50, 50, 50)`, and it renders as a clean disc on any neutral background. But roundness is only *visible* if the ground inside that circle differs from the surface behind it.

Grounds ranged from 12% to 90% lightness. The app's backgrounds are 8% (dark) and 97% (light). So a frog that drew a `deep` or `contrast` ground — about 60% of them — lost its edge on the dark theme: the disc merged into the page and what was left was a frog-shaped silhouette with the eye domes sliced off at the top. Same thing at the other end with `pale` grounds in light mode.

## The fix

Move the ground into a band that clears both surfaces (28–80% lightness). The three ground styles are **remapped** into that band rather than clamped, so the spread of values is preserved instead of piling up on the rails:

| ground | before | after |
| --- | --- | --- |
| `deep` | 12–24 | 29–39 |
| `contrast` | 15–28 | 31–44 |
| `pale` | 83–90 | 69–80 |

The "frog and ground never share a value" rule now runs inside the band, and falls back to the opposite side when the band leaves no room on the side it was heading for — so the minimum separation stays at 24 points instead of being quietly eaten by the clamp. The `duo` wedge's second tone is held to the same band, since a wedge that matches the page would take a bite out of the disc.

Separately, `border-radius: 50%` on the `<svg>` element itself, so the icon stays round even if the clip-path reference ever fails to resolve.

## Verified

- 30k generated ids: ground lightness stays within 28–80, frog/ground separation never drops below 24, disc clears the dark surface by ≥20 points and the light surface by ≥17.
- Rendered before/after on both real app surfaces (`hsl(0 0% 8%)` and `hsl(0 0% 97%)`) at 44px and at the 20px size the tables actually use — every avatar reads as a full disc.
- `tsc --noEmit` clean in `client/`; `docs/` unchanged from its pre-existing `@/.source` errors. Both copies of the generator stay byte-identical apart from the import path.

Existing avatars change appearance — same frog, different ground.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Avatar graphics are now displayed as circular discs across the application and documentation.
  * Updated avatar background colors improve visibility on both light and dark page backgrounds.
  * Avatar backgrounds maintain clearer contrast with the frog artwork for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->