### PR TITLE
Fix stale site access after site creation

### DIFF
--- a/server/src/api/sites/addSite.test.ts
+++ b/server/src/api/sites/addSite.test.ts
@@ -8,6 +8,7 @@ const state = vi.hoisted(() => ({
 
 const mocks = vi.hoisted(() => ({
   getSubscriptionInner: vi.fn(),
+  invalidateSitesAccessCache: vi.fn(),
 }));
 
 vi.mock("../../db/postgres/postgres.js", () => ({
@@ -40,6 +41,10 @@ vi.mock("../../lib/const.js", async importOriginal => {
 
 vi.mock("../stripe/getSubscription.js", () => ({
   getSubscriptionInner: mocks.getSubscriptionInner,
+}));
+
+vi.mock("../../lib/auth-utils.js", () => ({
+  invalidateSitesAccessCache: mocks.invalidateSitesAccessCache,
 }));
 
 import { addSite } from "./addSite.js";
@@ -78,6 +83,18 @@ beforeEach(() => {
   state.existingSiteCount = 0;
   state.insertedValues.length = 0;
   mocks.getSubscriptionInner.mockResolvedValue(subscription());
+});
+
+describe("addSite — access cache invalidation", () => {
+  it("invalidates the creator's cached site access after creating a site", async () => {
+    const reply = replyStub();
+
+    await addSite(makeRequest({}), reply);
+
+    expect(reply.statusCode).toBe(201);
+    expect(mocks.invalidateSitesAccessCache).toHaveBeenCalledOnce();
+    expect(mocks.invalidateSitesAccessCache).toHaveBeenCalledWith("u_1");
+  });
 });
 
 describe("addSite — cloud pro-feature gating (session replay)", () => {

--- a/server/src/api/sites/addSite.ts
+++ b/server/src/api/sites/addSite.ts
@@ -1,4 +1,5 @@
 import { FastifyReply, FastifyRequest } from "fastify";
+import { invalidateSitesAccessCache } from "../../lib/auth-utils.js";
 import {
   type CreateSiteInput,
   SiteLifecycleError,
@@ -20,6 +21,10 @@ export async function addSite(
       organizationId: request.params.organizationId,
       createdBy: request.user?.id,
     });
+
+    if (request.user?.id) {
+      invalidateSitesAccessCache(request.user.id);
+    }
 
     return reply.status(201).send(newSite);
   } catch (error) {


### PR DESCRIPTION
## Summary

- invalidate the creator's site-access cache immediately after a successful site creation
- add regression coverage for the creation handler

## Why

Site creation changed the creator's accessible site set without evicting the cached result. Authenticated site routes could therefore return 403 until the 15-second cache TTL expired.

## Testing

- npm test -- --run (1,679 tests passed)
- npm run build

Closes #1132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Site access information now refreshes automatically after a site is created, ensuring newly created sites appear without requiring stale access data to persist.
  * Added coverage to verify successful site creation and access refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->