### PR TITLE
fix(replay): resolve click labels per snapshot

### DIFF
--- a/client/src/components/replay/replayEvents.test.ts
+++ b/client/src/components/replay/replayEvents.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { getMeaningfulEvents } from "./replayEvents";
+
+const text = (id: number, textContent: string) => ({ id, type: 3, textContent });
+const element = (id: number, tagName: string, label: string) => ({
+  id,
+  type: 2,
+  tagName,
+  attributes: {},
+  childNodes: [text(id + 1, label)],
+});
+
+const click = (timestamp: number, id: number) => ({
+  timestamp,
+  type: 3,
+  data: { source: 2, type: 2, id },
+});
+
+describe("getMeaningfulEvents", () => {
+  it("resolves click targets against the FullSnapshot active at click time", () => {
+    const events = [
+      {
+        timestamp: 1_000,
+        type: 2,
+        data: {
+          node: {
+            id: 1,
+            type: 0,
+            childNodes: [
+              element(10, "summary", "$0.02 / video"),
+              element(20, "summary", "Do credits expire?"),
+              element(30, "summary", "What formats are available?"),
+              element(40, "summary", "What is MCP and why does it matter?"),
+              element(50, "summary", "Does this work with ChatGPT, Claude, Cursor..."),
+            ],
+          },
+        },
+      },
+      click(2_000, 10),
+      click(4_000, 20),
+      click(6_000, 30),
+      click(8_000, 40),
+      click(10_000, 50),
+      {
+        timestamp: 12_000,
+        type: 2,
+        data: {
+          node: {
+            id: 1,
+            type: 0,
+            childNodes: [
+              element(20, "a", "YouTube Bulk Transcript A product by someone"),
+              element(30, "a", "Terms of Service"),
+              element(40, "a", "Featured on Submitator"),
+              element(50, "a", ""),
+            ],
+          },
+        },
+      },
+      click(14_000, 30),
+    ];
+
+    expect(getMeaningfulEvents(events).map(event => event.detail)).toEqual([
+      "“$0.02 / video”",
+      "“Do credits expire?”",
+      "“What formats are available?”",
+      "“What is MCP and why does it matter?”",
+      "“Does this work with ChatGPT, Claude, Cu…”",
+      "“Terms of Service”",
+    ]);
+  });
+
+  it("resolves targets added by a mutation before the click", () => {
+    const events = [
+      {
+        timestamp: 1_000,
+        type: 2,
+        data: { node: { id: 1, type: 0, childNodes: [] } },
+      },
+      {
+        timestamp: 2_000,
+        type: 3,
+        data: {
+          source: 0,
+          adds: [{ parentId: 1, node: element(60, "button", "Save changes") }],
+        },
+      },
+      click(4_000, 60),
+    ];
+
+    expect(getMeaningfulEvents(events).map(event => event.detail)).toEqual(["“Save changes”"]);
+  });
+});

