### PR TITLE
feat(landing): show more of the demo in the variant B hero

### DIFF
--- a/docs/src/components/lp-b/HeroPlate.tsx
+++ b/docs/src/components/lp-b/HeroPlate.tsx
@@ -35,12 +35,12 @@ const LAYERS = [
 /**
  * The hero's product window on its "traffic landscape" plate: the live demo
  * embed, framed as a browser, sitting on layered traffic silhouettes. On
- * large screens the window runs past the plate's bottom edge, as in the
- * design; below that the plate simply wraps it.
+ * large screens the window runs just past the plate's bottom edge (the demo's
+ * last table row is clipped); below that the plate simply wraps it.
  */
 export function HeroPlate() {
   return (
-    <div className="relative overflow-hidden rounded-[14px] border border-neutral-200 bg-[#f4f5f8] p-3 dark:border-neutral-800 dark:bg-[#111318] sm:p-6 lg:h-[620px] lg:p-0">
+    <div className="relative overflow-hidden rounded-[14px] border border-neutral-200 bg-[#f4f5f8] p-3 dark:border-neutral-800 dark:bg-[#111318] sm:p-6 lg:h-[880px] lg:p-0">
       <svg
         viewBox={`0 0 ${PLATE_W} ${PLATE_H}`}
         preserveAspectRatio="none"
@@ -94,7 +94,7 @@ export function HeroPlate() {
             shows its full desktop layout at preview size. Keep 1:1 on mobile —
             a scaled viewport would land between the demo's responsive
             breakpoints. The two values must stay reciprocal. */}
-        <div className="h-[500px] min-w-0 max-w-full overflow-hidden md:h-[600px] lg:h-[650px]">
+        <div className="h-[500px] min-w-0 max-w-full overflow-hidden md:h-[600px] lg:h-[820px]">
           <iframe
             src="https://demo.rybbit.com/81/main"
             className="block h-full w-full border-none md:h-[117.6%] md:w-[117.6%] md:origin-top-left md:scale-[0.85]"


### PR DESCRIPTION
The hero plate on the B homepage clipped 128px of the demo window. The plate now runs to 880px on large screens with an 820px-tall iframe (was 650px), so the window is almost fully visible and the demo's referrers and pages tables appear below the chart instead of being cut off. Below the `lg` breakpoint the plate wraps the window as before.

Verified on `/lp/b` at 1440 wide; the demo renders its tables at the iframe's effective size.

https://claude.ai/code/session_01NefKVWXwg2A7qvgtuN1sFt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Increased the hero section’s height on large screens for a more spacious layout.
  - Expanded the demo window height at large-screen breakpoints.
  - Updated the layout documentation to clarify that the final table row may be partially clipped when the demo extends beyond the hero section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->