### PR TITLE
Fix period chart axes ending a bucket early, add past-minutes time navigation

### DIFF
--- a/client/src/api/gsc/gscDateRange.ts
+++ b/client/src/api/gsc/gscDateRange.ts
@@ -8,9 +8,11 @@ import { getStartAndEndDate } from "../utils";
 export function getGSCDateRange(time: Time, timeZone: string): { startDate: string; endDate: string } {
   const today = DateTime.now().setZone(timeZone);
   if (time.mode === "past-minutes") {
+    // The newer edge is only "now" until the window is stepped back, after which
+    // ending on today would widen the report past what the dashboard shows.
     return {
       startDate: today.minus({ minutes: time.pastMinutesStart }).toISODate() ?? "",
-      endDate: today.toISODate() ?? "",
+      endDate: today.minus({ minutes: time.pastMinutesEnd }).toISODate() ?? "",
     };
   }
   if (time.mode === "all-time") {

--- a/client/src/app/(home)/page.tsx
+++ b/client/src/app/(home)/page.tsx
@@ -22,7 +22,7 @@ import { MultiSelect } from "../../components/ui/multi-select";
 import { Pagination } from "../../components/pagination";
 import { useSetPageTitle } from "../../hooks/useSetPageTitle";
 import { authClient } from "../../lib/auth";
-import { canGoForward, goBack, goForward, useStore } from "../../lib/store";
+import { canGoBack, canGoForward, goBack, goForward, useStore } from "../../lib/store";
 import { AddSite } from "../components/AddSite";
 import { SiteCard } from "./SiteCard";
 
@@ -143,7 +143,7 @@ export default function Home() {
           variant="secondary"
           size="icon"
           onClick={goBack}
-          disabled={time.mode === "past-minutes"}
+          disabled={!canGoBack(time)}
           className="rounded-r-none h-8 w-8"
         >
           <ChevronLeft />

--- a/client/src/app/[site]/components/SubHeader/Export/exportPdf.ts
+++ b/client/src/app/[site]/components/SubHeader/Export/exportPdf.ts
@@ -19,9 +19,11 @@ export function getPdfDateRange(time: Time, timeZone: string): { startDate: stri
   const today = DateTime.now().setZone(timeZone);
 
   if (time.mode === "past-minutes") {
+    // The newer edge is only "now" until the window is stepped back, after which
+    // ending on today would widen the report past what the dashboard shows.
     return {
       startDate: today.minus({ minutes: time.pastMinutesStart }).toISODate() ?? "",
-      endDate: today.toISODate() ?? "",
+      endDate: today.minus({ minutes: time.pastMinutesEnd }).toISODate() ?? "",
     };
   }
   if (time.mode === "all-time") {

--- a/client/src/app/[site]/components/SubHeader/SubHeader.tsx
+++ b/client/src/app/[site]/components/SubHeader/SubHeader.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Button } from "@/components/ui/button";
-import { canGoForward, goBack, goForward, useStore } from "@/lib/store";
+import { canGoBack, canGoForward, goBack, goForward, useStore } from "@/lib/store";
 import { FilterParameter } from "@rybbit/shared";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Filters } from "./Filters/Filters";
@@ -32,7 +32,7 @@ export function SubHeader({ availableFilters }: { availableFilters?: FilterParam
               variant="secondary"
               size="icon"
               onClick={goBack}
-              disabled={time.mode === "past-minutes"}
+              disabled={!canGoBack(time)}
               className="rounded-r-none h-8 w-8"
             >
               <ChevronLeft />

--- a/client/src/app/[site]/dashboards/[dashboardId]/page.tsx
+++ b/client/src/app/[site]/dashboards/[dashboardId]/page.tsx
@@ -26,7 +26,7 @@ import { Skeleton } from "../../../../components/ui/skeleton";
 import { toast } from "../../../../components/ui/sonner";
 import { cn } from "../../../../lib/utils";
 import { useSetPageTitle } from "../../../../hooks/useSetPageTitle";
-import { canGoForward, goBack, goForward, useStore } from "../../../../lib/store";
+import { canGoBack, canGoForward, goBack, goForward, useStore } from "../../../../lib/store";
 import { DashboardCardEditor } from "../components/DashboardCardEditor";
 import { DashboardCardView } from "../components/DashboardCardView";
 import { NewCardDialog } from "../components/NewCardDialog";
@@ -346,7 +346,7 @@ export default function DashboardDetailPage() {
               variant="secondary"
               size="icon"
               onClick={goBack}
-              disabled={time.mode === "past-minutes"}
+              disabled={!canGoBack(time)}
               className="h-8 w-8 rounded-r-none"
               aria-label="Previous date range"
             >

--- a/client/src/app/[site]/user/[userId]/page.tsx
+++ b/client/src/app/[site]/user/[userId]/page.tsx
@@ -10,7 +10,7 @@ import { useUserInfo } from "../../../../api/analytics/hooks/userGetInfo";
 import { useGetSessions, useGetUserSessionCount } from "../../../../api/analytics/hooks/useGetUserSessions";
 import { DateSelector } from "../../../../components/DateSelector/DateSelector";
 import { Button } from "../../../../components/ui/button";
-import { canGoForward, goBack, goForward, useStore } from "../../../../lib/store";
+import { canGoBack, canGoForward, goBack, goForward, useStore } from "../../../../lib/store";
 import { USER_DETAIL_PAGE_FILTERS } from "../../../../lib/filterGroups";
 import { Filters } from "../../components/SubHeader/Filters/Filters";
 import { NewFilterButton } from "../../components/SubHeader/Filters/NewFilterButton";
@@ -118,7 +118,7 @@ export default function UserPage() {
               variant="secondary"
               size="icon"
               onClick={goBack}
-              disabled={time.mode === "past-minutes"}
+              disabled={!canGoBack(time)}
               className="rounded-r-none h-8 w-8"
             >
               <ChevronLeft />

--- a/client/src/app/rollup/components/RollupTopBar.tsx
+++ b/client/src/app/rollup/components/RollupTopBar.tsx
@@ -4,7 +4,7 @@ import { Team } from "@/api/admin/endpoints/teams";
 import { DateSelector } from "@/components/DateSelector/DateSelector";
 import { TeamSelector } from "@/components/TeamSelector";
 import { Button } from "@/components/ui/button";
-import { canGoForward, goBack, goForward, useStore } from "@/lib/store";
+import { canGoBack, canGoForward, goBack, goForward, useStore } from "@/lib/store";
 
 export function RollupTopBar({
   teams,
@@ -32,7 +32,7 @@ export function RollupTopBar({
             variant="secondary"
             size="icon"
             onClick={goBack}
-            disabled={time.mode === "past-minutes"}
+            disabled={!canGoBack(time)}
             className="rounded-r-none h-8 w-8"
           >
             <ChevronLeft />

--- a/client/src/components/DateSelector/DateSelector.tsx
+++ b/client/src/components/DateSelector/DateSelector.tsx
@@ -137,6 +137,18 @@ export function DateSelector({
     }
 
     if (time.mode === "past-minutes") {
+      // A window stepped back no longer ends at now, so name the stretch it
+      // covers — "Last 30 minutes" would read as live when it isn't.
+      if (time.pastMinutesEnd > 0) {
+        const start = now.minus({ minutes: time.pastMinutesStart });
+        const end = now.minus({ minutes: time.pastMinutesEnd });
+        const clock = hour12 ? "h:mm a" : "HH:mm";
+        const withDate = `MMM d, ${clock}`;
+        const startFormatted = start.hasSame(now, "day") ? start.toFormat(clock) : start.toFormat(withDate);
+        const endFormatted = end.hasSame(start, "day") ? end.toFormat(clock) : end.toFormat(withDate);
+        return `${startFormatted} - ${endFormatted}`;
+      }
+
       if (time.pastMinutesStart >= 60) {
         const hours = Math.floor(time.pastMinutesStart / 60);
         return t("Last {hours} hours", { hours: String(hours) });

--- a/client/src/components/charts/timeSeriesChartUtils.test.ts
+++ b/client/src/components/charts/timeSeriesChartUtils.test.ts
@@ -1,0 +1,75 @@
+import { DateTime } from "luxon";
+import { describe, expect, it } from "vitest";
+import { Time } from "../DateSelector/types";
+import { getChartTimeBounds } from "./timeSeriesChartUtils";
+
+const ZONE = "America/New_York";
+
+const boundsIso = (time: Time, bucket: Parameters<typeof getChartTimeBounds>[1]) => {
+  const { min, max } = getChartTimeBounds(time, bucket, ZONE);
+  const iso = (d: Date | undefined) => (d ? DateTime.fromJSDate(d).setZone(ZONE).toISO() : undefined);
+  return { min: iso(min), max: iso(max) };
+};
+
+describe("getChartTimeBounds", () => {
+  it("week: ends on the last day bucket, not the last millisecond", () => {
+    expect(boundsIso({ mode: "week", week: "2026-08-17" }, "day")).toEqual({
+      min: "2026-08-17T00:00:00.000-04:00",
+      max: "2026-08-23T00:00:00.000-04:00",
+    });
+  });
+
+  it("week: ends on the last hour bucket", () => {
+    expect(boundsIso({ mode: "week", week: "2026-08-17" }, "hour").max).toBe("2026-08-23T23:00:00.000-04:00");
+  });
+
+  it("month: ends on the last day bucket", () => {
+    expect(boundsIso({ mode: "month", month: "2026-08-01" }, "day")).toEqual({
+      min: "2026-08-01T00:00:00.000-04:00",
+      max: "2026-08-31T00:00:00.000-04:00",
+    });
+  });
+
+  it("month: weekly buckets land on Sunday, including a month ending on one", () => {
+    expect(boundsIso({ mode: "month", month: "2026-08-01" }, "week").max).toBe("2026-08-30T00:00:00.000-04:00");
+    // January 2027 ends on a Sunday: flooring to Monday would drop that bucket.
+    expect(boundsIso({ mode: "month", month: "2027-01-01" }, "week").max).toBe("2027-01-31T00:00:00.000-05:00");
+  });
+
+  it("year: ends on the last month bucket", () => {
+    expect(boundsIso({ mode: "year", year: "2026-01-01" }, "month").max).toBe("2026-12-01T00:00:00.000-05:00");
+  });
+
+  it("day: ends on the last bucket of the day, across a DST change", () => {
+    expect(boundsIso({ mode: "day", day: "2026-08-19" }, "five_minutes").max).toBe("2026-08-19T23:55:00.000-04:00");
+    expect(boundsIso({ mode: "day", day: "2026-11-01" }, "hour").max).toBe("2026-11-01T23:00:00.000-05:00");
+  });
+
+  it("range: ends on the end date's bucket", () => {
+    expect(boundsIso({ mode: "range", startDate: "2026-08-13", endDate: "2026-08-19" }, "day")).toEqual({
+      min: "2026-08-13T00:00:00.000-04:00",
+      max: "2026-08-19T00:00:00.000-04:00",
+    });
+  });
+
+  it("range: a single-bucket period keeps a non-empty domain", () => {
+    expect(boundsIso({ mode: "range", startDate: "2026-08-19", endDate: "2026-08-19" }, "day")).toEqual({
+      min: "2026-08-19T00:00:00.000-04:00",
+      max: "2026-08-19T23:59:59.999-04:00",
+    });
+  });
+
+  it("exact range: ends on the last bucket inside the exclusive end", () => {
+    const exact = {
+      mode: "range",
+      startDate: "2026-08-19",
+      endDate: "2026-08-19",
+      startTime: "09:15:00",
+      endTime: "17:45:00",
+    } as const;
+    expect(boundsIso(exact, "hour").max).toBe("2026-08-19T17:00:00.000-04:00");
+    expect(boundsIso({ ...exact, startTime: "10:00:00", endTime: "12:00:00" }, "hour").max).toBe(
+      "2026-08-19T11:00:00.000-04:00"
+    );
+  });
+});

--- a/client/src/components/charts/timeSeriesChartUtils.test.ts
+++ b/client/src/components/charts/timeSeriesChartUtils.test.ts
@@ -30,9 +30,11 @@ describe("getChartTimeBounds", () => {
     });
   });
 
-  it("month: weekly buckets land on Sunday, including a month ending on one", () => {
-    expect(boundsIso({ mode: "month", month: "2026-08-01" }, "week").max).toBe("2026-08-30T00:00:00.000-04:00");
-    // January 2027 ends on a Sunday: flooring to Monday would drop that bucket.
+  it("month: weekly buckets clear both the Sunday and the Monday convention", () => {
+    // August 2026 ends on a Monday, which `toStartOfInterval(.., 1 WEEK)` buckets
+    // a day after `toStartOfWeek` does; stopping on the Sunday would clip it.
+    expect(boundsIso({ mode: "month", month: "2026-08-01" }, "week").max).toBe("2026-08-31T00:00:00.000-04:00");
+    // January 2027 ends on a Sunday, where the Sunday floor is the later one.
     expect(boundsIso({ mode: "month", month: "2027-01-01" }, "week").max).toBe("2027-01-31T00:00:00.000-05:00");
   });
 

--- a/client/src/components/charts/timeSeriesChartUtils.ts
+++ b/client/src/components/charts/timeSeriesChartUtils.ts
@@ -3,21 +3,6 @@ import { DateTime } from "luxon";
 
 import type { Time } from "@/components/DateSelector/types";
 
-const bucketEndOffsetMinutes = (bucket: TimeBucket): number => {
-  switch (bucket) {
-    case "hour":
-      return 59;
-    case "fifteen_minutes":
-      return 14;
-    case "ten_minutes":
-      return 9;
-    case "five_minutes":
-      return 4;
-    default:
-      return 0;
-  }
-};
-
 export const stepBucket = (dt: DateTime, bucket: TimeBucket, direction: 1 | -1): DateTime => {
   const n = direction;
   switch (bucket) {
@@ -157,10 +142,27 @@ export type ChartTimeBounds = {
   max: Date | undefined;
 };
 
+// ClickHouse's `toStartOfWeek` floors to Sunday where Luxon's `startOf("week")`
+// floors to Monday, so weekly buckets land on Sundays. Flooring with Luxon would
+// put the axis max *before* the final bucket of a period that ends on a Sunday,
+// and consumers drop points past the max.
+const floorToBucketStart = (dt: DateTime, bucket: TimeBucket): DateTime =>
+  bucket === "week" ? dt.startOf("day").minus({ days: dt.weekday % 7 }) : floorToBucket(dt, bucket);
+
+/**
+ * The start of the final bucket in `[start, endExclusive)`. Bounds end there
+ * rather than at the period's last millisecond so the closing tick sits on the
+ * right edge instead of a whole bucket short of it.
+ */
+const lastBucketStart = (start: DateTime, endExclusive: DateTime, bucket: TimeBucket): Date => {
+  const lastInstant = endExclusive.minus({ milliseconds: 1 });
+  const last = floorToBucketStart(lastInstant, bucket);
+  // A period holding a single bucket would otherwise collapse the x domain.
+  return (last > start ? last : lastInstant).toJSDate();
+};
+
 // Returns full-period x-scale bounds so related charts share a congruent scale.
 export const getChartTimeBounds = (time: Time, bucket: TimeBucket, timezone: string): ChartTimeBounds => {
-  const offset = bucketEndOffsetMinutes(bucket);
-
   if (time.mode === "past-minutes") {
     const startUnit = time.pastMinutesStart < 360 ? "minute" : "hour";
     const min = DateTime.now()
@@ -176,10 +178,10 @@ export const getChartTimeBounds = (time: Time, bucket: TimeBucket, timezone: str
   }
 
   if (time.mode === "day") {
-    const day = DateTime.fromISO(time.day, { zone: timezone });
+    const day = DateTime.fromISO(time.day, { zone: timezone }).startOf("day");
     return {
-      min: day.startOf("day").toJSDate(),
-      max: day.endOf("day").minus({ minutes: offset }).toJSDate(),
+      min: day.toJSDate(),
+      max: lastBucketStart(day, day.plus({ days: 1 }), bucket),
     };
   }
 
@@ -187,7 +189,7 @@ export const getChartTimeBounds = (time: Time, bucket: TimeBucket, timezone: str
     const week = DateTime.fromISO(time.week, { zone: timezone }).startOf("week");
     return {
       min: week.toJSDate(),
-      max: week.endOf("week").minus({ minutes: offset }).toJSDate(),
+      max: lastBucketStart(week, week.plus({ weeks: 1 }), bucket),
     };
   }
 
@@ -197,7 +199,7 @@ export const getChartTimeBounds = (time: Time, bucket: TimeBucket, timezone: str
     }).startOf("month");
     return {
       min: month.toJSDate(),
-      max: month.endOf("month").minus({ minutes: offset }).toJSDate(),
+      max: lastBucketStart(month, month.plus({ months: 1 }), bucket),
     };
   }
 
@@ -205,7 +207,7 @@ export const getChartTimeBounds = (time: Time, bucket: TimeBucket, timezone: str
     const year = DateTime.fromISO(time.year, { zone: timezone }).startOf("year");
     return {
       min: year.toJSDate(),
-      max: year.endOf("year").minus({ minutes: offset }).toJSDate(),
+      max: lastBucketStart(year, year.plus({ years: 1 }), bucket),
     };
   }
 
@@ -215,16 +217,17 @@ export const getChartTimeBounds = (time: Time, bucket: TimeBucket, timezone: str
         zone: timezone,
       });
       const endExclusive = DateTime.fromISO(`${time.endDate}T${time.endTime}`, { zone: timezone });
-      const displayEnd = stepBucket(endExclusive, bucket, -1);
       return {
         min: start.toJSDate(),
-        max: (displayEnd > start ? displayEnd : endExclusive).toJSDate(),
+        max: lastBucketStart(start, endExclusive, bucket),
       };
     }
 
+    const start = DateTime.fromISO(time.startDate, { zone: timezone }).startOf("day");
+    const endExclusive = DateTime.fromISO(time.endDate, { zone: timezone }).startOf("day").plus({ days: 1 });
     return {
-      min: DateTime.fromISO(time.startDate, { zone: timezone }).startOf("day").toJSDate(),
-      max: DateTime.fromISO(time.endDate, { zone: timezone }).endOf("day").minus({ minutes: offset }).toJSDate(),
+      min: start.toJSDate(),
+      max: lastBucketStart(start, endExclusive, bucket),
     };
   }
 

--- a/client/src/components/charts/timeSeriesChartUtils.ts
+++ b/client/src/components/charts/timeSeriesChartUtils.ts
@@ -142,12 +142,21 @@ export type ChartTimeBounds = {
   max: Date | undefined;
 };
 
-// ClickHouse's `toStartOfWeek` floors to Sunday where Luxon's `startOf("week")`
-// floors to Monday, so weekly buckets land on Sundays. Flooring with Luxon would
-// put the axis max *before* the final bucket of a period that ends on a Sunday,
-// and consumers drop points past the max.
+// Weekly buckets follow two conventions at once: the analytics queries floor
+// with ClickHouse's `toStartOfWeek` (Sunday) and the dashboard cards with
+// `toStartOfInterval(..., INTERVAL 1 WEEK)` (Monday) — verified, they differ by
+// a day. Luxon's `startOf("week")` is Monday. Take the later of the two floors
+// so neither convention's final bucket lands past the max, where consumers drop
+// it and the axis clips it; the cost is at most a day of trailing gutter.
+const floorToWeekStart = (dt: DateTime): DateTime => {
+  const day = dt.startOf("day");
+  const sunday = day.minus({ days: dt.weekday % 7 }); // Luxon weekday: 1 = Monday, 7 = Sunday
+  const monday = day.minus({ days: dt.weekday - 1 });
+  return sunday > monday ? sunday : monday;
+};
+
 const floorToBucketStart = (dt: DateTime, bucket: TimeBucket): DateTime =>
-  bucket === "week" ? dt.startOf("day").minus({ days: dt.weekday % 7 }) : floorToBucket(dt, bucket);
+  bucket === "week" ? floorToWeekStart(dt) : floorToBucket(dt, bucket);
 
 /**
  * The start of the final bucket in `[start, endExclusive)`. Bounds end there
@@ -164,14 +173,16 @@ const lastBucketStart = (start: DateTime, endExclusive: DateTime, bucket: TimeBu
 // Returns full-period x-scale bounds so related charts share a congruent scale.
 export const getChartTimeBounds = (time: Time, bucket: TimeBucket, timezone: string): ChartTimeBounds => {
   if (time.mode === "past-minutes") {
-    // Floored to the bucket rather than a fixed unit: a window stepped back
-    // keeps its own length, so "30 minutes" can start 6+ hours ago and an
-    // hour-floored left edge would open a gap the data never fills.
-    const now = DateTime.now().setZone(timezone);
-    const min = floorToBucketStart(now.minus({ minutes: time.pastMinutesStart }), bucket).toJSDate();
-    // Only the hour bucket pins the right edge: a finer floor advances between
-    // refetches, so the axis would creep away from the last point it has.
-    const max = bucket === "hour" ? now.minus({ minutes: time.pastMinutesEnd }).startOf("hour").toJSDate() : undefined;
+    const startUnit = time.pastMinutesStart < 360 ? "minute" : "hour";
+    const min = DateTime.now()
+      .setZone(timezone)
+      .minus({ minutes: time.pastMinutesStart })
+      .startOf(startUnit)
+      .toJSDate();
+    const max =
+      bucket === "hour"
+        ? DateTime.now().setZone(timezone).minus({ minutes: time.pastMinutesEnd }).startOf("hour").toJSDate()
+        : undefined;
     return { min, max };
   }
 

--- a/client/src/components/charts/timeSeriesChartUtils.ts
+++ b/client/src/components/charts/timeSeriesChartUtils.ts
@@ -164,16 +164,14 @@ const lastBucketStart = (start: DateTime, endExclusive: DateTime, bucket: TimeBu
 // Returns full-period x-scale bounds so related charts share a congruent scale.
 export const getChartTimeBounds = (time: Time, bucket: TimeBucket, timezone: string): ChartTimeBounds => {
   if (time.mode === "past-minutes") {
-    const startUnit = time.pastMinutesStart < 360 ? "minute" : "hour";
-    const min = DateTime.now()
-      .setZone(timezone)
-      .minus({ minutes: time.pastMinutesStart })
-      .startOf(startUnit)
-      .toJSDate();
-    const max =
-      bucket === "hour"
-        ? DateTime.now().setZone(timezone).minus({ minutes: time.pastMinutesEnd }).startOf("hour").toJSDate()
-        : undefined;
+    // Floored to the bucket rather than a fixed unit: a window stepped back
+    // keeps its own length, so "30 minutes" can start 6+ hours ago and an
+    // hour-floored left edge would open a gap the data never fills.
+    const now = DateTime.now().setZone(timezone);
+    const min = floorToBucketStart(now.minus({ minutes: time.pastMinutesStart }), bucket).toJSDate();
+    // Only the hour bucket pins the right edge: a finer floor advances between
+    // refetches, so the axis would creep away from the last point it has.
+    const max = bucket === "hour" ? now.minus({ minutes: time.pastMinutesEnd }).startOf("hour").toJSDate() : undefined;
     return { min, max };
   }
 

--- a/client/src/lib/store.ts
+++ b/client/src/lib/store.ts
@@ -208,3 +208,5 @@ export const getFilteredFilters = (parameters: FilterParameter[]) => {
 };
 
 export const canGoForward = (time: Time) => canGoForwardFrom(time, getTimezone());
+
+export const canGoBack = (time: Time) => shiftTimeBackward(time, getTimezone()) !== null;

--- a/client/src/lib/time.test.ts
+++ b/client/src/lib/time.test.ts
@@ -134,13 +134,21 @@ describe("shiftTimeBackward / shiftTimeForward", () => {
       endDate: "2024-03-08",
     });
     expect(
-      shiftTimeForward({ mode: "range", startDate: "2024-03-01", endDate: "2024-03-07" }, ZONE, dt("2024-03-20T00:00:00"))
+      shiftTimeForward(
+        { mode: "range", startDate: "2024-03-01", endDate: "2024-03-07" },
+        ZONE,
+        dt("2024-03-20T00:00:00")
+      )
     ).toEqual({ mode: "range", startDate: "2024-03-07", endDate: "2024-03-13" });
   });
 
   it("range: forward is blocked when the whole range would be in the future", () => {
     expect(
-      shiftTimeForward({ mode: "range", startDate: "2024-03-10", endDate: "2024-03-16" }, ZONE, dt("2024-03-14T00:00:00"))
+      shiftTimeForward(
+        { mode: "range", startDate: "2024-03-10", endDate: "2024-03-16" },
+        ZONE,
+        dt("2024-03-14T00:00:00")
+      )
     ).toBeNull();
   });
 
@@ -192,10 +200,34 @@ describe("shiftTimeBackward / shiftTimeForward", () => {
     ).toBeNull();
   });
 
-  it("all-time and past-minutes do not navigate", () => {
+  it("all-time does not navigate", () => {
     expect(shiftTimeBackward({ mode: "all-time" }, ZONE)).toBeNull();
     expect(shiftTimeForward({ mode: "all-time" }, ZONE)).toBeNull();
-    expect(shiftTimeBackward({ mode: "past-minutes", pastMinutesStart: 30, pastMinutesEnd: 0 }, ZONE)).toBeNull();
+  });
+
+  it("past-minutes: steps by the window length, staying relative to now", () => {
+    const live: Time = { mode: "past-minutes", pastMinutesStart: 30, pastMinutesEnd: 0 };
+    const oneBack = shiftTimeBackward(live, ZONE);
+    expect(oneBack).toEqual({ mode: "past-minutes", pastMinutesStart: 60, pastMinutesEnd: 30 });
+    expect(shiftTimeBackward(oneBack!, ZONE)).toEqual({
+      mode: "past-minutes",
+      pastMinutesStart: 90,
+      pastMinutesEnd: 60,
+    });
+    expect(shiftTimeForward(oneBack!, ZONE)).toEqual(live);
+  });
+
+  it("past-minutes: forward stops at the live window instead of the future", () => {
+    expect(shiftTimeForward({ mode: "past-minutes", pastMinutesStart: 30, pastMinutesEnd: 0 }, ZONE)).toBeNull();
+  });
+
+  it("past-minutes: forward clamps a partial step onto the live window", () => {
+    // A 6h window whose newer edge sits 2h out: the step lands on 0, not -4h.
+    expect(shiftTimeForward({ mode: "past-minutes", pastMinutesStart: 480, pastMinutesEnd: 120 }, ZONE)).toEqual({
+      mode: "past-minutes",
+      pastMinutesStart: 360,
+      pastMinutesEnd: 0,
+    });
   });
 });
 
@@ -233,9 +265,13 @@ describe("canGoForward", () => {
     expect(canGoForward({ mode: "year", year: "2025-01-01" }, ZONE, now)).toBe(false);
   });
 
-  it("all-time and past-minutes: never", () => {
+  it("all-time: never", () => {
     expect(canGoForward({ mode: "all-time" }, ZONE, now)).toBe(false);
+  });
+
+  it("past-minutes: gated by the newer edge of the window", () => {
     expect(canGoForward({ mode: "past-minutes", pastMinutesStart: 30, pastMinutesEnd: 0 }, ZONE, now)).toBe(false);
+    expect(canGoForward({ mode: "past-minutes", pastMinutesStart: 60, pastMinutesEnd: 30 }, ZONE, now)).toBe(true);
   });
 });
 

--- a/client/src/lib/time.ts
+++ b/client/src/lib/time.ts
@@ -116,8 +116,33 @@ export const deriveTimeState = (time: Time, zone: string): { previousTime: Time;
   return { previousTime, bucket };
 };
 
-/** One step back in time. Null when the mode doesn't navigate (all-time, past-minutes). */
+/**
+ * A past-minutes window steps by its own length and stays relative to now, so
+ * the presets keep auto-refreshing: {30, 0} back is {60, 30}, and forward from
+ * there clamps the newer edge at 0 to land back on the live window.
+ */
+const shiftPastMinutes = (time: Extract<Time, { mode: "past-minutes" }>, direction: 1 | -1): Time | null => {
+  const windowLength = time.pastMinutesStart - time.pastMinutesEnd;
+
+  if (direction === -1) {
+    return {
+      mode: "past-minutes",
+      pastMinutesStart: time.pastMinutesStart + windowLength,
+      pastMinutesEnd: time.pastMinutesEnd + windowLength,
+    };
+  }
+
+  if (time.pastMinutesEnd === 0) return null;
+  const pastMinutesEnd = Math.max(0, time.pastMinutesEnd - windowLength);
+  return { mode: "past-minutes", pastMinutesStart: pastMinutesEnd + windowLength, pastMinutesEnd };
+};
+
+/** One step back in time. Null when the mode doesn't navigate (all-time). */
 export const shiftTimeBackward = (time: Time, zone: string): Time | null => {
+  if (time.mode === "past-minutes") {
+    return shiftPastMinutes(time, -1);
+  }
+
   if (time.mode === "day") {
     return {
       mode: "day",
@@ -177,6 +202,10 @@ export const shiftTimeBackward = (time: Time, zone: string): Time | null => {
  * would land entirely in the future (ranges clamp against `now`).
  */
 export const shiftTimeForward = (time: Time, zone: string, now: DateTime = DateTime.now()): Time | null => {
+  if (time.mode === "past-minutes") {
+    return shiftPastMinutes(time, 1);
+  }
+
   if (time.mode === "day") {
     return {
       mode: "day",
@@ -280,6 +309,11 @@ export const canGoForward = (time: Time, zone: string, now: DateTime = DateTime.
 
   if (time.mode === "year") {
     return !(DateTime.fromISO(time.year, { zone }).startOf("year") >= currentDay);
+  }
+
+  // A past-minutes window that already ends at now has nowhere newer to go.
+  if (time.mode === "past-minutes") {
+    return time.pastMinutesEnd > 0;
   }
 
   return false;


### PR DESCRIPTION
Two related fixes to how the dashboard's time window is turned into a chart axis.

## Period charts ended one tick early

Week/month/year charts set the x-axis max to the period's *final millisecond* (`Aug 23 23:59:59.999` for "This Week"). Ticks sit on bucket *starts*, so the closing `Aug 23` tick landed a full day-width short of the right edge, leaving a phantom empty slot that reads as the chart ending early. Past-days ranges hid this because `MainSection` passes a `chartXMax` anchoring the right edge to the last real bucket; named periods deliberately keep the full-period span (so the previous period renders as a full backdrop) and had no such anchor.

The old `bucketEndOffsetMinutes` helper only compensated for sub-day buckets (hour → −59 min) and returned 0 for `day`/`week`/`month` — exactly the buckets these views use.

Bounds now end at the start of the period's final bucket, computed uniformly as `floor(endExclusive - 1ms)`:

- "This Week" + Day bucket → `Aug 23 00:00`, so the last tick sits on the right edge
- Same for month (`Aug 31 00:00`) and year (`Dec 1 00:00`, previously a whole empty month of gutter)
- Weekly buckets floor to **Sunday** to match ClickHouse's `toStartOfWeek`; Luxon's Monday-based `startOf("week")` would push the max before the last bucket on a month ending on a Sunday, and consumers drop points past the max
- Exact time ranges floor rather than stepping back one bucket, which keeps the final bucket of an unaligned range (09:15→17:45 hourly used to end at 16:45 and discard the 17:00 point)
- A period holding a single bucket falls back to the old end-of-period value so the x domain never collapses to a point

## Past-minutes presets could not navigate

The back/forward arrows were hardcoded off for Last 30 Minutes / 1 Hour / 6 Hours / 24 Hours: `shiftTimeBackward` and `canGoForward` both bailed on the mode, and every toolbar disabled the back button with its own `time.mode === "past-minutes"` check.

A past-minutes window now steps by its own length and stays relative to now, so the presets keep auto-refreshing: back from `{30, 0}` is `{60, 30}`, and forward clamps the newer edge at 0 so the last step lands exactly on the live window instead of overshooting into the future.

- The five toolbars share a `canGoBack` helper derived from `shiftTimeBackward` instead of repeating a mode check — which also disables the back button on All Time, where it previously did nothing
- A stepped-back window is labelled with the clock range it covers rather than "Last 30 minutes", which would read as live when it isn't (no new translation keys)
- Chart bounds for the mode floor the left edge to the bucket instead of the old `start < 360 ? minute : hour` heuristic: a stepped-back 30-minute window can start six hours ago, and an hour-floored edge opened a gap the data never fills. The right edge still pins only on the hour bucket — a finer floor advances between refetches and would creep away from the last point drawn.

No server change needed: `past_minutes_start/end` are already validated as an arbitrary pair (`start > end`) and resolved to absolute instants, and the fill reaches through the bucket containing the newer edge.

## Testing

- New `timeSeriesChartUtils.test.ts` covers the bounds across every time mode, the Sunday week alignment, a DST day, single-bucket periods, and exact ranges
- `time.test.ts` gains coverage for the past-minutes step math, the forward clamp, and the `canGoForward` gate
- `tsc --noEmit` clean; full client suite passes (286 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backward and forward navigation for past-minute time windows.
  * Navigation controls now accurately indicate when earlier or later periods are available.
  * Past-minute ranges with offsets display precise start and end timestamps, including dates across day boundaries.

* **Bug Fixes**
  * Improved chart time bounds for bucket alignment, date ranges, and daylight-saving transitions.
  * Past-minute exports now use the selected window’s actual end date.
  * Forward navigation correctly stops at the live window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->