### PR TITLE
Three landing-page redesign candidates at /lp/a, /lp/b, /lp/c

### DIFF
--- a/docs/src/app/[locale]/(home)/lp/a/page.tsx
+++ b/docs/src/app/[locale]/(home)/lp/a/page.tsx
@@ -1,0 +1,21 @@
+import { VariantA } from "@/components/lp-variants/VariantA";
+import { LP_META_DESCRIPTION, LP_TITLE } from "@/components/lp-variants/shared";
+import { createMetadata, createOGImageUrl } from "@/lib/metadata";
+
+/**
+ * Redesign candidate A — no frame; centered column, whitespace does the separating.
+ *
+ * Temporary preview path. `lp/layout.tsx` marks everything under /lp as
+ * `robots: noindex, follow`, so these do not compete with the homepage while
+ * they are being polished. Intended end state is an A/B test against `/`.
+ */
+export const metadata = createMetadata({
+  title: "Rybbit - Cookieless Google Analytics Replacement",
+  description: LP_META_DESCRIPTION,
+  openGraph: { images: [createOGImageUrl(LP_TITLE, LP_META_DESCRIPTION)] },
+  twitter: { images: [createOGImageUrl(LP_TITLE, LP_META_DESCRIPTION)] },
+});
+
+export default function LandingVariantA() {
+  return <VariantA />;
+}

--- a/docs/src/app/[locale]/(home)/lp/b/page.tsx
+++ b/docs/src/app/[locale]/(home)/lp/b/page.tsx
@@ -1,0 +1,21 @@
+import { VariantB } from "@/components/lp-variants/VariantB";
+import { LP_META_DESCRIPTION, LP_TITLE } from "@/components/lp-variants/shared";
+import { createMetadata, createOGImageUrl } from "@/lib/metadata";
+
+/**
+ * Redesign candidate B — one live dashboard, switched between real views, instead of a feature mosaic.
+ *
+ * Temporary preview path. `lp/layout.tsx` marks everything under /lp as
+ * `robots: noindex, follow`, so these do not compete with the homepage while
+ * they are being polished. Intended end state is an A/B test against `/`.
+ */
+export const metadata = createMetadata({
+  title: "Rybbit - Cookieless Google Analytics Replacement",
+  description: LP_META_DESCRIPTION,
+  openGraph: { images: [createOGImageUrl(LP_TITLE, LP_META_DESCRIPTION)] },
+  twitter: { images: [createOGImageUrl(LP_TITLE, LP_META_DESCRIPTION)] },
+});
+
+export default function LandingVariantB() {
+  return <VariantB />;
+}

--- a/docs/src/app/[locale]/(home)/lp/c/page.tsx
+++ b/docs/src/app/[locale]/(home)/lp/c/page.tsx
@@ -1,0 +1,21 @@
+import { VariantC } from "@/components/lp-variants/VariantC";
+import { LP_META_DESCRIPTION, LP_TITLE } from "@/components/lp-variants/shared";
+import { createMetadata, createOGImageUrl } from "@/lib/metadata";
+
+/**
+ * Redesign candidate C — one structural device: a hairline between bands with a mono gutter label.
+ *
+ * Temporary preview path. `lp/layout.tsx` marks everything under /lp as
+ * `robots: noindex, follow`, so these do not compete with the homepage while
+ * they are being polished. Intended end state is an A/B test against `/`.
+ */
+export const metadata = createMetadata({
+  title: "Rybbit - Cookieless Google Analytics Replacement",
+  description: LP_META_DESCRIPTION,
+  openGraph: { images: [createOGImageUrl(LP_TITLE, LP_META_DESCRIPTION)] },
+  twitter: { images: [createOGImageUrl(LP_TITLE, LP_META_DESCRIPTION)] },
+});
+
+export default function LandingVariantC() {
+  return <VariantC />;
+}