--- a/client/src/components/replay/replayEvents.ts
+++ b/client/src/components/replay/replayEvents.ts
@@ -68,31 +68,29 @@ interface NodeIndex {
 const INTERACTIVE_TAGS = new Set(["a", "button", "input", "select", "textarea", "label", "summary", "option"]);
 const INTERACTIVE_ROLES = new Set(["button", "link", "tab", "menuitem", "checkbox", "switch", "radio", "option"]);
 
-function buildNodeIndex(events: RawEvent[]): NodeIndex {
-  const byId = new Map<number, SNode>();
-  const parent = new Map<number, number>();
+function createNodeIndex(): NodeIndex {
+  return { byId: new Map(), parent: new Map() };
+}
 
-  const walk = (node: SNode | undefined, parentId: number | null) => {
-    if (!node || typeof node.id !== "number") return;
-    byId.set(node.id, node);
-    if (parentId !== null) parent.set(node.id, parentId);
-    if (Array.isArray(node.childNodes)) {
-      for (const child of node.childNodes) walk(child, node.id);
-    }
-  };
-
-  for (const ev of events) {
-    const type = Number(ev.type);
-    if (type === 2 && ev.data?.node) {
-      walk(ev.data.node, null);
-    } else if (type === 3 && ev.data?.source === 0 && Array.isArray(ev.data?.adds)) {
-      for (const add of ev.data.adds) {
-        walk(add?.node, typeof add?.parentId === "number" ? add.parentId : null);
-      }
-    }
+function indexNode(index: NodeIndex, node: SNode | undefined, parentId: number | null): void {
+  if (!node || typeof node.id !== "number") return;
+  index.byId.set(node.id, node);
+  if (parentId !== null) index.parent.set(node.id, parentId);
+  if (Array.isArray(node.childNodes)) {
+    for (const child of node.childNodes) indexNode(index, child, node.id);
   }
+}
 
-  return { byId, parent };
+function resetNodeIndex(index: NodeIndex, root: SNode): void {
+  index.byId.clear();
+  index.parent.clear();
+  indexNode(index, root, null);
+}
+
+function indexMutationAdds(index: NodeIndex, adds: Array<{ node?: SNode; parentId?: unknown }>): void {
+  for (const add of adds) {
+    indexNode(index, add?.node, typeof add?.parentId === "number" ? add.parentId : null);
+  }
 }
 
 function truncate(value: string, max = 40): string {
@@ -223,7 +221,7 @@ export function getMeaningfulEvents(events: RawEvent[] | undefined): MeaningfulE
   if (!events || events.length === 0) return [];
 
   const first = events[0].timestamp;
-  const index = buildNodeIndex(events);
+  const index = createNodeIndex();
   const out: MeaningfulEvent[] = [];
   let metaSeen = false;
   // Track the current path so repeated Meta events for the same URL (rrweb emits
@@ -240,6 +238,13 @@ export function getMeaningfulEvents(events: RawEvent[] | undefined): MeaningfulE
     const ev = events[i];
     const type = Number(ev.type);
     const offset = ev.timestamp - first;
+
+    // A FullSnapshot is authoritative. Full page loads start a new recorder
+    // whose node ids may overlap the previous page's, so discard the old map.
+    if (type === 2 && ev.data?.node) {
+      resetNodeIndex(index, ev.data.node);
+      continue;
+    }
 
     // Meta (type 4): the first one is the session start, the rest are navigations.
     if (type === 4 && ev.data?.href) {
@@ -298,6 +303,13 @@ export function getMeaningfulEvents(events: RawEvent[] | undefined): MeaningfulE
 
     if (type !== 3) continue;
     const source = ev.data?.source;
+
+    // Keep the index in lockstep with the replay so clicks can resolve nodes
+    // inserted after the active FullSnapshot.
+    if (source === 0 && Array.isArray(ev.data?.adds)) {
+      indexMutationAdds(index, ev.data.adds);
+      continue;
+    }
 
     // Console via incremental Log (source 11).
     if (source === 11) {


### PR DESCRIPTION
## Summary
- build the rrweb node index chronologically instead of pre-indexing the full session
- reset the index for each authoritative FullSnapshot so reused node IDs cannot overwrite earlier click targets
- preserve target resolution for nodes introduced by mutation events
- add regression coverage reproducing the exact FAQ/footer label drift

Fixes #1108

## Testing
- npm test (303 tests passed)
- tsc --noEmit
- Prettier check for the new test
- git diff --check

## Lint note
- npm run lint is currently non-actionable because the empty ESLint config scans generated .next bundles; it reports generated-code errors unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replay event details now correctly resolve click targets based on the page state at the time of the click.
  * Click targets added through page mutations are now identified correctly.
  * Stale element references from previous page loads are no longer used.
  * Long click-target labels are truncated consistently.

* **Tests**
  * Added coverage for snapshot-based target resolution and mutation-added targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->