### PR TITLE
fix: resolve list_sites 401 for organization-owned API keys

### DIFF
--- a/server/src/api/user/getMyOrganizations.test.ts
+++ b/server/src/api/user/getMyOrganizations.test.ts
@@ -3,13 +3,17 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getSessionFromReq: vi.fn(),
   getUserIdFromRequest: vi.fn(),
+  getOrganizationIdFromApiKey: vi.fn(),
+  wasRateLimited: vi.fn(),
 }));
 
-// Keep the real db (PGlite below) but stub the two auth resolvers so we can
-// drive the session-vs-bearer branch directly.
+// Keep the real db (PGlite below) but stub the auth resolvers so we can drive
+// the session-vs-bearer-vs-org-key branch directly.
 vi.mock("../../lib/auth-utils.js", () => ({
   getSessionFromReq: mocks.getSessionFromReq,
   getUserIdFromRequest: mocks.getUserIdFromRequest,
+  getOrganizationIdFromApiKey: mocks.getOrganizationIdFromApiKey,
+  wasRateLimited: mocks.wasRateLimited,
 }));
 
 vi.mock("../../db/postgres/postgres.js", async () => {
@@ -32,13 +36,17 @@ CREATE TABLE "sites" ("id" text, "site_id" serial PRIMARY KEY, "name" text, "dom
 `;
 
 function replyStub() {
-  const reply: any = { statusCode: 200 };
+  const reply: any = { statusCode: 200, headers: {} };
   reply.status = (code: number) => {
     reply.statusCode = code;
     return reply;
   };
   reply.send = (body: unknown) => {
     reply.body = body;
+    return reply;
+  };
+  reply.header = (name: string, value: unknown) => {
+    reply.headers[name] = value;
     return reply;
   };
   return reply;
@@ -52,12 +60,15 @@ beforeEach(async () => {
   vi.clearAllMocks();
   await (sql as any).exec(`TRUNCATE "organization", "user", "member", "sites"`);
   await (sql as any).exec(`
-    INSERT INTO "organization" ("id","name","slug") VALUES ('org_1','Acme','acme');
+    INSERT INTO "organization" ("id","name","slug") VALUES ('org_1','Acme','acme'),('org_2','Beta','beta');
     INSERT INTO "user" ("id","name","email") VALUES ('u_caller','Owner','owner@acme.com'),('u_peer','Peer','peer@acme.com');
     INSERT INTO "member" ("id","organizationId","userId","role") VALUES ('m_caller','org_1','u_caller','owner'),('m_peer','org_1','u_peer','member');
     INSERT INTO "sites" ("id","name","domain","organization_id","public") VALUES ('hex1','Acme Site','acme.com','org_1',false);
+    INSERT INTO "sites" ("id","name","domain","organization_id","public") VALUES ('hex_beta1','Beta Site 1','beta1.com','org_2',false),('hex_beta2','Beta Site 2','beta2.com','org_2',false);
   `);
   mocks.getUserIdFromRequest.mockResolvedValue("u_caller");
+  mocks.getOrganizationIdFromApiKey.mockResolvedValue(null);
+  mocks.wasRateLimited.mockReturnValue(undefined);
 });
 
 describe("getMyOrganizations — member roster exposure", () => {
@@ -84,5 +95,63 @@ describe("getMyOrganizations — member roster exposure", () => {
     // Sites (what list_sites needs) are still returned; only member PII is withheld.
     expect(org.sites).toHaveLength(1);
     expect(JSON.stringify(reply.body)).not.toContain("peer@acme.com");
+  });
+});
+
+describe("getMyOrganizations — organization-owned API keys", () => {
+  beforeEach(() => {
+    mocks.getUserIdFromRequest.mockResolvedValue(null);
+    mocks.getSessionFromReq.mockResolvedValue(null);
+  });
+
+  it("returns only its own organization, with all its sites and no member PII", async () => {
+    mocks.getOrganizationIdFromApiKey.mockResolvedValue("org_2");
+    const reply = replyStub();
+
+    await getMyOrganizations({ headers: { authorization: "Bearer rb_org_key" } } as any, reply);
+
+    expect(reply.body).toHaveLength(1);
+    const [org] = reply.body;
+    expect(org.id).toBe("org_2");
+    expect(org.role).toBe("admin");
+    expect(org.members).toEqual([]);
+    expect(org.sites.map((s: any) => s.domain).sort()).toEqual(["beta1.com", "beta2.com"]);
+    expect(JSON.stringify(reply.body)).not.toContain("peer@acme.com");
+    expect(JSON.stringify(reply.body)).not.toContain("owner@acme.com");
+  });
+
+  it("never returns another organization's data (org A key can't see org B)", async () => {
+    mocks.getOrganizationIdFromApiKey.mockResolvedValue("org_1");
+    const reply = replyStub();
+
+    await getMyOrganizations({ headers: { authorization: "Bearer rb_org_key" } } as any, reply);
+
+    expect(reply.body).toHaveLength(1);
+    const [org] = reply.body;
+    expect(org.id).toBe("org_1");
+    expect(org.sites.map((s: any) => s.domain)).toEqual(["acme.com"]);
+    // Only org_1's data is present anywhere in the payload — org_2 never leaks in.
+    expect(JSON.stringify(reply.body)).not.toContain("org_2");
+    expect(JSON.stringify(reply.body)).not.toContain("beta1.com");
+    expect(JSON.stringify(reply.body)).not.toContain("beta2.com");
+  });
+
+  it("401s when neither a user id nor an org key resolve", async () => {
+    mocks.getOrganizationIdFromApiKey.mockResolvedValue(null);
+    const reply = replyStub();
+
+    await getMyOrganizations({ headers: {} } as any, reply);
+
+    expect(reply.statusCode).toBe(401);
+  });
+
+  it("429s instead of 401 when the credential was only rate-limited", async () => {
+    mocks.getOrganizationIdFromApiKey.mockResolvedValue(null);
+    mocks.wasRateLimited.mockReturnValue({ retryAfterSeconds: 30, scope: "org" });
+    const reply = replyStub();
+
+    await getMyOrganizations({ headers: { authorization: "Bearer rb_org_key" } } as any, reply);
+
+    expect(reply.statusCode).toBe(429);
   });
 });

--- a/server/src/api/user/getMyOrganizations.ts
+++ b/server/src/api/user/getMyOrganizations.ts
@@ -2,13 +2,16 @@ import { FastifyRequest, FastifyReply } from "fastify";
 import { db } from "../../db/postgres/postgres.js";
 import { eq } from "drizzle-orm";
 import { member, organization, sites, user } from "../../db/postgres/schema.js";
-import { getSessionFromReq, getUserIdFromRequest, wasRateLimited } from "../../lib/auth-utils.js";
+import { getOrganizationIdFromApiKey, getSessionFromReq, getUserIdFromRequest, wasRateLimited } from "../../lib/auth-utils.js";
 import { filterSitesByMemberAccess, getOrgMembership } from "../../lib/access.js";
 
 export const getMyOrganizations = async (request: FastifyRequest, reply: FastifyReply) => {
   try {
     const userId = await getUserIdFromRequest(request);
-    if (!userId) {
+    // Organization-owned API keys have no user id — resolve their single
+    // organization directly instead of 401ing.
+    const apiKeyOrganizationId = userId ? null : await getOrganizationIdFromApiKey(request);
+    if (!userId && !apiKeyOrganizationId) {
       // This route has no auth pre-handler, so a throttled credential resolves
       // to no user. Reporting that as 401 would tell a caller their key is
       // invalid when it is merely out of budget.
@@ -32,19 +35,38 @@ export const getMyOrganizations = async (request: FastifyRequest, reply: Fastify
     const session = await getSessionFromReq(request);
     const includeMembers = !!session?.user;
 
-    // First, get all organizations the user is a member of
-    const userOrganizations = await db
-      .select({
-        id: organization.id,
-        name: organization.name,
-        slug: organization.slug,
-        logo: organization.logo,
-        createdAt: organization.createdAt,
-        role: member.role,
-      })
-      .from(member)
-      .innerJoin(organization, eq(member.organizationId, organization.id))
-      .where(eq(member.userId, userId));
+    // First, get all organizations the user is a member of — or, for an
+    // org-owned key, just its own organization (it has no member row).
+    let userOrganizations;
+    if (userId) {
+      userOrganizations = await db
+        .select({
+          id: organization.id,
+          name: organization.name,
+          slug: organization.slug,
+          logo: organization.logo,
+          createdAt: organization.createdAt,
+          role: member.role,
+        })
+        .from(member)
+        .innerJoin(organization, eq(member.organizationId, organization.id))
+        .where(eq(member.userId, userId));
+    } else {
+      const orgRows = await db
+        .select({
+          id: organization.id,
+          name: organization.name,
+          slug: organization.slug,
+          logo: organization.logo,
+          createdAt: organization.createdAt,
+        })
+        .from(organization)
+        // apiKeyOrganizationId is guaranteed set here: the guard above already
+        // returned if both it and userId were missing.
+        .where(eq(organization.id, apiKeyOrganizationId!))
+        .limit(1);
+      userOrganizations = orgRows.map(org => ({ ...org, role: "admin" as const }));
+    }
 
     // For each organization, get all members with user details and sites
     const organizationsWithMembersAndSites = await Promise.all(
@@ -88,10 +110,12 @@ export const getMyOrganizations = async (request: FastifyRequest, reply: Fastify
         let organizationSites = allOrgSites;
 
         if (callerMemberRecord?.role === "member") {
+          // getOrgMembership null-guards a missing userId, so a non-null
+          // callerMemberRecord here means userId was set.
           organizationSites = await filterSitesByMemberAccess(
             allOrgSites,
             org.id,
-            userId,
+            userId!,
             callerMemberRecord.id,
             callerMemberRecord.hasRestrictedSiteAccess
           );

--- a/server/src/lib/auth-utils.ts
+++ b/server/src/lib/auth-utils.ts
@@ -445,6 +445,27 @@ export async function getUserIdFromRequest(req: FastifyRequest): Promise<string 
   return null;
 }
 
+/**
+ * Resolve an organization-owned API key's organization id. Mirrors
+ * getUserIdFromRequest, but for the org-key side of a bearer credential
+ * (org keys have no req.user/session — those only exist for people).
+ */
+export async function getOrganizationIdFromApiKey(req: FastifyRequest): Promise<string | null> {
+  const apiKey = resolveBearerTokenFromRequest(req);
+  if (!apiKey) {
+    return null;
+  }
+
+  const identity =
+    consumeBearerHandoff(req.headers[INTERNAL_BEARER_HANDOFF_HEADER], apiKey) ??
+    (await resolveBearerIdentity(apiKey, bearerResolverDeps));
+  if (identity.status === "valid" && identity.organizationId) {
+    return identity.organizationId;
+  }
+
+  return null;
+}
+
 // for routes that are potentially public
 export async function getUserHasAccessToSitePublic(
   req: FastifyRequest,


### PR DESCRIPTION
Fix for #1171 

getMyOrganizations 401ed for org-owned API keys because they resolve to an organization id, not a user id, and getUserIdFromRequest only returns the latter. Add getOrganizationIdFromApiKey (mirrors getUserIdFromRequest for the org-key side of a bearer credential) and fall back to it when no user id resolves, looking up that single organization directly and granting it admin authority in the response in place of the member-join query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Organization-owned API keys can retrieve their organization’s details and sites.
  - Responses identify the API-key organization with an administrator role and exclude member personal information.
  - Supported authorization methods now recognize API keys consistently.

- **Bug Fixes**
  - Organization API keys can no longer access other organizations’ data.
  - Requests without valid user or organization credentials return an unauthorized response.
  - Rate-limited credentials now receive a rate-limit response instead of unauthorized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->