--- a/docs/src/app/global.css
+++ b/docs/src/app/global.css
@@ -128,6 +128,20 @@ pre {
   background-color: color-mix(in oklab, #0a0a0a 94%, #34d399);
 }
 
+/* ── Landing redesign candidates (/lp/a, /lp/b, /lp/c) ───────────────────
+   Those variants drop the 1200px vertical container rules from the page body.
+   The shared site header draws the same pair, which would otherwise leave two
+   orphaned hairlines hanging above a page that has none. A variant opts the
+   header out by rendering `data-lp-bare-chrome` on its root; `:has()` is needed
+   because the header is a sibling of <main>, not an ancestor of the page. */
+body:has([data-lp-bare-chrome]) header nav,
+body:has([data-lp-bare-chrome]) footer > div {
+  border-inline-color: transparent;
+}
+body:has([data-lp-bare-chrome]) footer > div > [aria-hidden="true"]:first-child {
+  display: none;
+}
+
 /* ── Marketing data-line decoration ──────────────────────────────────────
    The plotted line draws itself on load via a left→right clip-path wipe.
    Not stroke-dasharray: with vector-effect: non-scaling-stroke, Chromium

--- a/docs/src/components/Integration.tsx
+++ b/docs/src/components/Integration.tsx
@@ -34,6 +34,7 @@ import {
   SiWoocommerce,
   SiWordpress,
 } from "@icons-pack/react-simple-icons";
+import { cn } from "@/lib/utils";
 import { ComponentType, CSSProperties } from "react";
 
 type IconProps = {
@@ -88,12 +89,15 @@ const platforms: Platform[] = [
   { name: "WordPress", icon: SiWordpress, path: "/docs/guides/wordpress", color: "#21759B", darkColor: "#5da9cc" },
 ];
 
-const PlatformLogo = ({ name, icon: Icon, path, color, darkColor }: Platform) => {
+const PlatformLogo = ({ name, icon: Icon, path, color, darkColor, bare }: Platform & { bare?: boolean }) => {
   return (
     <Link
       href={path}
       style={{ "--brand": color, "--brand-dark": darkColor ?? color } as CSSProperties}
-      className="group flex min-h-20 items-center gap-3 bg-white px-4 text-neutral-600 transition-colors duration-200 hover:bg-neutral-50 hover:text-neutral-950 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:bg-neutral-950 dark:text-neutral-400 dark:hover:bg-neutral-900 dark:hover:text-white"
+      className={cn(
+        "group flex items-center gap-3 bg-white text-neutral-600 transition-colors duration-200 hover:bg-neutral-50 hover:text-neutral-950 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:bg-neutral-950 dark:text-neutral-400 dark:hover:bg-neutral-900 dark:hover:text-white",
+        bare ? "min-h-14 rounded-md px-3" : "min-h-20 px-4"
+      )}
     >
       <Icon className="size-5 shrink-0 transition-colors duration-200 group-hover:text-[var(--brand)] group-focus-visible:text-[var(--brand)] dark:group-hover:text-[var(--brand-dark)] dark:group-focus-visible:text-[var(--brand-dark)]" />
       <span className="text-sm font-medium">{name}</span>
@@ -101,11 +105,21 @@ const PlatformLogo = ({ name, icon: Icon, path, color, darkColor }: Platform) =>
   );
 };
 
-export function IntegrationsGrid() {
+/**
+ * `bare` drops the hairline seams the production landing page uses (a `gap-px`
+ * grid over a neutral backdrop) in favour of plain spacing, for the /lp/*
+ * redesign candidates that remove structural rules from the page.
+ */
+export function IntegrationsGrid({ bare = false }: { bare?: boolean }) {
   return (
-    <div className="grid min-h-full grid-cols-2 gap-px bg-neutral-200 dark:bg-neutral-800 sm:grid-cols-3 xl:grid-cols-4">
+    <div
+      className={cn(
+        "grid min-h-full grid-cols-2 sm:grid-cols-3 xl:grid-cols-4",
+        bare ? "gap-x-2 gap-y-1" : "gap-px bg-neutral-200 dark:bg-neutral-800"
+      )}
+    >
       {platforms.map((platform) => (
-        <PlatformLogo key={platform.name} {...platform} />
+        <PlatformLogo key={platform.name} {...platform} bare={bare} />
       ))}
     </div>
   );

--- a/docs/src/components/LandingPricing.tsx
+++ b/docs/src/components/LandingPricing.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { PricingSection } from "./PricingSection";
 
-export function LandingPricing() {
+export function LandingPricing({ chrome }: { chrome?: "framed" | "bare" }) {
   const [isAnnual, setIsAnnual] = useState(true);
-  return <PricingSection isAnnual={isAnnual} setIsAnnual={setIsAnnual} />;
+  return <PricingSection isAnnual={isAnnual} setIsAnnual={setIsAnnual} chrome={chrome} />;
 }

--- a/docs/src/components/PricingCard.tsx
+++ b/docs/src/components/PricingCard.tsx
@@ -24,6 +24,12 @@ export interface PricingCardProps {
    * of the seamed `gap-px` plan grid, where the grid supplies the hairlines.
    */
   framed?: boolean;
+  /**
+   * Drop the recommended card's plate tint and graph texture, keeping only its
+   * emerald edge and badge. Used by the chrome="bare" pricing band, where the
+   * texture would reintroduce a surface the layout deliberately removed.
+   */
+  plain?: boolean;
   className?: string;
   featuresClassName?: string;
   eventLocation?: string;
@@ -39,6 +45,7 @@ export function PricingCard({
   features,
   recommended = false,
   framed = false,
+  plain = false,
   className,
   featuresClassName,
   eventLocation,
@@ -60,7 +67,7 @@ export function PricingCard({
     <div
       className={cn(
         "relative h-full overflow-hidden",
-        recommended ? "bg-plate-accent" : "bg-white dark:bg-neutral-950",
+        recommended && !plain ? "bg-plate-accent" : "bg-white dark:bg-neutral-950",
         framed
           ? cn(
               "rounded-lg border",
@@ -72,7 +79,7 @@ export function PricingCard({
         className
       )}
     >
-      {recommended && (
+      {recommended && !plain && (
         <div
           aria-hidden="true"
           className="pointer-events-none absolute inset-0 bg-graph-accent [mask-image:linear-gradient(to_bottom,black,transparent_92%),linear-gradient(to_left,transparent,black_40px)] [mask-composite:intersect]"

--- a/docs/src/components/PricingSection.tsx
+++ b/docs/src/components/PricingSection.tsx
@@ -67,11 +67,20 @@ export function PricingSection({
   isAnnual,
   setIsAnnual,
   standalone = false,
+  chrome = "framed",
 }: {
   isAnnual: boolean;
   setIsAnnual: (isAnnual: boolean) => void;
   /** Page-top mode for /pricing: h1 heading plus the marketing pages' plotted-dataline signature. */
   standalone?: boolean;
+  /**
+   * `"framed"` (default) is the production instrument sheet: 1200px bordered
+   * container, corner crosses, signal plate header, dot-grid slider mat, seamed
+   * plan grid. `"bare"` strips all of it and drops the header row entirely, so
+   * a caller can supply its own heading in its own voice — used by the /lp/*
+   * redesign candidates, whose whole premise is that the frame is the problem.
+   */
+  chrome?: "framed" | "bare";
 }) {
   const t = useExtracted();
   const [eventLimitIndex, setEventLimitIndex] = useState(0); // Default to 100k (index 0)
@@ -200,6 +209,131 @@ export function PricingSection({
 
   const headlineClasses = "mt-5 max-w-2xl font-semibold tracking-[-0.035em] text-balance";
 
+  /* Slider instrument, shared by both chrome modes. `mat` draws the dot-grid
+     surround the framed sheet uses; bare mode sits straight on the page. */
+  const sliderInstrument = (
+    <div className="rounded-md border border-neutral-300 bg-white px-5 py-6 dark:border-neutral-700 dark:bg-neutral-950 sm:px-6">
+      <div className="mb-7 flex items-end justify-between gap-5">
+        <div>
+          <h3 className="mb-2 text-sm font-medium text-neutral-600 dark:text-neutral-400">{t("Monthly pageviews")}</h3>
+          <div className="text-3xl font-semibold tabular-nums tracking-tight md:text-4xl">
+            {typeof eventLimit === "number" ? eventLimit.toLocaleString() : t("Custom")}
+          </div>
+        </div>
+        <div className="relative flex flex-col items-end">
+          <div className="mb-2 flex rounded-md border border-neutral-300 bg-neutral-100 p-1 text-sm dark:border-neutral-700 dark:bg-neutral-900">
+            <button
+              onClick={() => setIsAnnual(false)}
+              className={cn(
+                "cursor-pointer rounded-sm px-3 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500",
+                !isAnnual
+                  ? "bg-white text-neutral-950 dark:bg-neutral-800 dark:text-white font-medium"
+                  : "text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200"
+              )}
+            >
+              {t("Monthly")}
+            </button>
+            <button
+              onClick={() => setIsAnnual(true)}
+              className={cn(
+                "cursor-pointer rounded-sm px-3 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500",
+                isAnnual
+                  ? "bg-white text-neutral-950 dark:bg-neutral-800 dark:text-white font-medium"
+                  : "text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200"
+              )}
+            >
+              {t("Annual")}
+            </button>
+            <div className="absolute right-0 top-0 -translate-y-4 whitespace-nowrap rounded-sm bg-emerald-600 px-2 py-0.5 text-xs font-medium text-white">
+              {t("4 months free")}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <Slider
+        defaultValue={[0]}
+        max={EVENT_TIERS.length - 1}
+        min={0}
+        step={1}
+        onValueChange={handleSliderChange}
+        className="mb-3"
+      />
+
+      <div className="flex justify-between text-xs text-neutral-500 dark:text-neutral-400">
+        {EVENT_TIERS.map((tier, index) => (
+          <span
+            key={index}
+            className={cn(
+              // 12 tick labels never fit on small screens; the selected value renders large above.
+              index !== 0 && index !== EVENT_TIERS.length - 1 && "hidden sm:inline",
+              eventLimitIndex === index && "font-semibold text-emerald-700 dark:text-emerald-400"
+            )}
+          >
+            {index === EVENT_TIERS.length - 1
+              ? "50M+"
+              : typeof tier === "number" && tier >= 1_000_000
+                ? `${tier / 1_000_000}M`
+                : typeof tier === "number"
+                  ? `${tier / 1_000}K`
+                  : t("Custom")}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+
+  const bare = chrome === "bare";
+  const planCarousel = (
+    <div className="py-6 min-[700px]:hidden">
+      <Carousel setApi={setCarouselApi} opts={{ startIndex: 1 }}>
+        <CarouselContent>
+          <CarouselItem>
+            <PricingCard {...standardProps} framed plain={bare} />
+          </CarouselItem>
+          <CarouselItem>
+            <PricingCard {...proProps} framed plain={bare} />
+          </CarouselItem>
+          <CarouselItem>
+            <PricingCard {...enterpriseProps} framed plain={bare} />
+          </CarouselItem>
+        </CarouselContent>
+      </Carousel>
+      <div className="mt-4 flex justify-center gap-2">
+        {Array.from({ length: slideCount }).map((_, i) => (
+          <button
+            key={i}
+            onClick={() => carouselApi?.scrollTo(i)}
+            aria-label={t("Go to pricing option {number}", { number: String(i + 1) })}
+            className={cn(
+              "size-2 cursor-pointer rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2",
+              currentSlide === i ? "bg-emerald-500" : "bg-neutral-400 dark:bg-neutral-600"
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+
+  if (chrome === "bare") {
+    return (
+      <section className="relative z-10">
+        {sliderInstrument}
+        {planCarousel}
+        <div className="hidden gap-4 min-[700px]:grid min-[700px]:grid-cols-2 min-[1100px]:grid-cols-3">
+          <PricingCard {...standardProps} framed plain />
+          <PricingCard {...proProps} framed plain />
+          <PricingCard
+            {...enterpriseProps}
+            framed
+            plain
+            className="min-[700px]:col-span-2 min-[1100px]:col-span-1"
+          />
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section className="relative z-10 border-b border-neutral-200 dark:border-neutral-800">
       <div className="relative mx-auto max-w-[1200px] border-x border-neutral-200 dark:border-neutral-800">
@@ -249,109 +383,11 @@ export function PricingSection({
         {/* Quote instrument — a full-bleed row on the same dot-grid mat as the
             hero demo frame and the agent console. */}
         <div className="relative border-b border-neutral-200 bg-neutral-100 p-4 [background-image:radial-gradient(circle,rgba(0,0,0,0.08)_1px,transparent_1px)] [background-size:14px_14px] dark:border-neutral-800 dark:bg-neutral-900 dark:[background-image:radial-gradient(circle,rgba(255,255,255,0.07)_1px,transparent_1px)] sm:p-8 lg:p-10">
-          <div className="rounded-md border border-neutral-300 bg-white px-5 py-6 dark:border-neutral-700 dark:bg-neutral-950 sm:px-6">
-            <div className="mb-7 flex items-end justify-between gap-5">
-              <div>
-                <h3 className="mb-2 text-sm font-medium text-neutral-600 dark:text-neutral-400">{t("Monthly pageviews")}</h3>
-                <div className="text-3xl font-semibold tabular-nums tracking-tight md:text-4xl">
-                  {typeof eventLimit === "number" ? eventLimit.toLocaleString() : t("Custom")}
-                </div>
-              </div>
-              <div className="relative flex flex-col items-end">
-                {/* Billing toggle */}
-                <div className="mb-2 flex rounded-md border border-neutral-300 bg-neutral-100 p-1 text-sm dark:border-neutral-700 dark:bg-neutral-900">
-                  <button
-                    onClick={() => setIsAnnual(false)}
-                    className={cn(
-                      "cursor-pointer rounded-sm px-3 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500",
-                      !isAnnual
-                        ? "bg-white text-neutral-950 dark:bg-neutral-800 dark:text-white font-medium"
-                        : "text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200"
-                    )}
-                  >
-                    {t("Monthly")}
-                  </button>
-                  <button
-                    onClick={() => setIsAnnual(true)}
-                    className={cn(
-                      "cursor-pointer rounded-sm px-3 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500",
-                      isAnnual
-                        ? "bg-white text-neutral-950 dark:bg-neutral-800 dark:text-white font-medium"
-                        : "text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200"
-                    )}
-                  >
-                    {t("Annual")}
-                  </button>
-                  <div className="absolute right-0 top-0 -translate-y-4 whitespace-nowrap rounded-sm bg-emerald-600 px-2 py-0.5 text-xs font-medium text-white">
-                    {t("4 months free")}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Slider */}
-            <Slider
-              defaultValue={[0]}
-              max={EVENT_TIERS.length - 1}
-              min={0}
-              step={1}
-              onValueChange={handleSliderChange}
-              className="mb-3"
-            />
-
-            <div className="flex justify-between text-xs text-neutral-500 dark:text-neutral-400">
-              {EVENT_TIERS.map((tier, index) => (
-                <span
-                  key={index}
-                  className={cn(
-                    // 12 tick labels never fit on small screens; the selected value renders large above.
-                    index !== 0 && index !== EVENT_TIERS.length - 1 && "hidden sm:inline",
-                    eventLimitIndex === index && "font-semibold text-emerald-700 dark:text-emerald-400"
-                  )}
-                >
-                  {index === EVENT_TIERS.length - 1
-                    ? "50M+"
-                    : typeof tier === "number" && tier >= 1_000_000
-                      ? `${tier / 1_000_000}M`
-                      : typeof tier === "number"
-                        ? `${tier / 1_000}K`
-                        : t("Custom")}
-                </span>
-              ))}
-            </div>
-          </div>
+          {sliderInstrument}
         </div>
 
         {/* Plans — carousel below 700px, seamed grid cells above */}
-        <div className="px-4 py-6 min-[700px]:hidden">
-          <Carousel setApi={setCarouselApi} opts={{ startIndex: 1 }}>
-            <CarouselContent>
-              <CarouselItem>
-                <PricingCard {...standardProps} framed />
-              </CarouselItem>
-              <CarouselItem>
-                <PricingCard {...proProps} framed />
-              </CarouselItem>
-              <CarouselItem>
-                <PricingCard {...enterpriseProps} framed />
-              </CarouselItem>
-            </CarouselContent>
-          </Carousel>
-          {/* Dot indicators */}
-          <div className="mt-4 flex justify-center gap-2">
-            {Array.from({ length: slideCount }).map((_, i) => (
-              <button
-                key={i}
-                onClick={() => carouselApi?.scrollTo(i)}
-                aria-label={t("Go to pricing option {number}", { number: String(i + 1) })}
-                className={cn(
-                  "size-2 cursor-pointer rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2",
-                  currentSlide === i ? "bg-emerald-500" : "bg-neutral-400 dark:bg-neutral-600"
-                )}
-              />
-            ))}
-          </div>
-        </div>
+        <div className="px-4">{planCarousel}</div>
 
         <div className="hidden gap-px bg-neutral-200 dark:bg-neutral-800 min-[700px]:grid min-[700px]:grid-cols-2 min-[1100px]:grid-cols-3">
           <PricingCard {...standardProps} />

--- a/docs/src/components/lp-variants/DashboardTour.tsx
+++ b/docs/src/components/lp-variants/DashboardTour.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+import { DemoEmbed } from "./shared";
+
+/**
+ * The interactive core of variant B: one dashboard, switched between its real
+ * views, instead of six separate feature mockups.
+ *
+ * Every view is a live route on the public demo site, so nothing here can drift
+ * out of date with the product — if a view is redesigned, this section shows
+ * the redesign. Switching remounts the iframe (via `key`), which reloads it;
+ * that is the cost of showing the real thing rather than a screenshot.
+ */
+const VIEWS = [
+  { route: "main", label: "Live traffic", blurb: "Users, sessions, pageviews and referrers, updating as they happen." },
+  { route: "pages", label: "Pages & entries", blurb: "Which pages people land on, read, and leave from." },
+  { route: "funnels", label: "Funnels", blurb: "The steps that matter, and exactly where visitors drop off." },
+  { route: "journeys", label: "Journeys", blurb: "The routes people actually take between pages." },
+  { route: "performance", label: "Web vitals", blurb: "Core Web Vitals from real visits, by route, country and device." },
+  { route: "errors", label: "Errors", blurb: "Client errors grouped by message, with the sessions that hit them." },
+];
+
+export function DashboardTour() {
+  const [active, setActive] = useState(0);
+  const view = VIEWS[active];
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[260px_minmax(0,1fr)] lg:gap-10">
+      <div className="min-w-0">
+        <ul className="flex gap-2 overflow-x-auto pb-2 lg:flex-col lg:overflow-visible lg:pb-0">
+          {VIEWS.map((item, index) => {
+            const isActive = index === active;
+            return (
+              <li key={item.route} className="shrink-0 lg:shrink">
+                <button
+                  type="button"
+                  onClick={() => setActive(index)}
+                  aria-pressed={isActive}
+                  className={cn(
+                    "flex w-full cursor-pointer items-baseline gap-3 rounded-md px-3 py-2.5 text-left text-sm transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+                    isActive
+                      ? "bg-neutral-100 font-medium text-neutral-950 dark:bg-neutral-900 dark:text-white"
+                      : "text-neutral-600 hover:text-neutral-950 dark:text-neutral-400 dark:hover:text-white"
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "font-mono text-[11px] tabular-nums",
+                      isActive ? "text-emerald-700 dark:text-emerald-400" : "text-neutral-400 dark:text-neutral-600"
+                    )}
+                  >
+                    {String(index + 1).padStart(2, "0")}
+                  </span>
+                  {item.label}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+        <p className="mt-5 hidden max-w-[34ch] text-sm leading-6 text-neutral-600 dark:text-neutral-400 lg:block">
+          {view.blurb}
+        </p>
+      </div>
+
+      <div className="min-w-0">
+        <div className="h-[380px] overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800 sm:h-[460px] lg:h-[540px]">
+          <DemoEmbed key={view.route} route={view.route} title={`Rybbit demo — ${view.label}`} />
+        </div>
+        <p className="mt-4 text-sm leading-6 text-neutral-600 dark:text-neutral-400 lg:hidden">{view.blurb}</p>
+      </div>
+    </div>
+  );
+}

--- a/docs/src/components/lp-variants/VariantA.tsx
+++ b/docs/src/components/lp-variants/VariantA.tsx
@@ -1,0 +1,221 @@
+import { AgentConsole } from "@/components/Cards/AgentConsole";
+import { SessionReplay } from "@/components/Cards/SessionReplay";
+import { FAQAccordion } from "@/components/FAQAccordion";
+import { IntegrationsGrid } from "@/components/Integration";
+import { LandingPricing } from "@/components/LandingPricing";
+import { TrackingSnippet } from "@/components/deco/TrackingSnippet";
+import { Marquee } from "@/components/magicui/marquee";
+import { TweetCard } from "@/components/Tweet";
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+import {
+  DemoEmbedFading,
+  GitHubStar,
+  HeroCtas,
+  LogoRow,
+  LP_SUBTITLE,
+  LP_TITLE,
+  capabilityIndex,
+  faqSchema,
+  mcpClients,
+  tweetColumns,
+} from "./shared";
+
+/**
+ * Variant A — "Quiet Instrument".
+ *
+ * The bet: the page has no frame. Every container border, corner cross,
+ * graph-paper plate, dot grid and nested window chrome is gone; the column is
+ * centered and vertical space does all the separating. One idea and one visual
+ * per band.
+ *
+ * Consequences for anyone editing this file: there is nowhere to hide, so the
+ * spacing scale is the design. Bands are `py-24 md:py-32`, the gap between a
+ * heading and its supporting sentence is always `mt-5`, and between that and
+ * the band's single visual always `mt-14`. Don't introduce a border to solve a
+ * spacing problem here — that is the pattern this variant exists to test against.
+ *
+ * See lp-variants/shared.tsx for why the copy is untranslated literals.
+ */
+
+const SHELL = "mx-auto w-full max-w-[1200px] px-5 sm:px-8 lg:px-10";
+const BAND = "py-24 md:py-32";
+/** Running text never exceeds ~62 characters at the centered measure. */
+const MEASURE = "mx-auto max-w-[54ch]";
+
+function BandHeading({ title, children }: { title: string; children?: React.ReactNode }) {
+  return (
+    <div className="text-center">
+      <h2 className="mx-auto max-w-[19ch] text-3xl font-semibold leading-[1.06] tracking-[-0.035em] text-balance md:text-[2.75rem]">
+        {title}
+      </h2>
+      {children && (
+        <p className={cn(MEASURE, "mt-5 text-base leading-7 text-neutral-600 dark:text-neutral-400 text-pretty md:text-lg md:leading-8")}>
+          {children}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function VariantA() {
+  return (
+    <div data-lp-bare-chrome>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      {/* Hero — badge, headline, one sentence, two buttons. Nothing else. */}
+      <section className={cn(SHELL, "pb-4 pt-16 text-center md:pt-24")}>
+        <div className="flex justify-center">
+          <GitHubStar />
+        </div>
+        <h1 className="mx-auto mt-9 max-w-[15ch] text-[clamp(2.75rem,6vw,4.5rem)] font-semibold leading-[0.98] tracking-[-0.04em] text-neutral-950 text-balance dark:text-neutral-50">
+          {LP_TITLE}
+        </h1>
+        <p className={cn(MEASURE, "mt-6 text-lg leading-8 text-neutral-600 dark:text-neutral-300 text-pretty")}>
+          {LP_SUBTITLE}
+        </p>
+        <HeroCtas variant="a" className="mt-9 items-center justify-center" />
+        <p className="mt-5 text-sm text-neutral-500 dark:text-neutral-400">7-day free trial. Cancel anytime.</p>
+      </section>
+
+      {/* The product, unframed: no browser chrome, no mat, fading into the page. */}
+      <section className="mt-14 md:mt-20">
+        <div className="mx-auto w-full max-w-[1320px] px-0 sm:px-8">
+          <DemoEmbedFading
+            heightClassName="h-[380px] sm:h-[460px] lg:h-[560px]"
+            scrimHeightClassName="h-56 sm:h-64"
+            sideScrim
+            loading="eager"
+          />
+        </div>
+      </section>
+
+      <section className={cn(SHELL, "pb-8 pt-6")}>
+        <LogoRow />
+      </section>
+
+      <section className={cn(SHELL, BAND)}>
+        <BandHeading title="Go from signal to explanation without changing tools.">
+          Capture every interaction automatically, watch the sessions behind it, then measure what converts and how fast
+          it feels.
+        </BandHeading>
+        <div className="mx-auto mt-14 max-w-3xl">
+          <SessionReplay />
+        </div>
+      </section>
+
+      <section className={cn(SHELL, BAND)}>
+        <BandHeading title="Everything behind one script tag.">
+          Replay, funnels, goals, vitals, exports — everything Google Analytics made complicated, one click deeper.
+        </BandHeading>
+        <nav
+          aria-label="Feature index"
+          className="mx-auto mt-14 grid max-w-4xl grid-cols-2 gap-x-8 gap-y-10 text-left sm:grid-cols-4"
+        >
+          {capabilityIndex.map(group => (
+            <div key={group.title}>
+              <h3 className="text-sm font-semibold tracking-tight">{group.title}</h3>
+              <ul className="mt-3 space-y-1">
+                {group.links.map(link => (
+                  <li key={link.href}>
+                    <Link
+                      href={link.href}
+                      {...(link.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                      className="rounded-sm text-sm text-neutral-500 transition-colors duration-200 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-neutral-400 dark:hover:text-white"
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </nav>
+      </section>
+
+      <section className={cn(SHELL, BAND)}>
+        <BandHeading title="Analytics your AI can operate.">
+          A hosted MCP server on top of Rybbit&apos;s full REST API. Your agent reads live traffic, debugs errors, and
+          manages goals, with the same permissions as a teammate.
+        </BandHeading>
+        <div className="mx-auto mt-14 max-w-4xl">
+          <AgentConsole />
+        </div>
+        <div className="mx-auto mt-10 flex max-w-2xl flex-wrap items-center justify-center gap-2">
+          {mcpClients.map(client => (
+            <Link
+              key={client.name}
+              href={client.path}
+              className="inline-flex rounded-md border border-neutral-200 px-2.5 py-1 text-xs font-medium text-neutral-600 transition-colors duration-200 hover:border-neutral-300 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:border-neutral-800 dark:text-neutral-400 dark:hover:border-neutral-700 dark:hover:text-white"
+            >
+              {client.name}
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className={cn(SHELL, BAND)}>
+        <BandHeading title="Made to meet your stack.">
+          Install Rybbit on the platform you already use. Most integrations take only a few minutes.
+        </BandHeading>
+        <div className="mx-auto mt-14 max-w-md">
+          <TrackingSnippet />
+        </div>
+        <div className="mx-auto mt-12 max-w-5xl">
+          <IntegrationsGrid bare />
+        </div>
+      </section>
+
+      <section className={cn(SHELL, BAND)}>
+        <BandHeading title="Real posts from people who switched.">
+          What teams say after replacing heavier analytics products with Rybbit.
+        </BandHeading>
+        <div className="relative mx-auto mt-14 grid h-[520px] max-w-5xl grid-cols-1 gap-4 overflow-hidden md:grid-cols-3">
+          {tweetColumns.map((ids, columnIndex) => (
+            <Marquee
+              key={ids[0]}
+              vertical
+              pauseOnHover
+              reverse={columnIndex === 1}
+              className={cn(
+                columnIndex > 0 && "hidden md:flex",
+                "[--duration:60s] motion-reduce:[animation-play-state:paused]"
+              )}
+              repeat={2}
+            >
+              {ids.map(id => (
+                <TweetCard key={id} id={id} />
+              ))}
+            </Marquee>
+          ))}
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-24 bg-gradient-to-b from-white to-transparent dark:from-neutral-950" />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-white to-transparent dark:from-neutral-950" />
+        </div>
+      </section>
+
+      <section className={cn(SHELL, BAND)}>
+        <BandHeading title="Questions, answered plainly.">
+          The questions people ask before adding Rybbit to their site.
+        </BandHeading>
+        <div className="mx-auto mt-12 max-w-2xl text-left">
+          <FAQAccordion />
+        </div>
+      </section>
+
+      <div className={cn(SHELL, "pb-4")}>
+        <LandingPricing chrome="bare" />
+      </div>
+
+      {/* Closing CTA — the second and last emerald on the page. */}
+      <section className={cn(SHELL, "pb-32 pt-24 text-center md:pb-40 md:pt-32")}>
+        <h2 className="mx-auto max-w-[16ch] text-3xl font-semibold leading-[1.06] tracking-[-0.035em] text-balance md:text-[2.75rem]">
+          Start seeing your traffic today.
+        </h2>
+        <p className={cn(MEASURE, "mt-5 text-base leading-7 text-neutral-600 dark:text-neutral-400")}>
+          Cookieless, open source, and live in minutes. Or run it yourself with one Docker command, free forever.
+        </p>
+        <HeroCtas variant="a" placement="bottom_cta" className="mt-9 items-center justify-center" />
+      </section>
+    </div>
+  );
+}

--- a/docs/src/components/lp-variants/VariantB.tsx
+++ b/docs/src/components/lp-variants/VariantB.tsx
@@ -1,0 +1,228 @@
+import { AgentConsole } from "@/components/Cards/AgentConsole";
+import { FAQAccordion } from "@/components/FAQAccordion";
+import { IntegrationsGrid } from "@/components/Integration";
+import { LandingPricing } from "@/components/LandingPricing";
+import { TrackingSnippet } from "@/components/deco/TrackingSnippet";
+import { Marquee } from "@/components/magicui/marquee";
+import { TweetCard } from "@/components/Tweet";
+import { cn } from "@/lib/utils";
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+import { DashboardTour } from "./DashboardTour";
+import {
+  DemoEmbedFading,
+  EuNote,
+  GitHubStar,
+  HeroCtas,
+  LogoRow,
+  LP_SUBTITLE,
+  LP_TITLE,
+  capabilityIndex,
+  faqSchema,
+  mcpClients,
+  tweetColumns,
+} from "./shared";
+
+/**
+ * Variant B — "One Dashboard".
+ *
+ * The bet: the strongest claim on this page is "one readable dashboard instead
+ * of 150+ reports", so prove it with the dashboard rather than argue it with
+ * six separate feature mockups. The feature mosaic is replaced by a single live
+ * embed the visitor switches between real product views (DashboardTour).
+ *
+ * Consequences for anyone editing this file: the page leans on the demo site
+ * being up and looking good, and it is deliberately left-aligned and quiet so
+ * the product screen is the only loud thing on any given screen. If you find
+ * yourself adding a second visual to a band, it belongs in the tour instead.
+ *
+ * See lp-variants/shared.tsx for why the copy is untranslated literals.
+ */
+
+const SHELL = "mx-auto w-full max-w-[1200px] px-5 sm:px-8 lg:px-10";
+const BAND = "py-20 md:py-28";
+
+function BandHeading({ title, children, className }: { title: string; children?: React.ReactNode; className?: string }) {
+  return (
+    <div className={className}>
+      <h2 className="max-w-[17ch] text-3xl font-semibold leading-[1.06] tracking-[-0.035em] text-balance md:text-[2.75rem]">
+        {title}
+      </h2>
+      {children && (
+        <p className="mt-5 max-w-[56ch] text-base leading-7 text-neutral-600 dark:text-neutral-400 text-pretty md:text-lg md:leading-8">
+          {children}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function VariantB() {
+  return (
+    <div data-lp-bare-chrome>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      <section className={cn(SHELL, "pt-14 md:pt-20")}>
+        <GitHubStar />
+        <h1 className="mt-8 max-w-[16ch] text-[clamp(2.5rem,5.4vw,4.25rem)] font-semibold leading-[0.99] tracking-[-0.04em] text-neutral-950 text-balance dark:text-neutral-50">
+          {LP_TITLE}
+        </h1>
+        <p className="mt-6 max-w-[54ch] text-lg leading-8 text-neutral-600 dark:text-neutral-300 text-pretty">
+          {LP_SUBTITLE}
+        </p>
+        <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-4">
+          <HeroCtas variant="b" />
+          <EuNote />
+        </div>
+        <p className="mt-4 text-sm text-neutral-500 dark:text-neutral-400">7-day free trial. Cancel anytime.</p>
+      </section>
+
+      {/* The product, immediately and at size — running past the fold rather
+          than being cropped by a frame. */}
+      <section className={cn(SHELL, "mt-12 md:mt-16")}>
+        <div className="overflow-hidden rounded-t-lg border border-b-0 border-neutral-200 dark:border-neutral-800">
+          <DemoEmbedFading heightClassName="h-[360px] sm:h-[440px] lg:h-[520px]" loading="eager" />
+        </div>
+      </section>
+
+      <section className={cn(SHELL, "pb-6 pt-10")}>
+        <LogoRow align="start" />
+      </section>
+
+      <section className={cn(SHELL, BAND)}>
+        <BandHeading title="One dashboard. Not 150 reports.">
+          Everything loads at once, from an 18 KB script against GA4&apos;s 371 KB. The depth is here too — funnels,
+          journeys, vitals and errors are all the same screen, one click across. This is the real demo site; click
+          through it.
+        </BandHeading>
+        <div className="mt-12">
+          <DashboardTour />
+        </div>
+      </section>
+
+      <section className={cn(SHELL, BAND)}>
+        <div className="grid gap-10 lg:grid-cols-2 lg:gap-16">
+          <BandHeading title="Analytics your AI can operate.">
+            A hosted MCP server on top of Rybbit&apos;s full REST API. Your agent reads live traffic, debugs errors, and
+            manages goals, with the same permissions as a teammate.
+          </BandHeading>
+          <div className="min-w-0">
+            <AgentConsole />
+            <div className="mt-6 flex flex-wrap gap-2">
+              {mcpClients.map(client => (
+                <Link
+                  key={client.name}
+                  href={client.path}
+                  className="inline-flex rounded-md border border-neutral-200 px-2.5 py-1 text-xs font-medium text-neutral-600 transition-colors duration-200 hover:border-neutral-300 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:border-neutral-800 dark:text-neutral-400 dark:hover:border-neutral-700 dark:hover:text-white"
+                >
+                  {client.name}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className={cn(SHELL, BAND)}>
+        <div className="grid gap-10 lg:grid-cols-2 lg:gap-16">
+          <div>
+            <BandHeading title="One tag. Five minutes.">
+              Works anywhere you can add HTML — WordPress, Shopify, Next.js, Vue. For apps, install @rybbit/js from npm.
+            </BandHeading>
+            <TrackingSnippet className="mt-8 max-w-md" />
+          </div>
+          <div className="min-w-0">
+            <IntegrationsGrid bare />
+          </div>
+        </div>
+      </section>
+
+      <section className={cn(SHELL, BAND)}>
+        <BandHeading title="Real posts from people who switched.">
+          What teams say after replacing heavier analytics products with Rybbit.
+        </BandHeading>
+        <div className="relative mt-12 grid h-[520px] grid-cols-1 gap-4 overflow-hidden md:grid-cols-3">
+          {tweetColumns.map((ids, columnIndex) => (
+            <Marquee
+              key={ids[0]}
+              vertical
+              pauseOnHover
+              reverse={columnIndex === 1}
+              className={cn(
+                columnIndex > 0 && "hidden md:flex",
+                "[--duration:60s] motion-reduce:[animation-play-state:paused]"
+              )}
+              repeat={2}
+            >
+              {ids.map(id => (
+                <TweetCard key={id} id={id} />
+              ))}
+            </Marquee>
+          ))}
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-24 bg-gradient-to-b from-white to-transparent dark:from-neutral-950" />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-white to-transparent dark:from-neutral-950" />
+        </div>
+      </section>
+
+      <section className={cn(SHELL, BAND)}>
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.6fr)] lg:gap-16">
+          <BandHeading title="Questions, answered plainly.">
+            The questions people ask before adding Rybbit to their site.
+          </BandHeading>
+          <div className="min-w-0">
+            <FAQAccordion />
+          </div>
+        </div>
+      </section>
+
+      <section className={cn(SHELL, BAND)}>
+        <BandHeading title="Set your traffic. See your price.">
+          Start your 7-day free trial. No credit card charges until the trial ends.
+        </BandHeading>
+        <div className="mt-12">
+          <LandingPricing chrome="bare" />
+        </div>
+      </section>
+
+      {/* The capability index stays: it is the page's internal-link hub as well
+          as the evaluator's checklist. Compressed to a footer band here, since
+          the dashboard tour is doing the feature-explaining above. */}
+      <section className={cn(SHELL, "border-t border-neutral-200 py-14 dark:border-neutral-800")}>
+        <nav aria-label="Feature index" className="grid grid-cols-2 gap-x-8 gap-y-10 sm:grid-cols-4">
+          {capabilityIndex.map(group => (
+            <div key={group.title}>
+              <h3 className="text-sm font-semibold tracking-tight">{group.title}</h3>
+              <ul className="mt-3 space-y-1">
+                {group.links.map(link => (
+                  <li key={link.href}>
+                    <Link
+                      href={link.href}
+                      {...(link.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                      className="group/link inline-flex items-center gap-1.5 rounded-sm text-sm text-neutral-500 transition-colors duration-200 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-neutral-400 dark:hover:text-white"
+                    >
+                      {link.label}
+                      <ArrowRight
+                        className="size-3 shrink-0 opacity-0 transition-opacity duration-200 group-hover/link:opacity-100 motion-reduce:transition-none"
+                        aria-hidden="true"
+                      />
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </nav>
+      </section>
+
+      <section className={cn(SHELL, "pb-32 pt-20 md:pb-40")}>
+        <h2 className="max-w-[16ch] text-3xl font-semibold leading-[1.06] tracking-[-0.035em] text-balance md:text-[2.75rem]">
+          Start seeing your traffic today.
+        </h2>
+        <p className="mt-5 max-w-[54ch] text-base leading-7 text-neutral-600 dark:text-neutral-400">
+          Cookieless, open source, and live in minutes. Or run it yourself with one Docker command, free forever.
+        </p>
+        <HeroCtas variant="b" placement="bottom_cta" className="mt-8" />
+      </section>
+    </div>
+  );
+}

--- a/docs/src/components/lp-variants/VariantC.tsx
+++ b/docs/src/components/lp-variants/VariantC.tsx
@@ -1,0 +1,245 @@
+import { AgentConsole } from "@/components/Cards/AgentConsole";
+import { FAQAccordion } from "@/components/FAQAccordion";
+import { IntegrationsGrid } from "@/components/Integration";
+import { LandingPricing } from "@/components/LandingPricing";
+import { TrackingSnippet } from "@/components/deco/TrackingSnippet";
+import { Marquee } from "@/components/magicui/marquee";
+import { TweetCard } from "@/components/Tweet";
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+import {
+  DemoEmbed,
+  EuNote,
+  GitHubStar,
+  HeroCtas,
+  LogoRow,
+  LP_SUBTITLE,
+  LP_TITLE,
+  capabilityIndex,
+  faqSchema,
+  mcpClients,
+  tweetColumns,
+} from "./shared";
+
+/**
+ * Variant C — "The Ledger".
+ *
+ * The bet: the engineered look is Rybbit's identity, and the problem is only
+ * that it is currently expressed six ways at once. So keep exactly one
+ * structural device — a full-bleed hairline between bands, with a mono label in
+ * the left gutter naming what each band is — and delete the rest: vertical
+ * container rules, corner crosses, graph-paper plates, dot grids, and the
+ * window chrome nested inside every feature card.
+ *
+ * Consequences for anyone editing this file: the gutter label is the only
+ * eyebrow this page gets, and the hairline is the only rule. Adding a second
+ * structural device is the thing this variant is testing against. Density is
+ * intentional and higher than variant A.
+ *
+ * See lp-variants/shared.tsx for why the copy is untranslated literals.
+ */
+
+const SHELL = "mx-auto w-full max-w-[1200px] px-5 sm:px-8 lg:px-10";
+
+/** One ledger band: gutter label on the left, content on the right, one rule above. */
+function Row({
+  label,
+  children,
+  className,
+  first = false,
+}: {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+  first?: boolean;
+}) {
+  return (
+    <section className={cn(!first && "border-t border-neutral-200 dark:border-neutral-800")}>
+      <div className={cn(SHELL, "grid gap-4 py-12 lg:grid-cols-[136px_minmax(0,1fr)] lg:gap-12 lg:py-16", className)}>
+        <p className="pt-1 font-mono text-[11px] uppercase tracking-[0.11em] text-neutral-400 dark:text-neutral-600">
+          {label}
+        </p>
+        <div className="min-w-0">{children}</div>
+      </div>
+    </section>
+  );
+}
+
+function RowHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="max-w-[20ch] text-2xl font-semibold leading-[1.1] tracking-[-0.03em] text-balance md:text-[1.875rem]">
+      {children}
+    </h2>
+  );
+}
+
+const figures = [
+  { value: "18 KB", label: "script, against GA4's 371 KB" },
+  { value: "1", label: "dashboard, not 150+ reports" },
+  { value: "0", label: "cookies, so no consent banner" },
+  { value: "5 min", label: "from script tag to first data" },
+];
+
+export function VariantC() {
+  return (
+    <div data-lp-bare-chrome>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      <Row label="Rybbit" first>
+        <GitHubStar />
+        <h1 className="mt-7 max-w-[15ch] text-[clamp(2.5rem,5.4vw,4.25rem)] font-semibold leading-[0.99] tracking-[-0.04em] text-neutral-950 text-balance dark:text-neutral-50">
+          {LP_TITLE}
+        </h1>
+        <p className="mt-6 max-w-[56ch] text-lg leading-8 text-neutral-600 dark:text-neutral-300 text-pretty">
+          {LP_SUBTITLE}
+        </p>
+        <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-4">
+          <HeroCtas variant="c" />
+          <EuNote />
+        </div>
+        <p className="mt-4 text-sm text-neutral-500 dark:text-neutral-400">7-day free trial. Cancel anytime.</p>
+      </Row>
+
+      <Row label="The product">
+        <div className="h-[380px] overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800 sm:h-[480px] lg:h-[580px]">
+          <DemoEmbed loading="eager" />
+        </div>
+      </Row>
+
+      <Row label="In numbers">
+        <dl className="grid grid-cols-2 gap-x-8 gap-y-8 md:grid-cols-4">
+          {figures.map(figure => (
+            <div key={figure.value}>
+              <dt className="font-mono text-[1.75rem] tabular-nums tracking-[-0.03em] text-neutral-950 dark:text-neutral-50">
+                {figure.value}
+              </dt>
+              <dd className="mt-1.5 max-w-[22ch] text-xs leading-5 text-neutral-500 dark:text-neutral-400">
+                {figure.label}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </Row>
+
+      <Row label="Capabilities">
+        <RowHeading>Everything behind one script tag.</RowHeading>
+        <p className="mt-4 max-w-[56ch] text-base leading-7 text-neutral-600 dark:text-neutral-400">
+          Replay, funnels, goals, vitals, exports — everything Google Analytics made complicated, one click deeper.
+        </p>
+        <nav aria-label="Feature index" className="mt-8">
+          {capabilityIndex.map((group, index) => (
+            <div
+              key={group.title}
+              className={cn(
+                "grid gap-2 py-3.5 sm:grid-cols-[152px_minmax(0,1fr)] sm:gap-6",
+                index > 0 && "border-t border-neutral-200 dark:border-neutral-800"
+              )}
+            >
+              <h3 className="text-sm font-medium tracking-tight">{group.title}</h3>
+              <ul className="flex flex-wrap gap-x-5 gap-y-1.5">
+                {group.links.map(link => (
+                  <li key={link.href}>
+                    <Link
+                      href={link.href}
+                      {...(link.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                      className="rounded-sm text-sm text-neutral-500 transition-colors duration-200 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-neutral-400 dark:hover:text-white"
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </nav>
+      </Row>
+
+      <Row label="For agents">
+        <RowHeading>Analytics your AI can operate.</RowHeading>
+        <p className="mt-4 max-w-[56ch] text-base leading-7 text-neutral-600 dark:text-neutral-400">
+          A hosted MCP server on top of Rybbit&apos;s full REST API. Your agent reads live traffic, debugs errors, and
+          manages goals, with the same permissions as a teammate.
+        </p>
+        <div className="mt-8">
+          <AgentConsole />
+        </div>
+        <div className="mt-6 flex flex-wrap gap-2">
+          {mcpClients.map(client => (
+            <Link
+              key={client.name}
+              href={client.path}
+              className="inline-flex rounded-md border border-neutral-200 px-2.5 py-1 text-xs font-medium text-neutral-600 transition-colors duration-200 hover:border-neutral-300 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:border-neutral-800 dark:text-neutral-400 dark:hover:border-neutral-700 dark:hover:text-white"
+            >
+              {client.name}
+            </Link>
+          ))}
+        </div>
+      </Row>
+
+      <Row label="Install">
+        <RowHeading>Made to meet your stack.</RowHeading>
+        <p className="mt-4 max-w-[56ch] text-base leading-7 text-neutral-600 dark:text-neutral-400">
+          Install Rybbit on the platform you already use. Most sites are collecting data in under five minutes.
+        </p>
+        <TrackingSnippet className="mt-8 max-w-md" />
+        <div className="mt-10">
+          <IntegrationsGrid bare />
+        </div>
+      </Row>
+
+      <Row label="Trusted by">
+        <LogoRow align="start" />
+      </Row>
+
+      <Row label="From the community">
+        <RowHeading>Real posts from people who switched.</RowHeading>
+        <div className="relative mt-8 grid h-[500px] grid-cols-1 gap-4 overflow-hidden md:grid-cols-3">
+          {tweetColumns.map((ids, columnIndex) => (
+            <Marquee
+              key={ids[0]}
+              vertical
+              pauseOnHover
+              reverse={columnIndex === 1}
+              className={cn(
+                columnIndex > 0 && "hidden md:flex",
+                "[--duration:60s] motion-reduce:[animation-play-state:paused]"
+              )}
+              repeat={2}
+            >
+              {ids.map(id => (
+                <TweetCard key={id} id={id} />
+              ))}
+            </Marquee>
+          ))}
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-20 bg-gradient-to-b from-white to-transparent dark:from-neutral-950" />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-white to-transparent dark:from-neutral-950" />
+        </div>
+      </Row>
+
+      <Row label="Questions">
+        <RowHeading>Questions, answered plainly.</RowHeading>
+        <div className="mt-6">
+          <FAQAccordion />
+        </div>
+      </Row>
+
+      <Row label="Pricing">
+        <RowHeading>Set your traffic. See your price.</RowHeading>
+        <p className="mt-4 max-w-[56ch] text-base leading-7 text-neutral-600 dark:text-neutral-400">
+          Start your 7-day free trial. No credit card charges until the trial ends.
+        </p>
+        <div className="mt-8">
+          <LandingPricing chrome="bare" />
+        </div>
+      </Row>
+
+      <Row label="Start" className="lg:pb-28">
+        <RowHeading>Start seeing your traffic today.</RowHeading>
+        <p className="mt-4 max-w-[56ch] text-base leading-7 text-neutral-600 dark:text-neutral-400">
+          Cookieless, open source, and live in minutes. Or run it yourself with one Docker command, free forever.
+        </p>
+        <HeroCtas variant="c" placement="bottom_cta" className="mt-8" />
+      </Row>
+    </div>
+  );
+}

--- a/docs/src/components/lp-variants/shared.tsx
+++ b/docs/src/components/lp-variants/shared.tsx
@@ -1,0 +1,388 @@
+import { GitHubStarButton } from "@/components/GitHubStarButton";
+import { TrackedButton } from "@/components/TrackedButton";
+import { cn } from "@/lib/utils";
+import { ArrowRight, ExternalLink } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+
+/**
+ * Shared material for the three landing-page redesign candidates at /lp/a,
+ * /lp/b and /lp/c.
+ *
+ * i18n: these pages are English-only preview builds behind `robots: noindex`
+ * (see lp/layout.tsx), so the copy here is plain literals rather than
+ * `useExtracted()` calls. Wrapping new literals in `t()` would make the dev
+ * extractor write empty keys into all ten locale files, which render blank —
+ * translate whichever variant wins, once it wins.
+ *
+ * Copy is deliberately identical across the three variants: the A/B test is
+ * meant to isolate structure, not wording.
+ */
+
+export const LP_TITLE = "The Modern Google Analytics Replacement";
+
+export const LP_SUBTITLE =
+  "Rybbit is open-source, cookieless analytics: one readable dashboard and an 18 KB script. No consent banner needed, GDPR and CCPA compliant.";
+
+export const LP_META_DESCRIPTION =
+  "Open source, cookieless web & product analytics with an 18 KB script and one readable dashboard. GDPR/CCPA compliant, no cookie banner needed.";
+
+/** Variant key, used to namespace conversion events so the test can attribute. */
+export type LpVariant = "a" | "b" | "c";
+
+export const DEMO_SITE_URL = "https://demo.rybbit.com/81";
+export const SIGNUP_URL = "https://app.rybbit.io/signup";
+
+/* ── EU flag ─────────────────────────────────────────────────────────────
+   Copied from HeroSection rather than exported from it: the hero owns its
+   own layout and these variants only need the mark. */
+export function EUFlag() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 767 512"
+      role="img"
+      aria-label="European flag"
+      className="h-4 w-6 shrink-0 rounded-[2px]"
+    >
+      <title>European flag</title>
+      <path className="fill-[#233E90]" d="M766 1H1v510h765V1Z" />
+      <path
+        className="fill-yellow-400"
+        d="m387 117-35 25 13-41-35-26h43l14-41 14 41h43l-35 26 13 41-35-25Zm114 43-35 25 13-41-35-26h43l14-41 14 41h43l-35 26 13 41-35-25Zm47 125-35 25 13-41-35-26h43l14-41 14 41h43l-35 26 13 41-35-25Zm-321 0-35 25 13-41-35-26h43l14-41 14 41h43l-35 26 13 41-35-25Zm283 125-35 25 13-41-35-26h43l14-41 14 41h43l-35 26 13 41-35-25Zm-123 35-35 25 13-41-35-26h43l14-41 14 41h43l-35 26 13 41-35-25Zm-123-35-35 25 13-41-35-26h43l14-41 14 41h43l-35 26 13 41-35-25Zm0-250-35 25 13-41-35-26h43l14-41 14 41h43l-35 26 13 41-35-25Z"
+      />
+    </svg>
+  );
+}
+
+/* ── Hero calls to action ────────────────────────────────────────────────
+   Event location is namespaced per variant (`hero_lp_a`, …) so signups can
+   be attributed to the design they came from once the test is running. */
+export function HeroCtas({
+  variant,
+  className,
+  placement = "hero",
+}: {
+  variant: LpVariant;
+  className?: string;
+  /** Distinguishes the hero pair from the closing pair in event attribution. */
+  placement?: "hero" | "bottom_cta";
+}) {
+  const location = `${placement}_lp_${variant}`;
+  return (
+    <div className={cn("flex flex-col gap-3 sm:flex-row", className)}>
+      <TrackedButton
+        href={SIGNUP_URL}
+        eventName="signup"
+        eventProps={{ location, button_text: "get started" }}
+        className="group inline-flex min-h-11 items-center justify-center gap-2 rounded-md bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors duration-200 hover:bg-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-neutral-950"
+      >
+        Start for $0
+        <ArrowRight
+          className="size-4 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none"
+          aria-hidden="true"
+        />
+      </TrackedButton>
+      <TrackedButton
+        href={DEMO_SITE_URL}
+        eventName="demo"
+        target="_blank"
+        rel="noopener noreferrer"
+        eventProps={{ location, button_text: "Live demo" }}
+        className="group inline-flex min-h-11 items-center justify-center gap-2 rounded-md border border-neutral-300 px-5 py-2.5 text-sm font-medium text-neutral-900 transition-colors duration-200 hover:bg-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:ring-offset-2 dark:border-neutral-700 dark:text-white dark:hover:bg-neutral-900 dark:focus-visible:ring-offset-neutral-950"
+      >
+        Live demo
+        <ExternalLink
+          className="size-3.5 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 motion-reduce:transition-none"
+          aria-hidden="true"
+        />
+      </TrackedButton>
+    </div>
+  );
+}
+
+export function GitHubStar() {
+  return <GitHubStarButton />;
+}
+
+export function EuNote({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 text-xs font-medium text-neutral-500 dark:text-neutral-400",
+        className
+      )}
+    >
+      <EUFlag />
+      <span>EU-hosted cloud</span>
+    </div>
+  );
+}
+
+/* ── Customer logos ──────────────────────────────────────────────────────
+   Same set as the production landing page. Every SVG in /public/logos is
+   pure white, so it inverts to black in light mode and renders as-is in dark. */
+const whiteSvgLogo = "opacity-40 hover:opacity-70 invert dark:opacity-60 dark:hover:opacity-100 dark:invert-0";
+
+export const customerLogos = [
+  { src: "/logos/bosch.svg", alt: "Bosch", width: 120, className: whiteSvgLogo },
+  { src: "/logos/texas-instruments.svg", alt: "Texas Instruments", width: 120, className: whiteSvgLogo },
+  { src: "/logos/govuk-logo.svg", alt: "GOV.UK", width: 120, className: whiteSvgLogo },
+  { src: "/logos/royalcaribbean.svg", alt: "Royal Caribbean", width: 120, className: whiteSvgLogo },
+  { src: "/logos/netapp.svg", alt: "NetApp", width: 120, className: whiteSvgLogo },
+  { src: "/logos/obelinf.svg", alt: "Obelinf", width: 120, className: whiteSvgLogo, href: "https://obelinf.com" },
+  { src: "/logos/op.svg", alt: "OP.GG", width: 120, className: whiteSvgLogo },
+  {
+    src: "/logos/automatio.webp",
+    alt: "Automatio",
+    width: 140,
+    href: "https://automatio.ai",
+    className: "opacity-50 hover:opacity-80 grayscale invert dark:opacity-70 dark:hover:opacity-100 dark:invert-0",
+  },
+];
+
+/** A single unruled row of customer logos — no cells, no seams. */
+export function LogoRow({ className, align = "center" }: { className?: string; align?: "center" | "start" }) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-x-8 gap-y-6 sm:gap-x-10",
+        align === "center" ? "justify-center" : "justify-start",
+        className
+      )}
+    >
+      {customerLogos.map(logo => {
+        const image = (
+          <Image
+            src={logo.src}
+            alt={logo.alt}
+            width={logo.width}
+            height={40}
+            className={`max-h-7 w-auto max-w-full transition-opacity duration-200 ${logo.className}`}
+          />
+        );
+        /* The fixed-width wrapper is load-bearing, not cosmetic. Two of these
+           SVGs carry an aspect ratio but no intrinsic size (royalcaribbean is
+           width/height="100%"; texas-instruments' width/height disagree with
+           its viewBox), and inside a shrink-to-fit box Chrome resolves such an
+           image to 0x0 — they silently vanish from the row. Giving the wrapper
+           a definite width fixes both while leaving `max-h-7` to govern each
+           logo's optical size, so the row keeps the production page's ragged,
+           natural rhythm rather than a forced uniform height. */
+        return (
+          <span key={logo.alt} className="block w-24 shrink-0">
+            {logo.href ? (
+              <Link href={logo.href} target="_blank" rel="noopener noreferrer" aria-label={logo.alt}>
+                {image}
+              </Link>
+            ) : (
+              image
+            )}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ── Capability index ────────────────────────────────────────────────────
+   The same twenty links the production page carries. This band is the page's
+   internal-link hub as well as the evaluator's checklist, so all three
+   variants keep it — only its presentation changes. */
+export const capabilityIndex = [
+  {
+    title: "Understand",
+    links: [
+      { label: "Realtime data", href: "/features/web-analytics" },
+      { label: "Web vitals", href: "/features/web-vitals" },
+      { label: "Globe views", href: "/docs/feature-guides/globe" },
+      { label: "Email reports", href: "/docs/account-settings" },
+      { label: "Setup in minutes", href: "/docs/script" },
+    ],
+  },
+  {
+    title: "Investigate",
+    links: [
+      { label: "Session replay", href: "/features/session-replay" },
+      { label: "User journeys", href: "/features/user-journeys" },
+      { label: "User profiles", href: "/features/user-profiles" },
+      { label: "Error tracking", href: "/features/error-tracking" },
+      { label: "Organizations", href: "/docs/teams" },
+    ],
+  },
+  {
+    title: "Measure",
+    links: [
+      { label: "Funnels", href: "/features/funnels" },
+      { label: "Goals", href: "/features/goals" },
+      { label: "Retention", href: "/features/retention" },
+      { label: "Custom events", href: "/features/custom-events" },
+      { label: "API & data export", href: "/docs/api/getting-started" },
+    ],
+  },
+  {
+    title: "Stay private",
+    links: [
+      { label: "No cookies", href: "/privacy" },
+      { label: "GDPR & CCPA", href: "/dpa" },
+      { label: "Bot blocking", href: "/docs/bot-detection" },
+      { label: "Self-hosting", href: "/docs/self-hosting" },
+      { label: "Open source", href: "https://github.com/rybbit-io/rybbit", external: true },
+    ],
+  },
+];
+
+export const mcpClients = [
+  { name: "Claude Code", path: "/docs/mcp/claude-code" },
+  { name: "Claude Desktop", path: "/docs/mcp/claude-desktop" },
+  { name: "Codex", path: "/docs/mcp/codex" },
+  { name: "Cursor", path: "/docs/mcp/cursor" },
+  { name: "VS Code", path: "/docs/mcp/vscode" },
+  { name: "opencode", path: "/docs/mcp/opencode" },
+];
+
+/** Tweet ids, matching the production page. Only claims that are accurate. */
+export const tweetColumns = [
+  ["1991296442611184125", "1921928423284629758", "2000974573005889706", "1927817460993884321"],
+  ["1920899082253434950", "2000788904778326334", "1976495558480232672", "1977471983278535071"],
+  ["1982378431166963982", "2009548405488615871", "1920470706761929048", "1979830490006974510", "1970265809122705759"],
+];
+
+export const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "Is Rybbit GDPR and CCPA compliant?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes, Rybbit is fully compliant with GDPR, CCPA, and other privacy regulations. We don't use cookies or collect any personal data that could identify your users. We salt user IDs daily to ensure users are not fingerprinted. You will not need to display a cookie consent banner to your users.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How does Rybbit compare to Google Analytics?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Rybbit is far less bloated than Google Analytics, both in the tracking script and the dashboard. It's one dashboard instead of 150+ reports, and the script is 18KB against GA4's 371KB.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Can I self-host Rybbit?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. You can run Rybbit on your own server with Docker and keep full control of your data, or use the managed cloud if you'd rather not host it yourself.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How easy is it to set up Rybbit?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Add one script tag to your site, or install @rybbit/js from npm. Most sites are collecting data in under 5 minutes.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What platforms does Rybbit support?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "The script tag works anywhere you can add HTML: WordPress, Shopify, Next.js, React, Vue, and the rest. For apps, install @rybbit/js from npm.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Is Rybbit truly open source?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes, Rybbit is 100% open source. Every single line of code, including for our cloud/enterprise offerings, is available on GitHub under the AGPL 3.0 license.",
+      },
+    },
+  ],
+};
+
+/* ── Live demo embed ─────────────────────────────────────────────────────
+   md+ renders the demo at a 117.6% viewport and scales it to 0.85 so the full
+   desktop layout fits at preview size; the two values must stay reciprocal.
+   Mobile stays 1:1 — a scaled viewport lands between the demo's breakpoints. */
+export function DemoEmbed({
+  route = "main",
+  className,
+  title = "Rybbit Analytics Demo",
+  loading = "lazy",
+}: {
+  route?: string;
+  className?: string;
+  title?: string;
+  /** Each embed is a full app load; only the above-the-fold one should be eager. */
+  loading?: "eager" | "lazy";
+}) {
+  return (
+    <iframe
+      src={`${DEMO_SITE_URL}/${route}`}
+      title={title}
+      loading={loading}
+      className={cn(
+        "block h-full w-full border-none md:h-[117.6%] md:w-[117.6%] md:origin-top-left md:scale-[0.85]",
+        className
+      )}
+    />
+  );
+}
+
+/**
+ * The demo embed with a scrim fading its lower edge into the page. Used where
+ * the screenshot should read as continuing past the fold rather than being
+ * cropped by a frame. The scrim is `pointer-events-none`, so the embed stays
+ * scrollable and clickable underneath it.
+ */
+export function DemoEmbedFading({
+  route = "main",
+  heightClassName,
+  scrimHeightClassName = "h-40",
+  scrimClassName = "from-white dark:from-neutral-950",
+  sideScrim = false,
+  loading = "lazy",
+}: {
+  route?: string;
+  heightClassName: string;
+  /** A frameless embed needs a long fade; a bordered one needs much less. */
+  scrimHeightClassName?: string;
+  scrimClassName?: string;
+  /**
+   * Fade the left and right edges too. Without a frame the embed otherwise
+   * reads as an unexplained lighter rectangle — the demo app paints its own
+   * #141414 canvas, a step off the marketing page's near-black.
+   */
+  sideScrim?: boolean;
+  loading?: "eager" | "lazy";
+}) {
+  return (
+    <div className={cn("relative min-w-0 max-w-full overflow-hidden", heightClassName)}>
+      <DemoEmbed route={route} loading={loading} />
+      {sideScrim && (
+        <>
+          <div
+            aria-hidden="true"
+            className={cn("pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r to-transparent sm:w-24", scrimClassName)}
+          />
+          <div
+            aria-hidden="true"
+            className={cn("pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l to-transparent sm:w-24", scrimClassName)}
+          />
+        </>
+      )}
+      <div
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t to-transparent",
+          scrimHeightClassName,
+          scrimClassName
+        )}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Three fully built landing-page redesigns behind temporary preview paths, for review before any A/B test against `/`.

**Preview:** `/lp/a` · `/lp/b` · `/lp/c` — all already `robots: noindex, follow` via the existing `lp/layout.tsx`.

## Why

The current landing page isn't too long — it and the x.ai/bot reference are within 50px of each other (17,168 vs 17,214). The problem is how much *frame* each screen asks you to parse. Counted from `LandingPageTemplate.tsx`:

| Device | Count |
|---|---|
| 1200px container rules | every band |
| `GridCrosses` overlays | 9 |
| Graph-paper plates (`bg-plate-accent` + `bg-graph-accent`) | 4 |
| Radial dot grids (a second, unrelated texture) | 2 |
| Nested window chrome in feature cards | 6 |
| Accent hues on the page | ~10, against a system that specifies 2 |

Each variant is a different answer to "which single device survives".

## The three

**A — Quiet Instrument.** No frame at all. Centered column, whitespace does every separation, the demo floats and fades on all four edges, one visual per band. Emerald appears exactly twice. Closest to the x.ai/bot reference. *Risk:* nowhere to hide — the spacing scale is the design.

**B — One Dashboard.** The six-card feature mosaic is replaced by a single live embed the visitor switches between real demo routes (main, pages, funnels, journeys, performance, errors). The product does the arguing, and nothing can drift out of date with it — if a view is redesigned, the page shows the redesign. *Risk:* leans on the demo site being up and looking good.

**C — The Ledger.** Keeps the engineered identity but reduces it to one device: a full-bleed hairline between bands with a mono gutter label naming each. Densest of the three. *Risk:* reads more "developer tool", which cuts against the small-teams and agency audiences in PRODUCT.md.

## Test hygiene

- **Copy is identical across all three** — same headline, subtitle, CTAs, feature names, prices, and every content band. The test isolates structure, not wording.
- **Content parity is deliberate.** All 20 capability-index links survive in every variant (the band is the page's internal-link hub, as the production code comment notes), as do the MCP section, integrations, testimonials, FAQ, pricing and closing CTA.
- **Attribution is wired.** Hero and closing CTAs carry per-variant event locations (`hero_lp_a`, `bottom_cta_lp_b`, …).

## Shared components: opt-in props, no forks

Every default is unchanged, and the production landing page renders identically — verified at the same 17,168px page height, with the seamed integrations grid, pricing plate, dot mat and Pro-card texture all intact.

- `PricingSection` — `chrome="bare"` drops the sheet, crosses, plate, dot mat and seams, and omits the header row so each variant supplies its own heading in its own voice. The slider instrument and plan carousel were extracted so both modes share one definition rather than diverging.
- `PricingCard` — `plain` suppresses the recommended card's plate tint and graph texture, keeping its emerald edge and badge.
- `IntegrationsGrid` — `bare` swaps the `gap-px` seams for plain spacing.
- `global.css` — a page can render `data-lp-bare-chrome` to opt the shared header and footer out of their 1200px vertical rules, which would otherwise hang orphaned above and below a page that has none.

## Bug fixed along the way

`texas-instruments.svg` and `royalcaribbean.svg` carry an aspect ratio but no intrinsic size (`width="100%"`, and a `width`/`height` that disagrees with the `viewBox`). Inside a shrink-to-fit box Chrome resolves them to `0x0` and they silently vanish from the logo row. The wrapper's fixed width in `LogoRow` is load-bearing, not cosmetic — there's a comment saying so.

## Verified

- `npm run build` clean; all three routes register.
- `tsc --noEmit` clean.
- No horizontal overflow at 390 / 768 / 1440, light and dark, on all three.
- No console errors beyond the embedded demo's own pre-existing favicon 404s.
- Below-the-fold demo embeds are `loading="lazy"`; only the hero embed is eager.

## Not fixed here (pre-existing, worth a separate PR)

The `Footer`'s `GridCrosses` overhang causes **5px of horizontal scroll on every marketing page** at viewports near 1200px — reproduced on `/` and `/pricing` on master, unrelated to this change. The variants don't show it only because `data-lp-bare-chrome` hides those crosses.

## Open questions

1. **Which direction to take forward** — my pick is C: it fixes the noise without discarding what makes the page recognizably Rybbit, and it's the smallest conceptual jump from what's shipped.
2. **The shared header/footer stay untouched** across all three, which is right for an A/B test (nav isn't the variable) but does mean each variant is slightly compromised at its top and bottom edge.
3. **Translation** happens after a winner is picked, not before.

https://claude.ai/code/session_01FEjkCmrtCezrK3jwbY2UCN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added three landing-page preview variants with distinct layouts, messaging, demos, pricing, FAQs, integrations, and calls to action.
  - Added SEO and social-sharing metadata for each preview page.
  - Added an interactive dashboard tour with six selectable product views.
  - Added reusable demo embeds, customer logos, capability links, testimonials, and shared landing-page content.
  - Added framed and borderless presentation options for pricing and integrations.

- **Style**
  - Refined preview-page styling to remove unnecessary borders and decorative elements for cleaner layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->