### PR TITLE
feat(landing): GitHub star pill replaces Live demo in the variant B header

### DIFF
--- a/docs/src/components/CustomHeader.tsx
+++ b/docs/src/components/CustomHeader.tsx
@@ -2,6 +2,7 @@
 
 import { AppLink } from "@/components/AppLink";
 import { DesktopNav } from "@/components/header/DesktopNav";
+import { GitHubStarPill } from "@/components/header/GitHubStarPill";
 import { MobileNav } from "@/components/header/MobileNav";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { trackAdEvent } from "@/lib/trackAdEvent";
@@ -15,7 +16,7 @@ import { useState } from "react";
  * Site header. Default register is the marketing pages' instrument sheet
  * (1200px column with hairline sides, square buttons); under `data-chrome=
  * "bare"` (homepage redesign, see global.css) it is a 1280px column with no
- * sides, pill buttons and a Live demo button.
+ * sides, pill buttons and a GitHub star pill.
  */
 export function CustomHeader() {
   const t = useExtracted();
@@ -47,6 +48,7 @@ export function CustomHeader() {
 
         <div className="hidden items-center gap-2 lg:flex">
           <ThemeSwitcher />
+          <GitHubStarPill />
           <AppLink
             href="https://app.rybbit.io"
             target="_blank"
@@ -55,15 +57,6 @@ export function CustomHeader() {
             className="inline-flex h-8 items-center justify-center rounded-md px-2.5 text-sm font-medium text-neutral-700 transition-colors hover:bg-neutral-100 hover:text-neutral-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 bare:h-9 bare:rounded-full bare:px-3 bare:hover:bg-transparent dark:text-neutral-300 dark:hover:bg-neutral-900 dark:hover:text-white dark:bare:hover:bg-transparent"
           >
             {t("Login")}
-          </AppLink>
-          <AppLink
-            href="https://demo.rybbit.com/81"
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => trackAdEvent("demo", { location: "header" })}
-            className="hidden h-9 items-center justify-center rounded-full border border-neutral-300 bg-white px-4 text-sm font-medium text-neutral-900 transition-colors hover:bg-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 bare:inline-flex dark:border-neutral-800 dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
-          >
-            {t("Live demo")}
           </AppLink>
           <AppLink
             href="https://app.rybbit.io/signup"

--- a/docs/src/components/header/GitHubStarPill.tsx
+++ b/docs/src/components/header/GitHubStarPill.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { trackAdEvent } from "@/lib/trackAdEvent";
+import { Star } from "lucide-react";
+import { useEffect, useState } from "react";
+
+/**
+ * GitHub star pill for the "bare" header register (homepage redesign, see
+ * global.css). It is server-rendered on every page so there is no layout
+ * shift, hidden by CSS outside bare mode, and only fetches the star count
+ * when the bare register is actually active so the control pages don't spend
+ * GitHub API quota on a hidden element.
+ */
+export function GitHubStarPill() {
+  const [starCount, setStarCount] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (document.documentElement.getAttribute("data-chrome") !== "bare") {
+      setIsLoading(false);
+      return;
+    }
+    const controller = new AbortController();
+    const fetchStarCount = async () => {
+      try {
+        const response = await fetch("https://api.github.com/repos/rybbit-io/rybbit", { signal: controller.signal });
+        const data = await response.json();
+        if (typeof data.stargazers_count === "number") {
+          setStarCount(data.stargazers_count.toLocaleString());
+        }
+      } catch (error) {
+        if (!controller.signal.aborted) console.log("Could not fetch GitHub stars:", error);
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false);
+      }
+    };
+    fetchStarCount();
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <a
+      href="https://github.com/rybbit-io/rybbit"
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() => trackAdEvent("github", { location: "header" })}
+      className="hidden h-9 items-center gap-2 rounded-full border border-neutral-300 bg-white px-3.5 text-sm font-medium text-neutral-900 transition-colors hover:bg-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 bare:inline-flex dark:border-neutral-800 dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
+    >
+      <svg className="size-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.3.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+      </svg>
+      <span className="sr-only">GitHub</span>
+      <span className="flex items-center gap-1 tabular-nums">
+        <Star className="size-3.5 fill-current text-amber-500 dark:text-amber-400" aria-hidden="true" />
+        {isLoading ? (
+          <span className="h-3.5 w-9 animate-pulse rounded-sm bg-neutral-200 dark:bg-neutral-700" aria-hidden="true" />
+        ) : (
+          starCount && <span>{starCount}</span>
+        )}
+      </span>
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary

Variant B header (the `data-chrome="bare"` register): the **Live demo** button is removed and a **GitHub star pill** is added between the theme switcher and Login.

- New `docs/src/components/header/GitHubStarPill.tsx`: pill-styled link to the repo with the GitHub mark, a star and the live stargazer count (skeleton while loading).
- Server-rendered on every page so the header does not shift after hydration; hidden by CSS outside bare mode.
- Only fetches `api.github.com` when the bare attribute is actually set, so control-arm pages spend no GitHub API quota on a hidden element.
- Control header is unchanged. No message keys added or removed (`Live demo` is still used by CTASection / InteriorPageHero).

## Verification

- `tsc --noEmit` clean.
- Playwright with a real Chrome UA on the dev server: variant B `/` (dark) and `/pricing` (light) show `GitHub ★ 12,911` at 36px pill height, no Live demo button, one GitHub request; variant A shows Login / Sign up only, star pill not rendered visible, no extra GitHub request from the header.

https://claude.ai/code/session_01NefKVWXwg2A7qvgtuN1sFt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the header’s “Live demo” link with a GitHub star pill in the bare header.
  * Displays the repository’s current star count, with a loading placeholder while the count is retrieved.
  * Links directly to the project’s GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->