### PR TITLE
fix(annotations): valid dates on hover, any emoji as icon

### DIFF
--- a/client/src/app/[site]/main/components/MainSection/annotations/AnnotationFormDialog.tsx
+++ b/client/src/app/[site]/main/components/MainSection/annotations/AnnotationFormDialog.tsx
@@ -29,6 +29,7 @@ import {
   ANNOTATION_COLOR_OPTIONS,
   ANNOTATION_ICON_OPTIONS,
   annotationSwatch,
+  pickIconFromInput,
   toDateInput,
 } from "./annotationUtils";
 import { useAnnotationPermissions } from "./useAnnotationPermissions";
@@ -335,7 +336,7 @@ export function AnnotationFormDialog({
                   <FormLabel>
                     {t("Icon")} <span className="text-muted-foreground font-normal">({t("optional")})</span>
                   </FormLabel>
-                  <div className="flex flex-wrap gap-1">
+                  <div className="flex flex-wrap items-center gap-1">
                     {ANNOTATION_ICON_OPTIONS.map(icon => (
                       <button
                         key={icon}
@@ -352,6 +353,18 @@ export function AnnotationFormDialog({
                         {icon}
                       </button>
                     ))}
+                    {/* Any emoji: type or paste one (the OS emoji picker works here). */}
+                    <Input
+                      aria-label={t("Custom emoji")}
+                      placeholder="＋"
+                      title={t("Type or paste any emoji")}
+                      value={field.value && !ANNOTATION_ICON_OPTIONS.includes(field.value) ? field.value : ""}
+                      onChange={e => field.onChange(pickIconFromInput(e.target.value))}
+                      className={cn(
+                        "w-8 h-8 px-0 text-center text-base rounded-md",
+                        field.value && !ANNOTATION_ICON_OPTIONS.includes(field.value) && "border-neutral-900 dark:border-neutral-100 bg-neutral-100 dark:bg-neutral-800"
+                      )}
+                    />
                   </div>
                 </FormItem>
               )}

--- a/client/src/app/[site]/main/components/MainSection/annotations/AnnotationPins.tsx
+++ b/client/src/app/[site]/main/components/MainSection/annotations/AnnotationPins.tsx
@@ -4,7 +4,13 @@ import type { Annotation } from "@rybbit/shared";
 import { StickyNote } from "lucide-react";
 import { useMemo } from "react";
 import type { TimeSeriesOverlayContext } from "@/components/charts/TimeSeriesChart";
-import { annotationColor, clusterAnnotations, type AnnotationCluster, type PositionedAnnotation } from "./annotationUtils";
+import {
+  annotationColor,
+  clusterAnnotations,
+  parseAnnotationInstant,
+  type AnnotationCluster,
+  type PositionedAnnotation,
+} from "./annotationUtils";
 
 const PIN_RADIUS = 11;
 // Pins closer than this merge into one counted pin.
@@ -29,8 +35,8 @@ export function AnnotationPins({
     const [min, max] = xScale.domain();
     const positioned: PositionedAnnotation[] = [];
     for (const annotation of annotations) {
-      const start = new Date(annotation.date);
-      const end = annotation.endDate ? new Date(annotation.endDate) : null;
+      const start = parseAnnotationInstant(annotation.date).toJSDate();
+      const end = annotation.endDate ? parseAnnotationInstant(annotation.endDate).toJSDate() : null;
       if (start > max || (end ?? start) < min) continue;
       // A range that began before the visible window pins at the left edge.
       const anchor = start < min ? min : start;

--- a/client/src/app/[site]/main/components/MainSection/annotations/annotationUtils.test.ts
+++ b/client/src/app/[site]/main/components/MainSection/annotations/annotationUtils.test.ts
@@ -1,6 +1,13 @@
 import type { Annotation } from "@rybbit/shared";
 import { describe, expect, it } from "vitest";
-import { clusterAnnotations, formatAnnotationDate, toDateInput, type PositionedAnnotation } from "./annotationUtils";
+import {
+  clusterAnnotations,
+  formatAnnotationDate,
+  parseAnnotationInstant,
+  pickIconFromInput,
+  toDateInput,
+  type PositionedAnnotation,
+} from "./annotationUtils";
 
 const base: Annotation = {
   annotationId: 1,
@@ -64,5 +71,23 @@ describe("toDateInput", () => {
   it("gives the calendar date in the user's timezone", () => {
     expect(toDateInput("2026-08-18T07:00:00.000Z", "America/Los_Angeles")).toBe("2026-08-18");
     expect(toDateInput("2026-08-18T03:00:00.000Z", "America/Los_Angeles")).toBe("2026-08-17");
+  });
+});
+
+describe("parseAnnotationInstant", () => {
+  it("reads ISO 8601 and Postgres timestamptz text alike", () => {
+    expect(parseAnnotationInstant("2026-08-18T07:00:00.000Z").toMillis()).toBe(Date.UTC(2026, 7, 18, 7));
+    expect(parseAnnotationInstant("2026-08-18 07:00:00+00").toMillis()).toBe(Date.UTC(2026, 7, 18, 7));
+    expect(parseAnnotationInstant("2026-08-18 09:00:00+02").toMillis()).toBe(Date.UTC(2026, 7, 18, 7));
+    expect(formatAnnotationDate({ ...base, date: "2026-08-18 07:00:00+00" }, "America/Los_Angeles")).toBe("Aug 18, 2026");
+  });
+});
+
+describe("pickIconFromInput", () => {
+  it("keeps one visible character, including multi-code-point emoji", () => {
+    expect(pickIconFromInput("🚀")).toBe("🚀");
+    expect(pickIconFromInput("🚀🔥")).toBe("🔥");
+    expect(pickIconFromInput("👨‍👩‍👧")).toBe("👨‍👩‍👧");
+    expect(pickIconFromInput("  ")).toBeNull();
   });
 });

--- a/client/src/app/[site]/main/components/MainSection/annotations/annotationUtils.ts
+++ b/client/src/app/[site]/main/components/MainSection/annotations/annotationUtils.ts
@@ -18,8 +18,27 @@ export function annotationSwatch(color: AnnotationColor | null): string {
   return color ? `hsl(var(--${color}-500))` : "hsl(var(--neutral-400))";
 }
 
-function toZoned(iso: string, timezone: string): DateTime {
-  return DateTime.fromISO(iso, { zone: "utc" }).setZone(timezone);
+/**
+ * Annotation timestamps are ISO 8601 from the API, but a timestamptz read in
+ * string mode can also arrive as Postgres text ("2026-08-18 07:00:00+00").
+ */
+export function parseAnnotationInstant(value: string): DateTime {
+  const iso = DateTime.fromISO(value, { zone: "utc" });
+  return iso.isValid ? iso : DateTime.fromSQL(value, { zone: "utc" });
+}
+
+function toZoned(value: string, timezone: string): DateTime {
+  return parseAnnotationInstant(value).setZone(timezone);
+}
+
+const graphemes = typeof Intl !== "undefined" && "Segmenter" in Intl ? new Intl.Segmenter(undefined, { granularity: "grapheme" }) : null;
+
+/** The last single visible character typed or pasted, or null if there is none. */
+export function pickIconFromInput(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parts = graphemes ? [...graphemes.segment(trimmed)].map(part => part.segment) : Array.from(trimmed);
+  return parts[parts.length - 1] ?? null;
 }
 
 function isStartOfDay(dt: DateTime): boolean {

--- a/docs/content/docs/api/annotations/create.mdx
+++ b/docs/content/docs/api/annotations/create.mdx
@@ -38,7 +38,7 @@ Creates an annotation. Any member with access to the site can create site annota
     endDate: { description: 'End of a range; must be after date', type: 'string', required: false },
     description: { description: 'Longer note (max 2000 characters)', type: 'string', required: false },
     color: { description: 'Marker color', type: 'string', typeDescription: '"amber" | "rose" | "sky" | "violet" | "lime"', required: false },
-    icon: { description: 'Emoji shown in the marker (max 16 characters)', type: 'string', required: false },
+    icon: { description: 'A single emoji (or character) shown in the marker', type: 'string', required: false },
     isPublic: { description: 'Show on public dashboards and private links', type: 'boolean', default: 'false', required: false },
     scope: { description: 'Attach to this site or to every site in the organization', type: 'string', typeDescription: '"site" | "organization"', default: '"site"', required: false },
   }}

--- a/docs/content/docs/api/annotations/list.mdx
+++ b/docs/content/docs/api/annotations/list.mdx
@@ -70,7 +70,7 @@ An array of annotation objects.
     date: { description: 'ISO 8601 timestamp the annotation is pinned to', type: 'string' },
     endDate: { description: 'ISO 8601 end timestamp for range annotations', type: 'string | null' },
     color: { description: 'Marker color', type: 'string | null', typeDescription: '"amber" | "rose" | "sky" | "violet" | "lime" | null' },
-    icon: { description: 'Emoji shown in the marker', type: 'string | null' },
+    icon: { description: 'Single emoji shown in the marker', type: 'string | null' },
     isPublic: { description: 'Whether public dashboards and private links show it', type: 'boolean' },
     createdAt: { description: 'Creation timestamp', type: 'string' },
     updatedAt: { description: 'Last update timestamp', type: 'string' },

--- a/docs/content/docs/api/annotations/update.mdx
+++ b/docs/content/docs/api/annotations/update.mdx
@@ -35,7 +35,7 @@ Partial update: only the fields you send change. Admins and owners can edit any 
     endDate: { description: 'End of a range, or null to turn a range back into a point', type: 'string | null', required: false },
     description: { description: 'Longer note, or null to clear', type: 'string | null', required: false },
     color: { description: 'Marker color, or null for the neutral default', type: 'string | null', required: false },
-    icon: { description: 'Emoji, or null to clear', type: 'string | null', required: false },
+    icon: { description: 'A single emoji (or character), or null to clear', type: 'string | null', required: false },
     isPublic: { description: 'Show on public dashboards and private links', type: 'boolean', required: false },
     scope: { description: 'Move between site and organization-wide', type: 'string', typeDescription: '"site" | "organization"', required: false },
   }}

--- a/server/src/api/analytics/annotations/annotationSchema.test.ts
+++ b/server/src/api/analytics/annotations/annotationSchema.test.ts
@@ -53,3 +53,13 @@ describe("listAnnotationsQuerySchema", () => {
     expect(listAnnotationsQuerySchema.safeParse({ start_date: "2026-13-01" }).success).toBe(false);
   });
 });
+
+describe("icon", () => {
+  it("accepts one emoji (including multi-code-point ones) and rejects words", () => {
+    expect(createAnnotationSchema.safeParse({ title: "x", date: "2026-08-18", icon: "🚀" }).success).toBe(true);
+    expect(createAnnotationSchema.safeParse({ title: "x", date: "2026-08-18", icon: "👨‍👩‍👧" }).success).toBe(true);
+    expect(createAnnotationSchema.safeParse({ title: "x", date: "2026-08-18", icon: "🏷️" }).success).toBe(true);
+    expect(createAnnotationSchema.safeParse({ title: "x", date: "2026-08-18", icon: "ab" }).success).toBe(false);
+    expect(createAnnotationSchema.safeParse({ title: "x", date: "2026-08-18", icon: "🚀🔥" }).success).toBe(false);
+  });
+});

--- a/server/src/api/analytics/annotations/annotationSchema.ts
+++ b/server/src/api/analytics/annotations/annotationSchema.ts
@@ -32,6 +32,21 @@ const dateInput = z
 const endAfterStart = (data: { date?: string; endDate?: string | null }) =>
   !data.date || !data.endDate || Date.parse(data.endDate) > Date.parse(data.date);
 
+// One visible character (an emoji may be several code points), so a pin never
+// has to render a word.
+// Intl.Segmenter is in Node 16+ but not in this tsconfig's lib, hence the cast.
+type GraphemeSegmenter = { segment(value: string): Iterable<{ segment: string }> };
+const graphemes: GraphemeSegmenter = new (
+  Intl as unknown as { Segmenter: new (locale?: string, options?: { granularity: string }) => GraphemeSegmenter }
+).Segmenter(undefined, { granularity: "grapheme" });
+const iconInput = z
+  .string()
+  .trim()
+  .max(16)
+  .refine(value => value === "" || [...graphemes.segment(value)].length === 1, {
+    message: "icon must be a single emoji or character",
+  });
+
 export const annotationScopeSchema = z.enum(["site", "organization"]);
 
 export const createAnnotationSchema = z
@@ -41,7 +56,7 @@ export const createAnnotationSchema = z
     date: dateInput,
     endDate: dateInput.nullable().optional(),
     color: z.enum(ANNOTATION_COLORS).nullable().optional(),
-    icon: z.string().trim().max(16).nullable().optional(),
+    icon: iconInput.nullable().optional(),
     isPublic: z.boolean().optional().default(false),
     scope: annotationScopeSchema.optional().default("site"),
   })
