### PR TITLE
Fix keyless 2D map basemap

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -74,6 +74,7 @@
         "next-themes": "0.4.6",
         "nuqs": "^2.8.8",
         "ol": "^10.6.1",
+        "ol-mapbox-style": "^13.4.3",
         "papaparse": "^5.5.3",
         "react": "^19.2.4",
         "react-day-picker": "^10.0.1",
@@ -1633,11 +1634,11 @@
       }
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 22"
       }
     },
     "node_modules/@mapbox/mapbox-gl-supported": {
@@ -1683,6 +1684,29 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.1.tgz",
+      "integrity": "sha512-I/qcIKVFHFSg1Meu/eqHrkSTjIez0gCsSaK56TNPutM3TkE61aSq6F1cZ4Kg4KiNs3cpViLtubDjfyRcQCdEJQ==",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ=="
     },
     "node_modules/@marsidev/react-turnstile": {
       "version": "1.4.0",
@@ -11236,6 +11260,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q=="
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -11843,6 +11872,11 @@
         "tinyqueue": "^3.0.0"
       }
     },
+    "node_modules/mapbox-to-css-font": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-3.2.0.tgz",
+      "integrity": "sha512-kvsEfzvLik34BiFj+S19bv5d70l9qSdkUzrq99dvZ9d5POaLyB4vJMQmq3BoJ5D6lFG1GYnMM7o7cm5Jh8YEEg=="
+    },
     "node_modules/martinez-polygon-clipping": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.7.4.tgz",
@@ -11957,7 +11991,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12470,6 +12503,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/openlayers"
+      }
+    },
+    "node_modules/ol-mapbox-style": {
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-13.4.3.tgz",
+      "integrity": "sha512-fqoYg2AncNlLwtR2cj86WqsKOtYEyNsJg+jqC6TkrBEc8Mi9elOkdyU7X60ZDv4AohhwuH29UKkegIYZLM6qOQ==",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "^26.4.0",
+        "mapbox-to-css-font": "^3.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ahocevar"
+      },
+      "peerDependencies": {
+        "ol": "*"
       }
     },
     "node_modules/optionator": {

--- a/client/package.json
+++ b/client/package.json
@@ -81,6 +81,7 @@
     "next-themes": "0.4.6",
     "nuqs": "^2.8.8",
     "ol": "^10.6.1",
+    "ol-mapbox-style": "^13.4.3",
     "papaparse": "^5.5.3",
     "react": "^19.2.4",
     "react-day-picker": "^10.0.1",

--- a/client/src/app/[site]/globe/2d/components/OpenLayersMap.tsx
+++ b/client/src/app/[site]/globe/2d/components/OpenLayersMap.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useRef, useEffect } from "react";
+import { apply } from "ol-mapbox-style";
+import Attribution from "ol/control/Attribution";
+import LayerGroup from "ol/layer/Group";
 import Map from "ol/Map";
 import View from "ol/View";
-import TileLayer from "ol/layer/Tile";
-import XYZ from "ol/source/XYZ";
 import { fromLonLat } from "ol/proj";
 import "ol/ol.css";
 import { useOpenLayersCountriesLayer } from "../hooks/useOpenLayersCountriesLayer";
@@ -31,14 +32,8 @@ export function OpenLayersMap({ mapView, onSessionSelect }: OpenLayersMapProps) 
   useEffect(() => {
     if (!mapRef.current || mapInstanceRef.current) return;
 
-    // Create base tile layer with CartoDB Dark Matter (no labels)
-    const baseLayer = new TileLayer({
-      source: new XYZ({
-        url: "https://{a-d}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
-        attributions:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
-      }),
-    });
+    const baseLayer = new LayerGroup();
+    void apply(baseLayer, "https://tiles.openfreemap.org/styles/dark");
 
     const map = new Map({
       target: mapRef.current,
@@ -49,7 +44,7 @@ export function OpenLayersMap({ mapView, onSessionSelect }: OpenLayersMapProps) 
         minZoom: 1,
         maxZoom: 18,
       }),
-      controls: [],
+      controls: [new Attribution({ collapsible: false })],
     });
 
     mapInstanceRef.current = map;


### PR DESCRIPTION
## Summary
- replace CARTO raster tiles with the keyless OpenFreeMap dark vector style
- keep the existing OpenLayers analytics overlays and interactions
- restore visible OpenStreetMap/OpenMapTiles attribution

## Verification
- npx tsc --noEmit
- production Next.js build with Node 24
- 301 client tests passing
- focused Prettier check

Closes #1139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the 2D map with a refreshed dark basemap style.
  - Added a visible map attribution control for improved source transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->