### PR TITLE
fix(analytics): include untitled pages in Pages tab

### DIFF
--- a/client/src/api/analytics/endpoints/misc.ts
+++ b/client/src/api/analytics/endpoints/misc.ts
@@ -24,7 +24,7 @@ export interface JourneysResponse {
 
 // Page title types
 export type PageTitleItem = {
-  value: string; // The page_title
+  value: string; // The page_title; empty when the row represents an untitled pathname
   pathname: string; // A representative pathname
   count: number;
   percentage: number;

--- a/client/src/app/[site]/pages/components/PagesTable.tsx
+++ b/client/src/app/[site]/pages/components/PagesTable.tsx
@@ -21,6 +21,7 @@ import { useStore } from "@/lib/store";
 import { formatShortDuration } from "@/lib/dateTimeUtils";
 import { cn, truncateString } from "@/lib/utils";
 import { PageSparklineChart } from "./PageSparklineChart";
+import { getPageItemFilters, getPageItemKey } from "./pageIdentity";
 
 const PAGE_SIZE = 25;
 const MAX_TITLE_LENGTH = 80;
@@ -47,11 +48,12 @@ function TrendCell({ pageItem }: { pageItem: PageTitleItem }) {
   const { site, bucket, time } = useStore();
   const [isHovering, setIsHovering] = useState(false);
   const isPastMinutesMode = time.mode === "past-minutes";
+  const pageFilters = getPageItemFilters(pageItem);
 
   const { data: regularData, isLoading: isLoadingRegular } = useGetOverviewBucketed({
     site,
     bucket,
-    dynamicFilters: [{ parameter: "page_title", value: [pageItem.value], type: "equals" }],
+    dynamicFilters: pageFilters,
     props: { enabled: !isPastMinutesMode },
   });
 
@@ -74,7 +76,7 @@ function TrendCell({ pageItem }: { pageItem: PageTitleItem }) {
       <PageSparklineChart
         data={data}
         isHovering={isHovering}
-        pageTitle={pageItem.value}
+        pageTitle={pageItem.value || pageItem.pathname}
         isLoading={isLoading}
       />
     </div>
@@ -112,10 +114,10 @@ export function PagesTable() {
   const currentItems = currentResp?.data ?? [];
   const totalCount = currentResp?.totalCount ?? 0;
 
-  const previousByValue = useMemo(() => {
+  const previousByKey = useMemo(() => {
     const map = new Map<string, PageTitleItem>();
     for (const item of previousResp?.data ?? []) {
-      map.set(item.value, item);
+      map.set(getPageItemKey(item), item);
     }
     return map;
   }, [previousResp]);
@@ -136,7 +138,7 @@ export function PagesTable() {
             <div className="flex items-center gap-1.5">
               <span
                 className="text-sm font-medium truncate text-foreground"
-                title={title}
+                title={title || pathname}
               >
                 {truncateString(title || pathname, MAX_TITLE_LENGTH)}
               </span>
@@ -175,7 +177,7 @@ export function PagesTable() {
       header: t("Sessions"),
       cell: info => {
         const current = info.getValue() ?? 0;
-        const prev = previousByValue.get(info.row.original.value)?.count ?? 0;
+        const prev = previousByKey.get(getPageItemKey(info.row.original))?.count ?? 0;
         return (
           <div className="whitespace-nowrap flex items-center gap-1.5">
             <span>{current.toLocaleString()}</span>

--- a/client/src/app/[site]/pages/components/pageIdentity.test.ts
+++ b/client/src/app/[site]/pages/components/pageIdentity.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import type { PageTitleItem } from "@/api/analytics/endpoints";
+import { getPageItemFilters, getPageItemKey } from "./pageIdentity";
+
+const pageItem = (overrides: Partial<PageTitleItem> = {}): PageTitleItem => ({
+  value: "Pricing",
+  pathname: "/pricing",
+  count: 1,
+  percentage: 100,
+  ...overrides,
+});
+
+describe("page identity", () => {
+  it("identifies and filters titled rows by page title", () => {
+    const item = pageItem();
+
+    expect(getPageItemKey(item)).toBe("title:Pricing");
+    expect(getPageItemFilters(item)).toEqual([{ parameter: "page_title", value: ["Pricing"], type: "equals" }]);
+  });
+
+  it("identifies and filters untitled rows by pathname", () => {
+    const item = pageItem({ value: "", pathname: "/docs/getting-started" });
+
+    expect(getPageItemKey(item)).toBe("pathname:/docs/getting-started");
+    expect(getPageItemFilters(item)).toEqual([
+      { parameter: "page_title", value: [], type: "is_null" },
+      { parameter: "pathname", value: ["/docs/getting-started"], type: "equals" },
+    ]);
+  });
+});

--- a/client/src/app/[site]/pages/components/pageIdentity.ts
+++ b/client/src/app/[site]/pages/components/pageIdentity.ts
@@ -1,0 +1,18 @@
+import type { Filter } from "@rybbit/shared";
+
+import type { PageTitleItem } from "@/api/analytics/endpoints";
+
+export function getPageItemKey(item: PageTitleItem) {
+  return item.value ? `title:${item.value}` : `pathname:${item.pathname}`;
+}
+
+export function getPageItemFilters(item: PageTitleItem): Filter[] {
+  if (item.value) {
+    return [{ parameter: "page_title", value: [item.value], type: "equals" }];
+  }
+
+  return [
+    { parameter: "page_title", value: [], type: "is_null" },
+    { parameter: "pathname", value: [item.pathname], type: "equals" },
+  ];
+}

--- a/server/src/api/analytics/getPageTitles.test.ts
+++ b/server/src/api/analytics/getPageTitles.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../db/clickhouse/clickhouse.js", () => ({
+  clickhouse: { query: vi.fn() },
+}));
+vi.mock("../../db/postgres/postgres.js", () => ({
+  db: {},
+}));
+
+import { buildPageTitlesQuery } from "./getPageTitles.js";
+
+const baseQuery = (overrides: Partial<Record<string, unknown>> = {}) =>
+  ({
+    start_date: "",
+    end_date: "",
+    time_zone: "",
+    filters: "",
+    ...overrides,
+  }) as Parameters<typeof buildPageTitlesQuery>[0];
+
+describe("buildPageTitlesQuery", () => {
+  it("includes untitled pageviews as separate rows per pathname", () => {
+    const sql = buildPageTitlesQuery(baseQuery(), 1);
+
+    expect(sql).not.toContain("page_title IS NOT NULL");
+    expect(sql).not.toContain("page_title <> ''");
+    expect(sql).toContain("if(pd.page_title = '', pd.pathname, '') as untitled_pathname");
+    expect(sql).toContain("GROUP BY pd.page_title, untitled_pathname");
+  });
+
+  it("counts untitled pathname rows in pagination totals", () => {
+    const sql = buildPageTitlesQuery(baseQuery({ limit: 25, page: 2 }), 1, true);
+
+    expect(sql).toContain("GROUP BY pd.page_title, untitled_pathname");
+    expect(sql).toContain("SELECT COUNT(*) as totalCount FROM PageTitleStats");
+    expect(sql).not.toContain("LIMIT 25");
+    expect(sql).not.toContain("OFFSET 25");
+  });
+});

--- a/server/src/api/analytics/getPageTitles.ts
+++ b/server/src/api/analytics/getPageTitles.ts
@@ -69,8 +69,6 @@ export const buildPageTitlesQuery = (
         FROM events
         WHERE
           site_id = {siteId:Int32}
-          AND page_title IS NOT NULL
-          AND page_title <> ''
           AND type = 'pageview'
           ${filterStatement}
           ${timeStatement}
@@ -89,14 +87,16 @@ export const buildPageTitlesQuery = (
     ),
     PageTitleStats AS (
         SELECT
-            page_title as value,
-            argMax(pathname, timestamp) as pathname,
+            pd.page_title as value,
+            -- Preserve the existing title grouping, but do not merge every untitled URL into one row.
+            if(pd.page_title = '', pd.pathname, '') as untitled_pathname,
+            argMax(pd.pathname, pd.timestamp) as pathname,
             count(DISTINCT session_id) as unique_sessions,
             count() as pageviews,
             countIf(DISTINCT session_id, pageviews_in_session = 1) as bounced_sessions,
             avg(if(time_diff_seconds < 0, 0, if(time_diff_seconds > 1800, 1800, time_diff_seconds))) as avg_time_on_page_seconds
-        FROM PageDurations
-        GROUP BY page_title
+        FROM PageDurations pd
+        GROUP BY pd.page_title, untitled_pathname
     )
   `;
 


### PR DESCRIPTION
## Summary

- include pageviews with empty `page_title` values in the Pages tab query
- preserve title-based grouping while separating untitled rows by pathname
- key and filter untitled client rows by pathname so trends and comparisons stay page-specific
- add regression coverage for query pagination totals and client row identity

## Verification

- `cd server && npm run build`
- `cd server && npm run test:run` (1,680 tests)
- `cd client && npm run test` (301 tests)
- client ESLint and `tsc --noEmit`
- ClickHouse 26.3 fixture matching the issue returns both `/pricing` and `/docs/getting-started`

Fixes #1135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Untitled pages are now included in page analytics and grouped by pathname.
  * Page titles and untitled URLs are displayed and tracked as distinct entries.

* **Bug Fixes**
  * Improved page table identity handling for untitled pages.
  * Trend charts, tooltips, and previous-period comparisons now resolve untitled page data correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->