@@ -54,7 +69,7 @@ export const updateAnnotationSchema = z
     date: dateInput.optional(),
     endDate: dateInput.nullable().optional(),
     color: z.enum(ANNOTATION_COLORS).nullable().optional(),
-    icon: z.string().trim().max(16).nullable().optional(),
+    icon: iconInput.nullable().optional(),
     isPublic: z.boolean().optional(),
     scope: annotationScopeSchema.optional(),
   })

--- a/server/src/api/analytics/annotations/getAnnotations.ts
+++ b/server/src/api/analytics/annotations/getAnnotations.ts
@@ -9,6 +9,16 @@ import { isValidTimeZone } from "../utils/timeWindow.js";
 import { annotationsForSite, getSiteOrganizationId, parseSiteId } from "./annotationAccess.js";
 import { listAnnotationsQuerySchema } from "./annotationSchema.js";
 
+// timestamptz columns in string mode come back as Postgres text
+// ("2026-08-18 07:00:00+00"), which ISO parsers reject; hand clients ISO 8601.
+function toIso(value: string | null): string | null {
+  if (!value) return value;
+  const native = new Date(value);
+  if (!Number.isNaN(native.getTime())) return native.toISOString();
+  const parsed = DateTime.fromSQL(value, { zone: "utc" });
+  return parsed.isValid ? parsed.toUTC().toISO() : value;
+}
+
 export async function getAnnotations(
   request: FastifyRequest<{
     Params: { siteId: string };
@@ -81,7 +91,7 @@ export async function getAnnotations(
       .where(and(...conditions))
       .orderBy(asc(annotations.date), asc(annotations.annotationId));
 
-    return reply.send(rows);
+    return reply.send(rows.map(row => ({ ...row, date: toIso(row.date) ?? row.date, endDate: toIso(row.endDate) })));
   } catch (error) {
     if (error instanceof z.ZodError) {
       return reply.status(400).send({ error: "Validation error", details: error.errors });


### PR DESCRIPTION
## Summary

Follow-up to #1164.

- **"Invalid DateTime" on hover.** `date`/`endDate` are timestamptz columns read in string mode, so the API returned Postgres text (`2026-08-18 07:00:00+00`), which luxon's ISO parser rejects. The API now returns ISO 8601 for both, and the client parses either form defensively.
- **Any emoji as icon.** A free input next to the presets accepts any typed or pasted emoji (OS emoji picker works); only the last visible character is kept, so multi-code-point emoji like 🏷️ count as one. The server requires a single grapheme for `icon`; docs updated.

## Test plan

- [x] Server and client type-check; client lint clean
- [x] Annotation tests: 8 server (incl. multi-code-point emoji, rejected words), 8 client (incl. Postgres-text dates)
- [ ] Create an annotation, hover the pin: date renders
- [ ] Paste a custom emoji into the icon input and save

https://claude.ai/code/session_0195cYfX92kFPucpMqyv8FN9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Annotation icons now support a single custom emoji or character through the icon picker.
  * Annotation dates are handled consistently across supported timestamp formats.
* **Bug Fixes**
  * Annotation responses now return dates in a consistent ISO 8601 format.
  * Improved handling of emoji characters, including multi-code-point emoji.
* **Documentation**
  * Clarified that annotation icon fields accept one emoji or character, or can be cleared with `null`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->